### PR TITLE
feat(workspace): add document syntax and semantic APIs

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
@@ -18,17 +18,28 @@ public class SyntaxTreeProvider
         ".rav"
     };
 
+    /// <summary>Determines whether the specified document supports a syntax tree.</summary>
+    public virtual bool SupportsSyntaxTree(string name, string? filePath = null)
+    {
+        var path = filePath ?? name;
+        var ext = Path.GetExtension(path);
+        return s_sourceExtensions.Contains(ext);
+    }
+
+    /// <summary>Determines whether the specified document supports a semantic model.</summary>
+    public virtual bool SupportsSemanticModel(string name, string? filePath = null)
+        => SupportsSyntaxTree(name, filePath);
+
     /// <summary>
     /// Attempts to parse a <see cref="SyntaxTree"/> for the specified document
     /// name and text. Non-Raven files return <c>null</c>.
     /// </summary>
     public virtual SyntaxTree? TryParse(string name, SourceText text, string? filePath = null)
     {
-        var path = filePath ?? name;
-        var ext = Path.GetExtension(path);
-        if (!s_sourceExtensions.Contains(ext))
+        if (!SupportsSyntaxTree(name, filePath))
             return null;
 
+        var path = filePath ?? name;
         return SyntaxTree.ParseText(text, path: path);
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
@@ -38,4 +38,91 @@ public class DocumentTests
         var tree = doc.GetSyntaxTreeAsync().Result;
         Assert.Null(tree);
     }
+
+    [Fact]
+    public void SupportsSyntaxTree_ShouldReflectFileExtension()
+    {
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
+        var docId1 = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId1, "Test.rvn", SourceText.From("x = 1"));
+        var docId2 = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId2, "Readme.txt", SourceText.From("Hello"));
+
+        var doc1 = solution.GetDocument(docId1)!;
+        var doc2 = solution.GetDocument(docId2)!;
+
+        Assert.True(doc1.SupportsSyntaxTree);
+        Assert.False(doc2.SupportsSyntaxTree);
+        Assert.True(doc1.SupportsSemanticModel);
+        Assert.False(doc2.SupportsSemanticModel);
+    }
+
+    [Fact]
+    public async Task WithSyntaxRoot_ShouldUpdateTreeAndText()
+    {
+        var source = SourceText.From("x = 1");
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
+        var docId = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId, "Test.rvn", source);
+        var document = solution.GetDocument(docId)!;
+
+        var newTree = SyntaxFactory.ParseSyntaxTree("x = 2");
+        var newDoc = document.WithSyntaxRoot(newTree.GetRoot());
+
+        var updatedText = await newDoc.GetTextAsync();
+        Assert.Equal("x = 2", updatedText.ToString());
+        var tree = await newDoc.GetSyntaxTreeAsync();
+        Assert.Same(newTree, tree);
+    }
+
+    [Fact]
+    public async Task GetSemanticModelAsync_ShouldReturnModel()
+    {
+        var source = SourceText.From("x = 1");
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
+        var docId = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId, "Test.rvn", source);
+        var document = solution.GetDocument(docId)!;
+
+        var model = await document.GetSemanticModelAsync();
+        Assert.NotNull(model);
+    }
+
+    [Fact]
+    public async Task GetTextChangesAsync_ShouldReturnChanges()
+    {
+        var source = SourceText.From("x = 1");
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
+        var docId = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId, "Test.rvn", source);
+        var document = solution.GetDocument(docId)!;
+
+        var newDoc = document.WithText(SourceText.From("x = 2"));
+
+        var changes = await newDoc.GetTextChangesAsync(document);
+        Assert.Single(changes);
+    }
+
+    [Fact]
+    public async Task GetTextVersionAsync_ShouldReturnVersion()
+    {
+        var source = SourceText.From("x = 1");
+        var solution = new Solution(HostServices.Default);
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, "P");
+        var docId = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId, "Test.rvn", source);
+        var document = solution.GetDocument(docId)!;
+
+        var version = await document.GetTextVersionAsync();
+        Assert.Equal(document.Version, version);
+    }
 }


### PR DESCRIPTION
## Summary
- expose SupportsSyntaxTree/SemanticModel on Document
- add Document APIs for WithSyntaxRoot, GetSemanticModelAsync, GetTextChangesAsync and GetTextVersionAsync
- extend SyntaxTreeProvider with capability checks
- cover new APIs with unit tests

## Testing
- `dotnet build`
- `dotnet test` *(fails: System.ArgumentNullException and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a41d9fc28c832faddb0bff4bc86dc4