### PR TITLE
fix: report missing types

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -199,10 +199,6 @@ internal abstract class Binder
             var type = LookupType(ident.Identifier.Text);
             if (type is not null)
                 return type;
-
-            var ns = LookupNamespace(ident.Identifier.Text);
-            if (ns is not null)
-                throw new Exception($"Type '{typeSyntax}' could not be resolved.");
         }
 
         if (typeSyntax is GenericNameSyntax generic)
@@ -225,7 +221,14 @@ internal abstract class Binder
                 return symbol;
         }
 
-        throw new Exception($"Type '{typeSyntax}' could not be resolved.");
+        var name = typeSyntax switch
+        {
+            IdentifierNameSyntax id => id.Identifier.Text,
+            _ => typeSyntax.ToString()
+        };
+
+        _diagnostics.ReportUndefinedName(name, typeSyntax.GetLocation());
+        return Compilation.ErrorTypeSymbol;
     }
 
     private ITypeSymbol? ResolveQualifiedType(QualifiedNameSyntax qualified)

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -307,15 +307,6 @@ public class Compilation
             diagnostics.AddRange(model.GetDiagnostics(cancellationToken));
         }
 
-        /*
-        var diagnostics = BinderFactory
-            .GetAllBinders()
-            .SelectMany(b => b.Diagnostics.AsEnumerable())
-            .ToImmutableArray();
-        
-        diagnostics.AddRange(model.GetDiagnostics(cancellationToken));
-        */
-
         return diagnostics.OrderBy(x => x.Location).ToImmutableArray();
     }
 
@@ -565,18 +556,18 @@ public class Compilation
             switch (metadataReference)
             {
                 case PortableExecutableReference per:
-                {
-                    var assembly = _metadataLoadContext.LoadFromAssemblyPath(per.FilePath);
-                    symbol = GetAssembly(assembly);
-                    break;
-                }
+                    {
+                        var assembly = _metadataLoadContext.LoadFromAssemblyPath(per.FilePath);
+                        symbol = GetAssembly(assembly);
+                        break;
+                    }
                 case CompilationReference cr:
-                {
-                    var compilation = cr.Compilation;
-                    compilation.EnsureSetup();
-                    symbol = compilation.Assembly;
-                    break;
-                }
+                    {
+                        var compilation = cr.Compilation;
+                        compilation.EnsureSetup();
+                        symbol = compilation.Assembly;
+                        break;
+                    }
                 default:
                     throw new InvalidOperationException();
             }

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -35,20 +35,8 @@ public partial class SemanticModel
 
     private void EnsureDiagnosticsCollected()
     {
-        var root = SyntaxTree.GetRoot();
-
-        var topLevelBinder = GetBinder(root) as TopLevelBinder;
-
-        foreach (var globalStmt in root.DescendantNodes().OfType<GlobalStatementSyntax>())
-        {
-            topLevelBinder.BindGlobalStatement(globalStmt);
-        }
-
-        foreach (var typeDeclaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
-        {
-            var typeDeclarationBinder = GetBinder(typeDeclaration) as TypeDeclarationBinder;
-            // Bind declaration
-        }
+        // Binding is triggered during binder creation; simply ensure the root binder exists
+        _ = GetBinder(SyntaxTree.GetRoot());
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- report undefined type names and return error symbols
- simplify diagnostic collection by ensuring root binder is built

## Testing
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a48b1e7a38832f80ec14effab6cfc7