### PR TITLE
Add compute diagnostics for syntax nodes

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Syntax/SyntaxNodeTest.Diagnostics.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/SyntaxNodeTest.Diagnostics.cs
@@ -1,0 +1,23 @@
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+using Raven.CodeAnalysis.Syntax;
+using static Raven.CodeAnalysis.Syntax.SyntaxFactory;
+
+public partial class SyntaxNodeTest
+{
+    [Fact]
+    public void ReturnStatement_WithMissingSemicolon_ReportsDiagnostic()
+    {
+        var stmt = ReturnStatement(ReturnKeyword, MissingToken(SyntaxKind.SemicolonToken));
+        var diagnostics = stmt.GetDiagnostics().ToArray();
+        diagnostics.ShouldContain(d => d.Descriptor.Id == "RAV1002");
+    }
+
+    [Fact]
+    public void Block_WithMissingCloseBrace_ReportsDiagnostic()
+    {
+        var block = Block(OpenBraceToken, List<StatementSyntax>(), MissingToken(SyntaxKind.CloseBraceToken));
+        var diagnostics = block.GetDiagnostics().ToArray();
+        diagnostics.ShouldContain(d => d.Descriptor.Id == "RAV1003");
+    }
+}


### PR DESCRIPTION
## Summary
- add `ComputeDiagnostics` virtual method to syntax nodes and call from `GetDiagnostics`
- extend node generator to emit diagnostics checks for required tokens
- test diagnostics for missing semicolon and brace

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a098b4b170832fb2cca5e330ec0f2d