### PR TITLE
feat: enrich token metadata and node kind mapping

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticClassifier.cs
+++ b/src/Raven.CodeAnalysis/SemanticClassifier.cs
@@ -13,8 +13,8 @@ public static class SemanticClassifier
         {
             var kind = descendant.Kind;
 
-            // Keywords
-            if (descendant.IsKeyword())
+            // Reserved words
+            if (descendant.IsReservedWord())
             {
                 tokenMap[descendant] = SemanticClassification.Keyword;
             }

--- a/src/Raven.CodeAnalysis/Syntax/GreenNode.cs
+++ b/src/Raven.CodeAnalysis/Syntax/GreenNode.cs
@@ -126,7 +126,7 @@ public abstract class GreenNode
 
     public virtual object? GetValue() => (int)Kind;
 
-    public virtual string? GetValueText() => SyntaxFacts.IsKeywordKind(Kind) ? SyntaxFacts.GetSyntaxTokenText(Kind) : Kind.ToString();
+    public virtual string? GetValueText() => SyntaxFacts.IsReservedWordKind(Kind) ? SyntaxFacts.GetSyntaxTokenText(Kind) : Kind.ToString();
 
     public virtual int GetChildStartPosition(int childIndex)
     {

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
@@ -21,7 +21,7 @@ internal class PatternSyntaxParser : SyntaxParser
     {
         var left = ParseUnaryPattern();
 
-        while (ConsumeToken(SyntaxKind.OrKeyword, out var orKeyword))
+        while (ConsumeToken(SyntaxKind.OrToken, out var orKeyword))
         {
             var right = ParseUnaryPattern();
             left = BinaryPattern(SyntaxKind.OrPattern, left, orKeyword, right);

--- a/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
+++ b/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NodeKinds>
+  <NodeKind Name="GetAccessorDeclaration" Type="AccessorDeclaration" />
+  <NodeKind Name="SetAccessorDeclaration" Type="AccessorDeclaration" />
+  <NodeKind Name="NumericLiteralExpression" Type="LiteralExpression" />
+  <NodeKind Name="TrueLiteralExpression" Type="LiteralExpression" />
+  <NodeKind Name="FalseLiteralExpression" Type="LiteralExpression" />
+  <NodeKind Name="CharacterLiteralExpression" Type="LiteralExpression" />
+  <NodeKind Name="StringLiteralExpression" Type="LiteralExpression" />
+  <NodeKind Name="NullLiteralExpression" Type="LiteralExpression" />
+  <NodeKind Name="UnaryPlusExpression" Type="UnaryExpression" />
+  <NodeKind Name="UnaryMinusExpression" Type="UnaryExpression" />
+  <NodeKind Name="LogicalNotExpression" Type="UnaryExpression" />
+  <NodeKind Name="AddressOfExpression" Type="UnaryExpression" />
+  <NodeKind Name="AddExpression" Type="BinaryExpression" />
+  <NodeKind Name="SubtractExpression" Type="BinaryExpression" />
+  <NodeKind Name="MultiplyExpression" Type="BinaryExpression" />
+  <NodeKind Name="DivideExpression" Type="BinaryExpression" />
+  <NodeKind Name="ModuloExpression" Type="BinaryExpression" />
+  <NodeKind Name="PowerExpression" Type="BinaryExpression" />
+  <NodeKind Name="EqualsExpression" Type="BinaryExpression" />
+  <NodeKind Name="NotEqualsExpression" Type="BinaryExpression" />
+  <NodeKind Name="LessThanExpression" Type="BinaryExpression" />
+  <NodeKind Name="GreaterThanExpression" Type="BinaryExpression" />
+  <NodeKind Name="LessThanOrEqualsExpression" Type="BinaryExpression" />
+  <NodeKind Name="GreaterThanOrEqualsExpression" Type="BinaryExpression" />
+  <NodeKind Name="LogicalAndExpression" Type="BinaryExpression" />
+  <NodeKind Name="LogicalOrExpression" Type="BinaryExpression" />
+  <NodeKind Name="SimpleAssignmentExpression" Type="AssignmentExpression" />
+  <NodeKind Name="SimpleMemberAccessExpression" Type="MemberAccessExpression" />
+</NodeKinds>

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -2,44 +2,6 @@ namespace Raven.CodeAnalysis.Syntax;
 
 public static partial class SyntaxFacts
 {
-    public static bool TryResolveOperatorPrecedence(SyntaxKind kind, out int precedence)
-    {
-        switch (kind)
-        {
-            case SyntaxKind.StarToken:
-            case SyntaxKind.SlashToken:
-            case SyntaxKind.PercentToken:
-                precedence = 5;
-                return true;
-
-            case SyntaxKind.PlusToken:
-            case SyntaxKind.MinusToken:
-                precedence = 4;
-                return true;
-
-            case SyntaxKind.LessThanToken:
-            case SyntaxKind.LessThanOrEqualsToken:
-            case SyntaxKind.GreaterThanToken:
-            case SyntaxKind.GreaterThanOrEqualsToken:
-            case SyntaxKind.EqualsEqualsToken:
-            case SyntaxKind.NotEqualsToken:
-                precedence = 3;
-                return true;
-
-            case SyntaxKind.AndToken:
-                precedence = 2;
-                return true;
-
-            case SyntaxKind.OrToken:
-                precedence = 1;
-                return true;
-
-            default:
-                precedence = -1;
-                return false;
-        }
-    }
-
     public static bool IsExpression(SyntaxKind kind)
     {
         switch (kind)
@@ -148,15 +110,4 @@ public static partial class SyntaxFacts
         };
     }
 
-    public static bool IsUnaryOperatorToken(SyntaxKind kind)
-    {
-        return kind switch
-        {
-            SyntaxKind.PlusToken => true,        // Unary +
-            SyntaxKind.MinusToken => true,       // Unary -
-            SyntaxKind.ExclamationToken => true, // Logical not
-            SyntaxKind.AmpersandToken => true,   // Address-of
-            _ => false
-        };
-    }
 }

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxTokenExtension.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxTokenExtension.cs
@@ -2,8 +2,8 @@ namespace Raven.CodeAnalysis.Syntax;
 
 public static class SyntaxTokenExtension
 {
-    public static bool IsKeyword(this SyntaxToken token)
+    public static bool IsReservedWord(this SyntaxToken token)
     {
-        return SyntaxFacts.IsKeywordKind(token.Kind);
+        return SyntaxFacts.IsReservedWordKind(token.Kind);
     }
 }

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -1,66 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Tokens>
   <!-- Keywords -->
-  <TokenKind Name="VoidKeyword" Text="void" IsKeyword="true" />
-  <TokenKind Name="NullKeyword" Text="null" IsKeyword="true" />
-  <TokenKind Name="IntKeyword" Text="int" IsKeyword="true" />
-  <TokenKind Name="StringKeyword" Text="string" IsKeyword="true" />
-  <TokenKind Name="BoolKeyword" Text="bool" IsKeyword="true" />
-  <TokenKind Name="CharKeyword" Text="char" IsKeyword="true" />
-  <TokenKind Name="ImportKeyword" Text="import" IsKeyword="true" />
-  <TokenKind Name="NamespaceKeyword" Text="namespace" IsKeyword="true" />
-  <TokenKind Name="LetKeyword" Text="let" IsKeyword="true" />
-  <TokenKind Name="VarKeyword" Text="var" IsKeyword="true" />
-  <TokenKind Name="FuncKeyword" Text="func" IsKeyword="true" />
-  <TokenKind Name="EnumKeyword" Text="enum" IsKeyword="true" />
-  <TokenKind Name="StructKeyword" Text="struct" IsKeyword="true" />
-  <TokenKind Name="ClassKeyword" Text="class" IsKeyword="true" />
-  <TokenKind Name="InitKeyword" Text="init" IsKeyword="true" />
-  <TokenKind Name="SelfKeyword" Text="self" IsKeyword="true" />
-  <TokenKind Name="IfKeyword" Text="if" IsKeyword="true" />
-  <TokenKind Name="ElseKeyword" Text="else" IsKeyword="true" />
-  <TokenKind Name="WhileKeyword" Text="while" IsKeyword="true" />
-  <TokenKind Name="ReturnKeyword" Text="return" IsKeyword="true" />
-  <TokenKind Name="NewKeyword" Text="new" IsKeyword="true" />
-  <TokenKind Name="TrueKeyword" Text="true" IsKeyword="true" />
-  <TokenKind Name="FalseKeyword" Text="false" IsKeyword="true" />
-  <TokenKind Name="IsKeyword" Text="is" IsKeyword="true" />
-  <TokenKind Name="NotKeyword" Text="not" IsKeyword="true" />
-  <TokenKind Name="AndKeyword" Text="and" IsKeyword="true" />
-  <TokenKind Name="OrKeyword" Text="or" IsKeyword="true" />
-  <TokenKind Name="RefKeyword" Text="ref" IsKeyword="true" />
-  <TokenKind Name="OutKeyword" Text="out" IsKeyword="true" />
-  <TokenKind Name="InKeyword" Text="in" IsKeyword="true" />
-  <TokenKind Name="PublicKeyword" Text="public" IsKeyword="true" />
-  <TokenKind Name="PrivateKeyword" Text="private" IsKeyword="true" />
-  <TokenKind Name="InternalKeyword" Text="internal" IsKeyword="true" />
-  <TokenKind Name="ProtectedKeyword" Text="protected" IsKeyword="true" />
-  <TokenKind Name="StaticKeyword" Text="static" IsKeyword="true" />
-  <TokenKind Name="AbstractKeyword" Text="abstract" IsKeyword="true" />
-  <TokenKind Name="SealedKeyword" Text="sealed" IsKeyword="true" />
-  <TokenKind Name="OverrideKeyword" Text="override" IsKeyword="true" />
-  <TokenKind Name="GetKeyword" Text="get" IsKeyword="true" />
-  <TokenKind Name="SetKeyword" Text="set" IsKeyword="true" />
+  <TokenKind Name="VoidKeyword" Text="void" IsReservedWord="true" />
+  <TokenKind Name="NullKeyword" Text="null" IsReservedWord="true" />
+  <TokenKind Name="IntKeyword" Text="int" IsReservedWord="true" />
+  <TokenKind Name="StringKeyword" Text="string" IsReservedWord="true" />
+  <TokenKind Name="BoolKeyword" Text="bool" IsReservedWord="true" />
+  <TokenKind Name="CharKeyword" Text="char" IsReservedWord="true" />
+  <TokenKind Name="ImportKeyword" Text="import" IsReservedWord="true" />
+  <TokenKind Name="NamespaceKeyword" Text="namespace" IsReservedWord="true" />
+  <TokenKind Name="LetKeyword" Text="let" IsReservedWord="true" />
+  <TokenKind Name="VarKeyword" Text="var" IsReservedWord="true" />
+  <TokenKind Name="FuncKeyword" Text="func" IsReservedWord="true" />
+  <TokenKind Name="EnumKeyword" Text="enum" IsReservedWord="true" />
+  <TokenKind Name="StructKeyword" Text="struct" IsReservedWord="true" />
+  <TokenKind Name="ClassKeyword" Text="class" IsReservedWord="true" />
+  <TokenKind Name="InitKeyword" Text="init" IsReservedWord="true" />
+  <TokenKind Name="SelfKeyword" Text="self" IsReservedWord="true" />
+  <TokenKind Name="IfKeyword" Text="if" IsReservedWord="true" />
+  <TokenKind Name="ElseKeyword" Text="else" IsReservedWord="true" />
+  <TokenKind Name="WhileKeyword" Text="while" IsReservedWord="true" />
+  <TokenKind Name="ReturnKeyword" Text="return" IsReservedWord="true" />
+  <TokenKind Name="NewKeyword" Text="new" IsReservedWord="true" />
+  <TokenKind Name="TrueKeyword" Text="true" IsReservedWord="true" />
+  <TokenKind Name="FalseKeyword" Text="false" IsReservedWord="true" />
+  <TokenKind Name="IsKeyword" Text="is" IsReservedWord="true" />
+  <TokenKind Name="NotKeyword" Text="not" IsReservedWord="true" />
+  <TokenKind Name="AndToken" Text="and" IsReservedWord="true" IsBinaryOperator="true" Precedence="2" />
+  <TokenKind Name="OrToken" Text="or" IsReservedWord="true" IsBinaryOperator="true" Precedence="1" />
+  <TokenKind Name="RefKeyword" Text="ref" IsReservedWord="true" />
+  <TokenKind Name="OutKeyword" Text="out" IsReservedWord="true" />
+  <TokenKind Name="InKeyword" Text="in" IsReservedWord="true" />
+  <TokenKind Name="PublicKeyword" Text="public" IsReservedWord="true" />
+  <TokenKind Name="PrivateKeyword" Text="private" IsReservedWord="true" />
+  <TokenKind Name="InternalKeyword" Text="internal" IsReservedWord="true" />
+  <TokenKind Name="ProtectedKeyword" Text="protected" IsReservedWord="true" />
+  <TokenKind Name="StaticKeyword" Text="static" IsReservedWord="true" />
+  <TokenKind Name="AbstractKeyword" Text="abstract" IsReservedWord="true" />
+  <TokenKind Name="SealedKeyword" Text="sealed" IsReservedWord="true" />
+  <TokenKind Name="OverrideKeyword" Text="override" IsReservedWord="true" />
+  <TokenKind Name="GetKeyword" Text="get" IsReservedWord="true" />
+  <TokenKind Name="SetKeyword" Text="set" IsReservedWord="true" />
 
   <!-- Operators and punctuation -->
   <TokenKind Name="ArrowToken" Text="->" />
   <TokenKind Name="FatArrowToken" Text="=>" />
   <TokenKind Name="EqualsToken" Text="=" />
-  <TokenKind Name="EqualsEqualsToken" Text="==" />
-  <TokenKind Name="NotEqualsToken" Text="!=" />
-  <TokenKind Name="LessThanToken" Text="&lt;" />
-  <TokenKind Name="LessThanOrEqualsToken" Text="&lt;=" />
-  <TokenKind Name="GreaterThanToken" Text="&gt;" />
-  <TokenKind Name="GreaterThanOrEqualsToken" Text="&gt;=" />
-  <TokenKind Name="PlusToken" Text="+" />
-  <TokenKind Name="MinusToken" Text="-" />
-  <TokenKind Name="StarToken" Text="*" />
-  <TokenKind Name="SlashToken" Text="/" />
-  <TokenKind Name="PercentToken" Text="%" />
+  <TokenKind Name="EqualsEqualsToken" Text="==" IsBinaryOperator="true" Precedence="3" />
+  <TokenKind Name="NotEqualsToken" Text="!=" IsBinaryOperator="true" Precedence="3" />
+  <TokenKind Name="LessThanToken" Text="&lt;" IsBinaryOperator="true" Precedence="3" />
+  <TokenKind Name="LessThanOrEqualsToken" Text="&lt;=" IsBinaryOperator="true" Precedence="3" />
+  <TokenKind Name="GreaterThanToken" Text="&gt;" IsBinaryOperator="true" Precedence="3" />
+  <TokenKind Name="GreaterThanOrEqualsToken" Text="&gt;=" IsBinaryOperator="true" Precedence="3" />
+  <TokenKind Name="PlusToken" Text="+" IsUnaryOperator="true" IsBinaryOperator="true" Precedence="4" />
+  <TokenKind Name="MinusToken" Text="-" IsUnaryOperator="true" IsBinaryOperator="true" Precedence="4" />
+  <TokenKind Name="StarToken" Text="*" IsBinaryOperator="true" Precedence="5" />
+  <TokenKind Name="SlashToken" Text="/" IsBinaryOperator="true" Precedence="5" />
+  <TokenKind Name="PercentToken" Text="%" IsBinaryOperator="true" Precedence="5" />
   <TokenKind Name="CaretToken" Text="^" />
-  <TokenKind Name="AmpersandToken" Text="&amp;" />
+  <TokenKind Name="AmpersandToken" Text="&amp;" IsUnaryOperator="true" />
   <TokenKind Name="BarToken" Text="|" />
-  <TokenKind Name="ExclamationToken" Text="!" />
+  <TokenKind Name="ExclamationToken" Text="!" IsUnaryOperator="true" />
   <TokenKind Name="QuestionToken" Text="?" />
   <TokenKind Name="DotToken" Text="." />
   <TokenKind Name="CommaToken" Text="," />

--- a/tools/Generator/HelperExtensions.cs
+++ b/tools/Generator/HelperExtensions.cs
@@ -6,8 +6,8 @@ public static class HelperExtensions
     {
         name = name.ToCamelCase();
 
-        var x = SyntaxFacts.IsKeywordKind(SyntaxFacts.GetKeywordKind(name));
-        if (x)
+        var keywordKind = SyntaxFacts.GetKeywordKind(name);
+        if (SyntaxFacts.IsKeywordKind(keywordKind))
         {
             return $"@{name}";
         }


### PR DESCRIPTION
## Summary
- capture reserved words and operator metadata in `Tokens.xml`
- add `NodeKinds.xml` for SyntaxKinds lacking dedicated node types
- generate operator helpers and reserved word checks in `SyntaxFacts`

## Testing
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Tests.DocumentTests.GetSemanticModelAsync_ShouldReturnModel, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a46bb28d08832fa964e710d70dc259