### PR TITLE
Ensure VersionStamp handles non-monotonic clocks

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/VersionStamp.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/VersionStamp.cs
@@ -72,7 +72,16 @@ public readonly struct VersionStamp : IEquatable<VersionStamp>, IComparable<Vers
     public VersionStamp GetNewerVersion()
     {
         DateTime utcNow = DateTime.UtcNow;
-        int nextLocal = (utcNow == _utcLastModified) ? (_localIncrement + 1) : 0;
+        int nextLocal;
+        if (utcNow <= _utcLastModified)
+        {
+            utcNow = _utcLastModified;
+            nextLocal = _localIncrement + 1;
+        }
+        else
+        {
+            nextLocal = 0;
+        }
         return new VersionStamp(utcNow, nextLocal);
     }
 


### PR DESCRIPTION
## Summary
- Ensure `VersionStamp.GetNewerVersion` never returns an older value when the system clock moves backwards

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a08b58f4c0832fab4d28f738e5e63c