### PR TITLE
Add document editor API for text modifications

### DIFF
--- a/src/Raven.CodeAnalysis/Editing/Editor.cs
+++ b/src/Raven.CodeAnalysis/Editing/Editor.cs
@@ -1,0 +1,65 @@
+using Raven.CodeAnalysis.Text;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Editing;
+
+/// <summary>
+/// Provides a simple API for making textual edits to a <see cref="Document"/>.
+/// Similar in spirit to Roslyn's <c>DocumentEditor</c>, this class allows callers
+/// to build up changes and produce a new document with those changes applied.
+/// </summary>
+public sealed class Editor
+{
+    private readonly Document _originalDocument;
+    private SourceText _text;
+
+    private Editor(Document document, SourceText text)
+    {
+        _originalDocument = document;
+        _text = text;
+    }
+
+    /// <summary>Creates a new <see cref="Editor"/> for the provided document.</summary>
+    public static Editor Create(Document document)
+    {
+        if (document is null)
+            throw new ArgumentNullException(nameof(document));
+
+        var text = document.GetTextAsync().GetAwaiter().GetResult();
+        return new Editor(document, text);
+    }
+
+    /// <summary>The document that edits are being applied to.</summary>
+    public Document OriginalDocument => _originalDocument;
+
+    /// <summary>Inserts <paramref name="newText"/> at the specified <paramref name="position"/>.</summary>
+    public void Insert(int position, string newText)
+    {
+        if (newText is null)
+            throw new ArgumentNullException(nameof(newText));
+
+        _text = _text.WithChange(position, newText);
+    }
+
+    /// <summary>Replaces the text within <paramref name="span"/> with <paramref name="newText"/>.</summary>
+    public void Replace(TextSpan span, string newText)
+    {
+        if (newText is null)
+            throw new ArgumentNullException(nameof(newText));
+
+        _text = _text.WithChange(new TextChange(span, newText));
+    }
+
+    /// <summary>Removes the text within the specified <paramref name="span"/>.</summary>
+    public void Remove(TextSpan span)
+    {
+        _text = _text.WithChange(new TextChange(span, string.Empty));
+    }
+
+    /// <summary>Gets a new <see cref="Document"/> with all edits applied.</summary>
+    public Document GetChangedDocument()
+    {
+        return _originalDocument.WithText(_text);
+    }
+}
+

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
@@ -1,0 +1,53 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Editing;
+using Raven.CodeAnalysis.Text;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class EditorTests
+{
+    [Fact]
+    public async Task InsertText_ShouldUpdateDocument()
+    {
+        var document = CreateDocument("Hello World");
+        var editor = Editor.Create(document);
+        editor.Insert(5, ",");
+        var changed = editor.GetChangedDocument();
+        var text = await changed.GetTextAsync();
+        Assert.Equal("Hello, World", text.ToString());
+    }
+
+    [Fact]
+    public async Task ReplaceText_ShouldUpdateDocument()
+    {
+        var document = CreateDocument("Hello World");
+        var editor = Editor.Create(document);
+        editor.Replace(new TextSpan(6, 5), "Universe");
+        var changed = editor.GetChangedDocument();
+        var text = await changed.GetTextAsync();
+        Assert.Equal("Hello Universe", text.ToString());
+    }
+
+    [Fact]
+    public async Task RemoveText_ShouldUpdateDocument()
+    {
+        var document = CreateDocument("Hello World");
+        var editor = Editor.Create(document);
+        editor.Remove(new TextSpan(5, 1));
+        var changed = editor.GetChangedDocument();
+        var text = await changed.GetTextAsync();
+        Assert.Equal("HelloWorld", text.ToString());
+    }
+
+    private static Document CreateDocument(string text)
+    {
+        var source = SourceText.From(text);
+        var solutionId = SolutionId.CreateNew();
+        var projectId = ProjectId.CreateNew(solutionId);
+        var documentId = DocumentId.CreateNew(projectId);
+        return new Document(documentId, "Test", source, null, VersionStamp.Create());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add simple `Editor` class to compose text changes on documents
- cover insert, replace, and remove operations with unit tests

## Testing
- `dotnet test` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a0939f1918832f9627c839828ee5a7