### PR TITLE
feat: add Project.AddDocument helper

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
@@ -58,6 +58,32 @@ public sealed class Project
         return doc;
     }
 
+    /// <summary>
+    /// Adds a new document to this project and returns the resulting <see cref="Document"/>.
+    /// </summary>
+    /// <remarks>
+    /// The returned document belongs to a new <see cref="Solution"/> that contains the
+    /// added document. To update a <see cref="Workspace"/>, apply the returned document's
+    /// solution via <c>workspace.TryApplyChanges(document.Project.Solution)</c>.
+    /// </remarks>
+    public Document AddDocument(DocumentId id, string name, SourceText text)
+    {
+        if (id.ProjectId != Id)
+            throw new ArgumentException("DocumentId must belong to this project", nameof(id));
+
+        var newSolution = _solution.AddDocument(id, name, text);
+        return newSolution.GetDocument(id)!;
+    }
+
+    /// <summary>
+    /// Adds a new document with an automatically generated identifier.
+    /// </summary>
+    public Document AddDocument(string name, SourceText text)
+    {
+        var id = DocumentId.CreateNew(Id);
+        return AddDocument(id, name, text);
+    }
+
     internal Project AddDocument(DocumentInfo info)
     {
         var newInfos = _documentInfos.Add(info.Id, info);

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/RavenWorkspaceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/RavenWorkspaceTests.cs
@@ -23,12 +23,13 @@ public class RavenWorkspaceTests
         var workspace = RavenWorkspace.Create();
         var projectId = workspace.AddProject("App");
 
-        workspace.CurrentSolution.AddDocument(
-                DocumentId.CreateNew(projectId),
-                "test.rav",
-                SourceText.From("System.Console.WriteLine(\"Hello\")\n"));
+        var project = workspace.CurrentSolution.GetProject(projectId)!;
+        var document = project.AddDocument(
+            "test.rav",
+            SourceText.From("System.Console.WriteLine(\"Hello\")\n"));
+        workspace.TryApplyChanges(document.Project.Solution);
 
         var compilation = workspace.GetCompilation(projectId);
-        Assert.NotEmpty(compilation.References);
+        Assert.Contains(compilation.SyntaxTrees, t => t.FilePath == "test.rav");
     }
 }


### PR DESCRIPTION
## Summary
- allow adding documents directly to a Project via new AddDocument overloads
- update workspace tests to exercise new API

## Testing
- `dotnet build`
- `dotnet test` *(fails: 14 tests)*
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter AddProjectAndDocument_ShouldIncludeDocumentInProject`


------
https://chatgpt.com/codex/tasks/task_e_68a437094430832f95c143419f6ff7cb