### PR TITLE
feat: add syntax tree support to documents

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Document.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Document.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
 
@@ -58,7 +59,7 @@ public sealed class Document
             }
             catch
             {
-                newTree = SyntaxTree.ParseText(newText, path: FilePath ?? Name);
+                newTree = SyntaxTreeProvider.TryParse(Name, newText, FilePath ?? Name);
             }
         }
         return new Document(Id, Name, newText, newTree, FilePath, Version.GetNewerVersion());

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
@@ -53,7 +53,8 @@ public sealed class Solution
         if (!_projects.TryGetValue(id.ProjectId, out var project))
             throw new InvalidOperationException("Project not found");
 
-        var document = new Document(id, name, text, null, VersionStamp.Create());
+        var tree = SyntaxTreeProvider.TryParse(name, text);
+        var document = new Document(id, name, text, tree, null, VersionStamp.Create());
         var newProject = project.AddDocument(document);
         var newProjects = _projects.SetItem(project.Id, newProject);
         return new Solution(Id, Version.GetNewerVersion(), newProjects);

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
 

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Text;
+
+namespace Raven.CodeAnalysis;
+
+internal static class SyntaxTreeProvider
+{
+    private static readonly HashSet<string> s_sourceExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".rvn",
+        ".rav"
+    };
+
+    public static SyntaxTree? TryParse(string name, SourceText text, string? filePath = null)
+    {
+        var path = filePath ?? name;
+        var ext = Path.GetExtension(path);
+        if (!s_sourceExtensions.Contains(ext))
+            return null;
+
+        return SyntaxTree.ParseText(text, path: path);
+    }
+}

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
@@ -102,14 +102,15 @@ public class Workspace
         foreach (var doc in project.Documents)
         {
             presentDocs.Add(doc.Id);
+            var tree = doc.SyntaxTree;
+            if (tree is null)
+                continue;
             if (documentStates.TryGetValue(doc.Id, out var docState) && docState.Version == doc.Version)
             {
                 syntaxTrees.Add(docState.SyntaxTree);
             }
             else
             {
-                var text = doc.GetTextAsync().Result;
-                var tree = SyntaxTree.ParseText(text, options: null, path: doc.FilePath ?? doc.Name);
                 syntaxTrees.Add(tree);
                 documentStates[doc.Id] = new DocumentState(doc.Version, tree);
             }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Text;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class DocumentTests
+{
+    [Fact]
+    public async Task GetSyntaxTreeAsync_ShouldReturnSameInstance()
+    {
+        var source = SourceText.From("x = 1");
+        var solutionId = SolutionId.CreateNew();
+        var projectId = ProjectId.CreateNew(solutionId);
+        var documentId = DocumentId.CreateNew(projectId);
+        var tree = SyntaxTree.ParseText(source, path: "Test.rvn");
+        var document = new Document(documentId, "Test.rvn", source, tree, null, VersionStamp.Create());
+
+        var tree1 = await document.GetSyntaxTreeAsync();
+        var tree2 = await document.GetSyntaxTreeAsync();
+        Assert.NotNull(tree1);
+        Assert.Same(tree1, tree2);
+    }
+
+    [Fact]
+    public void NonRavenDocument_ShouldNotHaveSyntaxTree()
+    {
+        var solution = new Solution();
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
+        var docId = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId, "Readme.txt", SourceText.From("Hello"));
+
+        var doc = solution.GetDocument(docId)!;
+        var tree = doc.GetSyntaxTreeAsync().Result;
+        Assert.Null(tree);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
@@ -47,7 +47,8 @@ public class EditorTests
         var solutionId = SolutionId.CreateNew();
         var projectId = ProjectId.CreateNew(solutionId);
         var documentId = DocumentId.CreateNew(projectId);
-        return new Document(documentId, "Test", source, null, VersionStamp.Create());
+        var tree = SyntaxTree.ParseText(source, path: "Test");
+        return new Document(documentId, "Test", source, tree, null, VersionStamp.Create());
     }
 }
 


### PR DESCRIPTION
## Summary
- add provider to parse syntax trees only for Raven source files
- store optional syntax trees in Document and update incrementally
- skip non-source documents when building compilations and test non-Raven files

## Testing
- `dotnet build`
- `dotnet test` *(fails: 36 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1b2f7fc832f8145e5a07544332c