### PR TITLE
Add class symbol analysis and codegen test

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class CodeGeneratorTests
+{
+    [Fact]
+    public void Emit_ShouldGenerateClass()
+    {
+        var code = """
+class Program {
+    Main() -> void {
+        return;
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location));
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(result.Success);
+
+        peStream.Position = 0;
+        var assembly = Assembly.Load(peStream.ToArray());
+        Assert.NotNull(assembly.GetType("Program"));
+    }
+}


### PR DESCRIPTION
## Summary
- support class declarations in compilation symbol analysis
- include nested members when analyzing classes
- add code generation test for emitting a simple class

## Testing
- `dotnet test` *(fails: ReturnStatementSyntax type not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e818ac6c832fab7802a8f1bddf77