### PR TITLE
feat: add raven workspace

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -53,16 +53,20 @@ public class Compilation
 
     public static Compilation Create(string assemblyName, SyntaxTree[] syntaxTrees, CompilationOptions? options = null)
     {
-        return new Compilation(assemblyName, syntaxTrees, [], options);
+        var core = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        return new Compilation(assemblyName, syntaxTrees, [core], options);
     }
 
     public static Compilation Create(string assemblyName, CompilationOptions? options = null)
     {
-        return new Compilation(assemblyName, [], [], options);
+        var core = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        return new Compilation(assemblyName, [], [core], options);
     }
 
     public static Compilation Create(string assemblyName, SyntaxTree[] syntaxTrees, MetadataReference[] references, CompilationOptions? options = null)
     {
+        if (references.Length == 0)
+            references = [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)];
         return new Compilation(assemblyName, syntaxTrees, references, options);
     }
 

--- a/src/Raven.CodeAnalysis/ReferenceAssemblyPaths.cs
+++ b/src/Raven.CodeAnalysis/ReferenceAssemblyPaths.cs
@@ -1,17 +1,21 @@
+using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Raven.CodeAnalysis;
 
 public static class ReferenceAssemblyPaths
 {
-    public static string[] GetReferenceAssemblyPaths(string sdkVersion = "9.0.0", string targetFramework = "net9.0")
+    public static string[] GetReferenceAssemblyPaths(string sdkVersion = "9.0.7", string targetFramework = "net9.0")
     {
         var assemblyDir = GetReferenceAssemblyDir(sdkVersion, targetFramework);
+        if (assemblyDir is null || !Directory.Exists(assemblyDir))
+            return Array.Empty<string>();
 
-        return Directory.GetFiles(assemblyDir!, "*.dll");
+        return Directory.GetFiles(assemblyDir, "*.dll");
     }
 
-    public static string? GetReferenceAssemblyDir(string sdkVersion = "9.0.0", string targetFramework = "net9.0")
+    public static string? GetReferenceAssemblyDir(string sdkVersion = "9.0.7", string targetFramework = "net9.0")
     {
         string? referencePath = null;
 
@@ -25,7 +29,8 @@ public static class ReferenceAssemblyPaths
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            //referencePath = $@"/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/{sdkVersion}/ref/{targetFramework}";
+            var root = Environment.GetEnvironmentVariable("DOTNET_ROOT") ?? "/usr/lib/dotnet";
+            referencePath = Path.Combine(root, "packs", "Microsoft.NETCore.App.Ref", sdkVersion, "ref", targetFramework);
         }
 
         return referencePath;

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// A simple workspace that preconfigures projects with .NET framework references
+/// similar to Roslyn's MSBuildWorkspace.
+/// </summary>
+public sealed class RavenWorkspace : Workspace
+{
+    private readonly MetadataReference[] _frameworkReferences;
+
+    private RavenWorkspace(MetadataReference[] frameworkReferences)
+        : base("Raven")
+    {
+        _frameworkReferences = frameworkReferences;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="RavenWorkspace"/> with framework references for the
+    /// specified SDK version and target framework.
+    /// </summary>
+    public static RavenWorkspace Create(string sdkVersion = "9.0.7", string targetFramework = "net9.0")
+    {
+        var paths = ReferenceAssemblyPaths.GetReferenceAssemblyPaths(sdkVersion, targetFramework);
+        MetadataReference[] refs;
+        if (paths.Length == 0)
+        {
+            // fall back to the current runtime if reference assemblies are missing
+            refs = new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) };
+        }
+        else
+        {
+            refs = paths
+                .Where(p => System.IO.File.Exists(p))
+                .Select(MetadataReference.CreateFromFile)
+                .ToArray();
+        }
+        return new RavenWorkspace(refs);
+    }
+
+    /// <summary>
+    /// Adds a new project to the workspace preloaded with framework references.
+    /// </summary>
+    public ProjectId AddProject(string name)
+    {
+        var solution = CurrentSolution;
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, name);
+        foreach (var reference in _frameworkReferences)
+            solution = solution.AddMetadataReference(projectId, reference);
+        TryApplyChanges(solution);
+        return projectId;
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/RavenWorkspaceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/RavenWorkspaceTests.cs
@@ -1,0 +1,17 @@
+using Raven.CodeAnalysis;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class RavenWorkspaceTests
+{
+    [Fact]
+    public void AddProject_ShouldIncludeFrameworkReferences()
+    {
+        var workspace = RavenWorkspace.Create();
+        var projectId = workspace.AddProject("App");
+
+        var compilation = workspace.GetCompilation(projectId);
+        Assert.NotEmpty(compilation.References);
+    }
+}


### PR DESCRIPTION
## Summary
- add simple RavenWorkspace that loads .NET framework references
- resolve reference assembly paths for installed SDKs
- ensure compilation includes core runtime reference by default

## Testing
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Tests - Failed: 14, Passed: 102)*

------
https://chatgpt.com/codex/tasks/task_e_68a430a88940832f82bc4a35de1049c6