### PR TITLE
fix: avoid duplicate local function emission

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -73,6 +73,11 @@ internal class MethodBodyGenerator
 
                 foreach (var localFunctionStmt in compilationUnit.DescendantNodes().OfType<LocalFunctionStatementSyntax>())
                 {
+                    var methodSymbol = GetDeclaredSymbol<IMethodSymbol>(localFunctionStmt);
+                    if (methodSymbol is null)
+                        continue;
+                    if (MethodGenerator.TypeGenerator.HasMethodGenerator(methodSymbol))
+                        continue;
                     EmitLocalFunction(localFunctionStmt);
                 }
 
@@ -130,6 +135,9 @@ internal class MethodBodyGenerator
     {
         var methodSymbol = GetDeclaredSymbol<IMethodSymbol>(localFunctionStmt);
         if (methodSymbol is null)
+            return;
+
+        if (MethodGenerator.TypeGenerator.HasMethodGenerator(methodSymbol))
             return;
 
         var methodGenerator = new MethodGenerator(MethodGenerator.TypeGenerator, methodSymbol);

--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -126,6 +126,11 @@ internal class TypeGenerator
 
     public Type CreateType() => TypeBuilder!.CreateType();
 
+    public bool HasMethodGenerator(IMethodSymbol methodSymbol)
+    {
+        return _methodGenerators.ContainsKey(methodSymbol);
+    }
+
     public void Add(IMethodSymbol methodSymbol, MethodGenerator methodGenerator)
     {
         _methodGenerators[methodSymbol] = methodGenerator;


### PR DESCRIPTION
## Summary
- avoid duplicate local function emission when TypeGenerator already generated them
- track method generators in TypeGenerator via HasMethodGenerator helper

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*
- `dotnet run --project src/Raven.Compiler src/Raven.Compiler/samples/main.rav` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e3ec5b90832fa8b269a2c378aaf2