### PR TITLE
feat: add host services and solution APIs

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/Objects/HostServices.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/HostServices.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// Provides application-wide services for workspaces and solutions.
+/// </summary>
+public class HostServices
+{
+    public HostServices(SyntaxTreeProvider syntaxTreeProvider)
+    {
+        SyntaxTreeProvider = syntaxTreeProvider ?? throw new ArgumentNullException(nameof(syntaxTreeProvider));
+    }
+
+    /// <summary>The <see cref="SyntaxTreeProvider"/> used to parse documents.</summary>
+    public SyntaxTreeProvider SyntaxTreeProvider { get; }
+
+    /// <summary>Gets a default instance of <see cref="HostServices"/>.</summary>
+    public static HostServices Default { get; } = new HostServices(new SyntaxTreeProvider());
+}

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Text;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// Provides syntax tree parsing for documents. Only files with recognised Raven
+/// source extensions are parsed; others return <c>null</c>.
+/// </summary>
+public class SyntaxTreeProvider
+{
+    private static readonly HashSet<string> s_sourceExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".rvn",
+        ".rav"
+    };
+
+    /// <summary>
+    /// Attempts to parse a <see cref="SyntaxTree"/> for the specified document
+    /// name and text. Non-Raven files return <c>null</c>.
+    /// </summary>
+    public virtual SyntaxTree? TryParse(string name, SourceText text, string? filePath = null)
+    {
+        var path = filePath ?? name;
+        var ext = Path.GetExtension(path);
+        if (!s_sourceExtensions.Contains(ext))
+            return null;
+
+        return SyntaxTree.ParseText(text, path: path);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Text;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class DocumentTests
+{
+    [Fact]
+    public async Task GetSyntaxTreeAsync_ShouldReturnSameInstance()
+    {
+        var source = SourceText.From("x = 1");
+        var solutionId = SolutionId.CreateNew();
+        var projectId = ProjectId.CreateNew(solutionId);
+        var documentId = DocumentId.CreateNew(projectId);
+        var tree = SyntaxTree.ParseText(source, path: "Test.rvn");
+        var document = new Document(documentId, "Test.rvn", source, tree, null, VersionStamp.Create());
+
+        var tree1 = await document.GetSyntaxTreeAsync();
+        var tree2 = await document.GetSyntaxTreeAsync();
+        Assert.NotNull(tree1);
+        Assert.Same(tree1, tree2);
+    }
+
+    [Fact]
+    public void NonRavenDocument_ShouldNotHaveSyntaxTree()
+    {
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
+        var docId = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId, "Readme.txt", SourceText.From("Hello"));
+
+        var doc = solution.GetDocument(docId)!;
+        var tree = doc.GetSyntaxTreeAsync().Result;
+        Assert.Null(tree);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
@@ -47,7 +47,8 @@ public class EditorTests
         var solutionId = SolutionId.CreateNew();
         var projectId = ProjectId.CreateNew(solutionId);
         var documentId = DocumentId.CreateNew(projectId);
-        return new Document(documentId, "Test", source, null, VersionStamp.Create());
+        var tree = SyntaxTree.ParseText(source, path: "Test");
+        return new Document(documentId, "Test", source, tree, null, VersionStamp.Create());
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce HostServices with pluggable SyntaxTreeProvider
- wire Solution and Workspace to host services and expose Services/HostServices
- add creation and opening APIs for solutions on Workspace
- adjust tests for new Solution constructor

## Testing
- `dotnet build`
- `dotnet test` *(fails: 36 failed, 71 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1b2f7fc832f8145e5a07544332c