### PR TITLE
Implement named constructor lowering and synthesize default constructors

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -240,7 +240,7 @@ partial class BlockBinder : Binder
 
     private BoundExpression BindSelfExpression(SelfExpressionSyntax selfExpression)
     {
-        if (_containingSymbol is IMethodSymbol method && !method.IsStatic)
+        if (_containingSymbol is IMethodSymbol method && (!method.IsStatic || method.IsNamedConstructor))
         {
             var containingType = method.ContainingType;
             return new BoundSelfExpression(containingType);

--- a/src/Raven.CodeAnalysis/Binder/MethodBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBinder.cs
@@ -1,3 +1,4 @@
+using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis;
 
@@ -30,6 +31,61 @@ class MethodBinder : BlockBinder
             return parentSymbol;
 
         return Compilation.GlobalNamespace.GetMembers(name).FirstOrDefault();
+    }
+
+    public override BoundBlockExpression BindBlock(BlockSyntax block)
+    {
+        var bound = base.BindBlock(block);
+
+        if (_methodSymbol.IsNamedConstructor)
+        {
+            var selfLocal = new SourceLocalSymbol(
+                "__self",
+                _methodSymbol.ContainingType!,
+                isMutable: true,
+                _methodSymbol,
+                _methodSymbol.ContainingType,
+                _methodSymbol.ContainingNamespace,
+                [block.GetLocation()],
+                [block.GetReference()]);
+
+            var rewriter = new NamedConstructorRewriter(_methodSymbol, selfLocal);
+            bound = rewriter.Rewrite(bound);
+        }
+
+        CacheBoundNode(block, bound);
+        return bound;
+    }
+
+    private sealed class NamedConstructorRewriter : BoundTreeRewriter
+    {
+        private readonly IMethodSymbol _methodSymbol;
+        private readonly SourceLocalSymbol _self;
+
+        public NamedConstructorRewriter(IMethodSymbol methodSymbol, SourceLocalSymbol self)
+        {
+            _methodSymbol = methodSymbol;
+            _self = self;
+        }
+
+        public BoundBlockExpression Rewrite(BoundBlockExpression body)
+        {
+            var statements = VisitList(body.Statements).Cast<BoundStatement>().ToList();
+
+            var ctor = _methodSymbol.ContainingType!.Constructors.First(c => c.Parameters.Length == 0);
+            var creation = new BoundObjectCreationExpression(ctor, Array.Empty<BoundExpression>());
+            var declarator = new BoundVariableDeclarator(_self, creation);
+            var declaration = new BoundLocalDeclarationStatement(new[] { declarator });
+            statements.Insert(0, declaration);
+            statements.Add(new BoundReturnStatement(new BoundLocalAccess(_self)));
+
+            return new BoundBlockExpression(statements);
+        }
+
+        public override BoundNode? VisitSelfExpression(BoundSelfExpression node)
+        {
+            return new BoundLocalAccess(_self);
+        }
     }
 
     public IMethodSymbol GetMethodSymbol() => _methodSymbol;

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -42,22 +42,16 @@ internal class MethodBodyGenerator
 
         var semanticModel = Compilation.GetSemanticModel(syntax.SyntaxTree);
 
-        foreach (var localDeclStmt in syntax.DescendantNodes()
-            //.OfType<GlobalStatementSyntax>()
-            //.Select(x => x.Statement)
-            .OfType<LocalDeclarationStatementSyntax>())
+        BoundBlockExpression? boundBody = syntax switch
         {
-            foreach (var localDeclarator in localDeclStmt.Declaration.Declarators)
-            {
-                var localSymbol = GetDeclaredSymbol<ILocalSymbol>(localDeclarator);
+            MethodDeclarationSyntax m when m.Body != null => semanticModel.GetBoundNode(m.Body) as BoundBlockExpression,
+            LocalFunctionStatementSyntax l when l.Body != null => semanticModel.GetBoundNode(l.Body) as BoundBlockExpression,
+            BaseConstructorDeclarationSyntax c when c.Body != null => semanticModel.GetBoundNode(c.Body) as BoundBlockExpression,
+            _ => null
+        };
 
-                var clrType = ResolveClrType(localSymbol.Type);
-                var builder = ILGenerator.DeclareLocal(clrType);
-                builder.SetLocalSymInfo(localSymbol.Name);
-
-                scope.AddLocal(localSymbol, builder);
-            }
-        }
+        if (boundBody != null)
+            DeclareLocals(boundBody);
 
         switch (syntax)
         {
@@ -73,15 +67,15 @@ internal class MethodBodyGenerator
                 break;
 
             case LocalFunctionStatementSyntax localFunctionStatement:
-                if (localFunctionStatement.Body != null)
-                    EmitIL(localFunctionStatement.Body.Statements.ToList());
+                if (boundBody != null)
+                    EmitBoundBlock(boundBody);
                 else
                     ILGenerator.Emit(OpCodes.Ret);
                 break;
 
             case MethodDeclarationSyntax methodDeclaration:
-                if (methodDeclaration.Body != null)
-                    EmitIL(methodDeclaration.Body.Statements.ToList());
+                if (boundBody != null)
+                    EmitBoundBlock(boundBody);
                 else
                     ILGenerator.Emit(OpCodes.Ret);
                 break;
@@ -96,18 +90,20 @@ internal class MethodBodyGenerator
                     ILGenerator.Emit(OpCodes.Call, baseCtor);
                 }
 
