### PR TITLE
feat: adopt info-based workspace facades

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/InfoTypes/DocumentInfo.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/InfoTypes/DocumentInfo.cs
@@ -12,11 +12,12 @@ public sealed class DocumentInfo
     public DocumentId Id => Attributes.Id;
     public string Name => Attributes.Name;
     public SourceText Text => Attributes.Text;
+    public VersionStamp Version => Attributes.Version;
     public string? FilePath => Attributes.FilePath;
 
     /// <summary>Factory helper for convenience.</summary>
     public static DocumentInfo Create(DocumentId id, string name, SourceText text, string? filePath = null) =>
-        new(new DocumentAttributes(id, name, text, filePath));
+        new(new DocumentAttributes(id, name, text, VersionStamp.Create(), filePath));
 
     public DocumentInfo WithText(SourceText newText) => new(Attributes.WithText(newText));
 
@@ -29,10 +30,14 @@ public sealed class DocumentInfo
         DocumentId Id,
         string Name,
         SourceText Text,
+        VersionStamp Version,
         string? FilePath)
     {
-        public DocumentAttributes WithText(SourceText text) => text == Text ? this : this with { Text = text };
-        public DocumentAttributes WithName(string name) => name == Name ? this : this with { Name = name };
-        public DocumentAttributes WithFilePath(string? path) => path == FilePath ? this : this with { FilePath = path };
+        public DocumentAttributes WithText(SourceText text) =>
+            text == Text ? this : this with { Text = text, Version = Version.GetNewerVersion() };
+        public DocumentAttributes WithName(string name) =>
+            name == Name ? this : this with { Name = name, Version = Version.GetNewerVersion() };
+        public DocumentAttributes WithFilePath(string? path) =>
+            path == FilePath ? this : this with { FilePath = path, Version = Version.GetNewerVersion() };
     }
 }

--- a/src/Raven.CodeAnalysis/Workspaces/InfoTypes/SolutionInfo.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/InfoTypes/SolutionInfo.cs
@@ -24,6 +24,9 @@ public sealed class SolutionInfo
     public SolutionInfo WithProjects(IEnumerable<ProjectInfo> projects) =>
         new(Attributes, projects);
 
+    public SolutionInfo WithVersion(VersionStamp version) =>
+        new(new SolutionAttributes(Id, FilePath, version), Projects);
+
     public sealed record SolutionAttributes(SolutionId Id,
                                             string FilePath,
                                             VersionStamp Version);

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Document.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Document.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.CodeAnalysis.Syntax;
@@ -6,36 +7,52 @@ using Raven.CodeAnalysis.Text;
 namespace Raven.CodeAnalysis;
 
 /// <summary>
