### PR TITLE
Propagate import binder to type declarations

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -189,7 +189,7 @@ public partial class SemanticModel
 
         _binderCache[cu] = topLevelBinder;
 
-        RegisterNamespaceMembers(cu, namespaceBinder, targetNamespace);
+        RegisterNamespaceMembers(cu, parentBinder, targetNamespace);
 
         // Step 5: Register and bind global statements
         foreach (var stmt in cu.DescendantNodes().OfType<GlobalStatementSyntax>())

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -35,4 +35,40 @@ public class ImportResolutionTest : DiagnosticTestBase
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void NamespaceSystemNotImportedStringInClassNotAvailable_Should_ProduceDiagnostic()
+    {
+        string testCode =
+            """
+            class C {
+                String field;
+            }
+            """;
+
+        var verifier = CreateVerifier(
+            testCode,
+            [
+                new DiagnosticResult("RAV0103").WithLocation(2, 5).WithArguments("String")
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void ImportedNamespaceSystemDoesContainStringInClass_ShouldNot_ProduceDiagnostic()
+    {
+        string testCode =
+            """
+            import System;
+
+            class C {
+                String field;
+            }
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure namespace members inherit ImportBinder so class scopes see imported namespaces
- add tests verifying imported types resolve within classes

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Value cannot be null. (Parameter 'path'))*

------
https://chatgpt.com/codex/tasks/task_e_68a0dde34454832f8eb441c9cf3fe2fe