-                if (constructorDeclaration.Body != null)
-                    EmitIL(constructorDeclaration.Body.Statements.ToList(), false);
+                if (boundBody != null)
+                    EmitBoundBlock(boundBody, false);
 
                 if (ordinaryConstr)
                 {
                     ILGenerator.Emit(OpCodes.Ret);
                 }
-                else
-                {
-                    ILGenerator.Emit(OpCodes.Ldarg_0);
-                    ILGenerator.Emit(OpCodes.Ret);
-                }
+                break;
+
+            case ClassDeclarationSyntax:
+                ILGenerator.Emit(OpCodes.Ldarg_0);
+                var baseCtor2 = ResolveClrType(MethodSymbol.ContainingType!.BaseType!).GetConstructor(Type.EmptyTypes);
+                ILGenerator.Emit(OpCodes.Call, baseCtor2);
+                ILGenerator.Emit(OpCodes.Ret);
                 break;
 
             default:
@@ -125,6 +121,45 @@ internal class MethodBodyGenerator
         MethodGenerator.TypeGenerator.Add(methodSymbol, methodGenerator);
         methodGenerator.DefineMethodBuilder();
         methodGenerator.EmitBody();
+    }
+
+    private void DeclareLocals(BoundBlockExpression block)
+    {
+        var collector = new LocalCollector();
+        collector.Visit(block);
+
+        foreach (var localSymbol in collector.Locals)
+        {
+            var clrType = ResolveClrType(localSymbol.Type);
+            var builder = ILGenerator.DeclareLocal(clrType);
+            builder.SetLocalSymInfo(localSymbol.Name);
+            scope.AddLocal(localSymbol, builder);
+        }
+    }
+
+    private void EmitBoundBlock(BoundBlockExpression block, bool withReturn = true)
+    {
+        foreach (var statement in block.Statements)
+            EmitStatement(statement);
+
+        if (withReturn)
+        {
+            ILGenerator.Emit(OpCodes.Nop);
+            ILGenerator.Emit(OpCodes.Ret);
+        }
+    }
+
+    private sealed class LocalCollector : Raven.CodeAnalysis.BoundTreeWalker
+    {
+        public List<ILocalSymbol> Locals { get; } = new();
+
+        public override void VisitLocalDeclarationStatement(BoundLocalDeclarationStatement node)
+        {
+            foreach (var d in node.Declarators)
+                Locals.Add(d.Local);
+
+            base.VisitLocalDeclarationStatement(node);
+        }
     }
 
     private void EmitIL(IEnumerable<StatementSyntax> statements, bool withReturn = true)

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -282,6 +282,21 @@ public partial class SemanticModel
                         break;
                     }
             }
+
+            if (!classSymbol.Constructors.Any())
+            {
+                _ = new SourceMethodSymbol(
+                    ".ctor",
+                    Compilation.GetSpecialType(SpecialType.System_Void),
+                    ImmutableArray<SourceParameterSymbol>.Empty,
+                    classSymbol,
+                    classSymbol,
+                    parentNamespace.AsSourceNamespace(),
+                    [classDecl.GetLocation()],
+                    [classDecl.GetReference()],
+                    isStatic: false,
+                    methodKind: MethodKind.Constructor);
+            }
         }
     }
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ObjectCreationTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ObjectCreationTests.cs
@@ -62,5 +62,46 @@ public class ObjectCreationTests : DiagnosticTestBase
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void NamedConstructorCreatesObject()
+    {
+        string testCode =
+            """
+            class Person {
+                var name: string;
+
+                public init WithName(name: string) {
+                    self.name = name;
+                }
+
+                public GetName() -> string => name;
+            }
+
+            let p = Person.WithName("John");
+            let n = p.GetName();
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void DefaultConstructorSynthesizedWhenMissing()
+    {
+        string testCode =
+            """
+            class Foo {
+                var x: int;
+            }
+
+            let f = Foo();
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
 }
 


### PR DESCRIPTION
## Summary
- Allow `self` in named constructors and lower them to static factory methods
- Synthesize default constructors when none are declared
- Update code generation to emit lowered named constructors via rewritten bound trees
- Add tests for named constructors and implicit default constructor

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a1df2d6b80832fadf022fe9c59b0d7