-/// Represents a source document within a project. Instances are immutable and
-/// any change results in a new <see cref="Document"/> instance.
+/// Represents a source document within a project. Acts as a facade over immutable
+/// <see cref="DocumentInfo"/> data and is owned by a <see cref="Project"/>.
 /// </summary>
 public sealed class Document
 {
-    internal Document(DocumentId id, string name, SourceText text, SyntaxTree? syntaxTree, string? filePath, VersionStamp version)
+    private readonly DocumentInfo _info;
+    private readonly Project _project;
+    private SyntaxTree? _syntaxTree;
+
+    internal Document(DocumentInfo info, Project project)
     {
-        Id = id;
-        Name = name;
-        Text = text;
-        SyntaxTree = syntaxTree;
-        FilePath = filePath;
-        Version = version;
+        _info = info ?? throw new ArgumentNullException(nameof(info));
+        _project = project ?? throw new ArgumentNullException(nameof(project));
     }
 
+    /// <summary>The project that contains this document.</summary>
+    public Project Project => _project;
+
+    /// <summary>The solution that owns this document.</summary>
+    public Solution Solution => _project.Solution;
+
     /// <summary>The identifier for this document.</summary>
-    public DocumentId Id { get; }
+    public DocumentId Id => _info.Id;
 
     /// <summary>The name of the document.</summary>
-    public string Name { get; }
+    public string Name => _info.Name;
 
     /// <summary>The path to the document on disk if any.</summary>
-    public string? FilePath { get; }
+    public string? FilePath => _info.FilePath;
 
     /// <summary>The current version of the text.</summary>
-    public VersionStamp Version { get; }
+    public VersionStamp Version => _info.Version;
 
-    internal SourceText Text { get; }
+    internal SourceText Text => _info.Text;
 
-    internal SyntaxTree? SyntaxTree { get; }
+    internal DocumentInfo Info => _info;
+
+    internal SyntaxTree? SyntaxTree
+    {
+        get
+        {
+            if (_syntaxTree is null)
+                _syntaxTree = Solution.Services.SyntaxTreeProvider.TryParse(Name, Text, FilePath);
+            return _syntaxTree;
+        }
+    }
 
     /// <summary>Asynchronously gets the text of the document.</summary>
     public Task<SourceText> GetTextAsync(CancellationToken cancellationToken = default)
@@ -45,22 +62,11 @@ public sealed class Document
     public Task<SyntaxTree?> GetSyntaxTreeAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(SyntaxTree);
 
-    /// <summary>Creates a new document with updated text and a new version stamp.</summary>
+    /// <summary>Creates a new document with updated text using the owning solution.</summary>
     public Document WithText(SourceText newText)
     {
         if (newText is null) throw new ArgumentNullException(nameof(newText));
-        SyntaxTree? newTree = null;
-        if (SyntaxTree is not null)
-        {
-            try
-            {
-                newTree = SyntaxTree.WithChangedText(newText);
-            }
-            catch
-            {
-                newTree = SyntaxTree.ParseText(newText, path: FilePath ?? Name);
-            }
-        }
-        return new Document(Id, Name, newText, newTree, FilePath, Version.GetNewerVersion());
+        var newSolution = Solution.WithDocumentText(Id, newText);
+        return newSolution.GetDocument(Id)!;
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
@@ -12,11 +12,12 @@ public class DocumentTests
     public async Task GetSyntaxTreeAsync_ShouldReturnSameInstance()
     {
         var source = SourceText.From("x = 1");
-        var solutionId = SolutionId.CreateNew();
-        var projectId = ProjectId.CreateNew(solutionId);
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
         var documentId = DocumentId.CreateNew(projectId);
-        var tree = SyntaxTree.ParseText(source, path: "Test.rvn");
-        var document = new Document(documentId, "Test.rvn", source, tree, null, VersionStamp.Create());
+        solution = solution.AddDocument(documentId, "Test.rvn", source);
+        var document = solution.GetDocument(documentId)!;
 
         var tree1 = await document.GetSyntaxTreeAsync();
         var tree2 = await document.GetSyntaxTreeAsync();

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/EditorTests.cs
@@ -44,11 +44,12 @@ public class EditorTests
     private static Document CreateDocument(string text)
     {
         var source = SourceText.From(text);
-        var solutionId = SolutionId.CreateNew();
-        var projectId = ProjectId.CreateNew(solutionId);
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
         var documentId = DocumentId.CreateNew(projectId);
-        var tree = SyntaxTree.ParseText(source, path: "Test");
-        return new Document(documentId, "Test", source, tree, null, VersionStamp.Create());
+        solution = solution.AddDocument(documentId, "Test", source);
+        return solution.GetDocument(documentId)!;
     }
 }
 


### PR DESCRIPTION
## Summary
- track document versions via DocumentInfo and bump versions on edits
- add SolutionInfo.WithVersion for updating solution metadata
- rework Document, Project, and Solution as facades over info objects with lazy caching and parent navigation

## Testing
- `dotnet build`
- `dotnet test` *(fails: 36 failed, 71 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cf410060832fad00a1daa9c2c339