### PR TITLE
refactor: clarify block binder creation

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -21,7 +21,7 @@ class BinderFactory
         {
             NamespaceDeclarationSyntax ns => CreateNamespaceBinder(ns, parentBinder!),
             MethodDeclarationSyntax => parentBinder,
-            BlockSyntax => ResolveBlockBinder(parentBinder),
+            BlockSyntax => CreateBlockBinder(parentBinder),
             IfExpressionSyntax expr => new LocalScopeBinder(parentBinder!),
             ElseClauseSyntax elseClause => new LocalScopeBinder(parentBinder!),
             WhileExpressionSyntax expr => new LocalScopeBinder(parentBinder!),
@@ -34,8 +34,11 @@ class BinderFactory
         return newBinder;
     }
 
-    private Binder? ResolveBlockBinder(Binder? parentBinder)
+    private Binder? CreateBlockBinder(Binder? parentBinder)
     {
+        // A block directly under a method requires a MethodBodyBinder so the method body
+        // can bind parameters and local declarations. Nested blocks receive a
+        // LocalScopeBinder to track their own local scope.
         return parentBinder is MethodBinder
             ? new MethodBodyBinder(GetMethodSymbol(parentBinder)!, parentBinder!)
             : new LocalScopeBinder(parentBinder!);


### PR DESCRIPTION
## Summary
- rename `ResolveBlockBinder` to `CreateBlockBinder`
- document when `MethodBodyBinder` vs `LocalScopeBinder` is returned

## Testing
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Syntax.Tests.SyntaxNodeTest.Block_AllChildrenMissing_ShouldBeMarkedAsMissing, Raven.CodeAnalysis.Tests.VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f45a4a60832fa3812ce97e0ea9ff