### PR TITLE
Add incremental project compilation and versioning tests

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using Raven.CodeAnalysis.Syntax;
+
 namespace Raven.CodeAnalysis;
 
 /// <summary>
@@ -6,6 +10,7 @@ namespace Raven.CodeAnalysis;
 public class Workspace
 {
     private Solution _currentSolution;
+    private readonly Dictionary<ProjectId, ProjectCompilationState> _projectCompilations = new();
 
     protected Workspace(string kind)
     {
@@ -28,6 +33,12 @@ public class Workspace
 
         var (kind, projectId, documentId) = ComputeChangeKind(oldSolution, newSolution);
         _currentSolution = newSolution;
+
+        // drop compilation caches for removed projects
+        var removed = _projectCompilations.Keys.Where(id => newSolution.GetProject(id) is null).ToList();
+        foreach (var id in removed)
+            _projectCompilations.Remove(id);
+
         OnWorkspaceChanged(new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId));
         return true;
     }
@@ -59,4 +70,71 @@ public class Workspace
 
     protected virtual void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
         => WorkspaceChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Gets a <see cref="Compilation"/> for the specified project. Results are cached
+    /// and incrementally rebuilt when documents change.
+    /// </summary>
+    public Compilation GetCompilation(ProjectId projectId)
+    {
+        var project = CurrentSolution.GetProject(projectId)
+            ?? throw new ArgumentException("Project not found", nameof(projectId));
+
+        if (!_projectCompilations.TryGetValue(projectId, out var state))
+        {
+            return BuildCompilation(project);
+        }
+
+        if (state.Version == project.Version)
+            return state.Compilation;
+
+        return BuildCompilation(project, state);
+    }
+
+    private Compilation BuildCompilation(Project project, ProjectCompilationState? state = null)
+    {
+        state ??= new ProjectCompilationState();
+
+        var syntaxTrees = new List<SyntaxTree>();
+        var documentStates = state.DocumentStates;
+        var presentDocs = new HashSet<DocumentId>();
+
+        foreach (var doc in project.Documents)
+        {
+            presentDocs.Add(doc.Id);
+            if (documentStates.TryGetValue(doc.Id, out var docState) && docState.Version == doc.Version)
+            {
+                syntaxTrees.Add(docState.SyntaxTree);
+            }
+            else
+            {
+                var text = doc.GetTextAsync().Result;
+                var tree = SyntaxTree.ParseText(text, options: null, path: doc.FilePath ?? doc.Name);
+                syntaxTrees.Add(tree);
+                documentStates[doc.Id] = new DocumentState(doc.Version, tree);
+            }
+        }
+
+        // remove cached documents no longer present
+        var toRemove = documentStates.Keys.Where(id => !presentDocs.Contains(id)).ToList();
+        foreach (var id in toRemove)
+            documentStates.Remove(id);
+
+        var compilation = Compilation.Create(project.Name, syntaxTrees.ToArray());
+
+        state.Version = project.Version;
+        state.Compilation = compilation;
+
+        _projectCompilations[project.Id] = state;
+        return compilation;
+    }
+
+    private sealed class ProjectCompilationState
+    {
+        public VersionStamp Version;
+        public Compilation Compilation = null!;
+        public Dictionary<DocumentId, DocumentState> DocumentStates { get; } = new();
+    }
+
+    private sealed record DocumentState(VersionStamp Version, SyntaxTree SyntaxTree);
 }


### PR DESCRIPTION
## Summary
- cache compilations per project and rebuild incrementally on document changes
- expand workspace tests for solution/project version tracking
- add tests verifying compilation reuse for unchanged documents

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj` *(fails: missing generated syntax types)*

------
https://chatgpt.com/codex/tasks/task_e_68a07c06cab4832fa797e46924417733