### PR TITLE
test: execute sample programs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Major components:
 Run all commands from the repository root unless noted:
 
 ```bash
-# To generate the syntax nodes (first time and then when Model.xml has changed)
+# Generate syntax nodes (run whenever working in Raven.CodeAnalysis or when Model.xml changes)
 cd src/Raven.CodeAnalysis/Syntax
 dotnet run --project ../../../tools/NodeGenerator -- -f
 cd ../../..
@@ -35,6 +35,7 @@ dotnet test               # run unit tests
 ## Contribution Checklist
 * Run `dotnet build` and `dotnet test`.
 * Ensure generated files (e.g., via `tools/NodeGenerator`) are up to date.
+* Add or update unit tests for every fix or feature.
 * Include concise commit messages (`feat:`, `fix:`, `docs:` etc.).
 * Provide PR summaries referencing relevant diagnostics or examples.
 

--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -59,7 +59,7 @@ class BinderFactory
     private Binder CreateNamespaceBinder(NamespaceDeclarationSyntax nsSyntax, Binder parentBinder)
     {
         var nsSymbol = _compilation.GlobalNamespace.LookupNamespace(nsSyntax.Name.ToString());
-        var nsBinder = new NamespaceBinder(parentBinder, nsSymbol!, _compilation);
+        var nsBinder = new NamespaceBinder(parentBinder, nsSymbol!);
 
         // Register `import` directives
         foreach (var importDirective in nsSyntax.Imports)

--- a/src/Raven.CodeAnalysis/Binder/ClassDeclarationBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/ClassDeclarationBinder.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Collections.Immutable;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed class ClassDeclarationBinder : TypeDeclarationBinder
+{
+    public ClassDeclarationBinder(Binder parent, INamedTypeSymbol containingType, ClassDeclarationSyntax syntax)
+        : base(parent, containingType, syntax)
+    {
+    }
+
+    public void EnsureDefaultConstructor()
+    {
+        if (ContainingSymbol is INamedTypeSymbol named && !named.Constructors.Any(x => x.Parameters.Length == 0))
+        {
+            var classSyntax = (ClassDeclarationSyntax)Syntax;
+            _ = new SourceMethodSymbol(
+                ".ctor",
+                Compilation.GetSpecialType(SpecialType.System_Void),
+                ImmutableArray<SourceParameterSymbol>.Empty,
+                ContainingSymbol,
+                ContainingSymbol,
+                CurrentNamespace!.AsSourceNamespace(),
+                [classSyntax.GetLocation()],
+                [classSyntax.GetReference()],
+                isStatic: false,
+                methodKind: MethodKind.Constructor);
+        }
+    }
+}

--- a/src/Raven.CodeAnalysis/Binder/EnumDeclarationBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/EnumDeclarationBinder.cs
@@ -1,0 +1,12 @@
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed class EnumDeclarationBinder : TypeDeclarationBinder
+{
+    public EnumDeclarationBinder(Binder parent, INamedTypeSymbol containingType, EnumDeclarationSyntax syntax)
+        : base(parent, containingType, syntax)
+    {
+    }
+}

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -5,20 +5,14 @@ namespace Raven.CodeAnalysis;
 class NamespaceBinder : Binder
 {
     private readonly INamespaceSymbol _namespaceSymbol;
-    private readonly Compilation _compilation;
-    private readonly SemanticModel? _semanticModel;
     private readonly List<INamespaceSymbol> _imports = new(); // Stores `using` directives
     private readonly List<SourceNamedTypeSymbol> _declaredTypes = [];
 
-    public NamespaceBinder(Binder parent, INamespaceSymbol ns, Compilation compilation, SemanticModel? semanticModel = null)
+    public NamespaceBinder(Binder parent, INamespaceSymbol ns)
         : base(parent)
     {
         _namespaceSymbol = ns;
-        _compilation = compilation;
-        _semanticModel = semanticModel;
     }
-
-    public override SemanticModel SemanticModel => _semanticModel ?? base.SemanticModel;
 
     /// <summary>
     /// Adds a namespace to the list of imports (`using System;`).
@@ -48,7 +42,7 @@ class NamespaceBinder : Binder
         }
 
         // 3. Finally, check global namespace for metadata types
-        return _compilation.GlobalNamespace.LookupType(name) ?? base.LookupType(name);
+        return Compilation.GlobalNamespace.LookupType(name) ?? base.LookupType(name);
     }
 
     public void DeclareType(SourceNamedTypeSymbol type)

--- a/src/Raven.CodeAnalysis/Binder/TypeDeclarationBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeDeclarationBinder.cs
@@ -1,59 +1,33 @@
 using System.Linq;
-using System.Collections.Immutable;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
 
 namespace Raven.CodeAnalysis;
 
-internal class TypeDeclarationBinder : Binder
+internal abstract class TypeDeclarationBinder : Binder
 {
-    private readonly INamedTypeSymbol _containingType;
-
-    public TypeDeclarationBinder(Binder parent, INamedTypeSymbol containingType)
+    protected TypeDeclarationBinder(Binder parent, INamedTypeSymbol containingType, SyntaxNode syntax)
         : base(parent)
     {
-        _containingType = containingType;
+        ContainingSymbol = containingType;
+        Syntax = syntax;
     }
 
-    public new INamedTypeSymbol ContainingSymbol => _containingType;
+    protected SyntaxNode Syntax { get; }
+
+    public new INamedTypeSymbol ContainingSymbol { get; }
 
     public override ISymbol? LookupSymbol(string name)
     {
-        var symbol = _containingType.GetMembers(name).FirstOrDefault();
+        var symbol = ContainingSymbol.GetMembers(name).FirstOrDefault();
         if (symbol is not null)
             return symbol;
-
-        var parentSymbol = ParentBinder?.LookupSymbol(name);
-        if (parentSymbol != null)
-            return parentSymbol;
 
         return base.LookupSymbol(name);
     }
 
     public override ISymbol? BindDeclaredSymbol(SyntaxNode node)
     {
-        return node switch
-        {
-            ClassDeclarationSyntax => _containingType,
-            _ => base.BindDeclaredSymbol(node)
-        };
-    }
-
-    public void EnsureDefaultConstructor(ClassDeclarationSyntax classDecl)
-    {
-        if (_containingType is INamedTypeSymbol named && !named.Constructors.Any(x => x.Parameters.Length == 0))
-        {
-            _ = new SourceMethodSymbol(
-                ".ctor",
-                Compilation.GetSpecialType(SpecialType.System_Void),
-                ImmutableArray<SourceParameterSymbol>.Empty,
-                _containingType,
-                _containingType,
-                CurrentNamespace!.AsSourceNamespace(),
-                [classDecl.GetLocation()],
-                [classDecl.GetReference()],
-                isStatic: false,
-                methodKind: MethodKind.Constructor);
-        }
+        return node == Syntax ? ContainingSymbol : base.BindDeclaredSymbol(node);
     }
 }

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -49,6 +49,10 @@ public class Compilation
 
     internal BinderFactory BinderFactory { get; private set; }
 
+    internal DeclarationTable DeclarationTable { get; private set; }
+
+    internal SymbolFactory SymbolFactory { get; } = new SymbolFactory();
+
     public ITypeSymbol ErrorTypeSymbol => _errorTypeSymbol ??= new ErrorTypeSymbol(this, "Error", null, [], []);
 
     public static Compilation Create(string assemblyName, SyntaxTree[] syntaxTrees, CompilationOptions? options = null)
@@ -164,6 +168,7 @@ public class Compilation
         }
 
         BinderFactory = new BinderFactory(this);
+        DeclarationTable = new DeclarationTable(SyntaxTrees);
 
         Assembly = new SourceAssemblySymbol(AssemblyName, []);
 

--- a/src/Raven.CodeAnalysis/DeclKey.cs
+++ b/src/Raven.CodeAnalysis/DeclKey.cs
@@ -1,0 +1,18 @@
+namespace Raven.CodeAnalysis;
+
+using System.Collections.Immutable;
+
+/// <summary>
+/// Represents a syntax-only identity for a declaration. Used as a key for symbol caching.
+/// </summary>
+/// <param name="Kind">Kind of symbol (method, type, etc.).</param>
+/// <param name="Name">Name of the declaration.</param>
+/// <param name="Arity">Generic arity, if any.</param>
+/// <param name="Containing">Key of the containing declaration.</param>
+/// <param name="Locations">Locations of the declaration in source.</param>
+internal sealed record class DeclKey(
+    SymbolKind Kind,
+    string Name,
+    int Arity,
+    DeclKey? Containing,
+    ImmutableArray<Location> Locations);

--- a/src/Raven.CodeAnalysis/DeclarationTable.cs
+++ b/src/Raven.CodeAnalysis/DeclarationTable.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// Provides mapping from syntax nodes to declaration keys.
+/// </summary>
+internal sealed class DeclarationTable
+{
+    private readonly ConcurrentDictionary<SyntaxNode, DeclKey> _map = new();
+
+    public DeclarationTable(IEnumerable<SyntaxTree> syntaxTrees)
+    {
+        foreach (var tree in syntaxTrees)
+            Build(tree.GetRoot());
+    }
+
+    private void Build(SyntaxNode node)
+    {
+        if (TryCreateDeclKey(node, out var key))
+            _map[node] = key;
+
+        foreach (var child in node.ChildNodes())
+            Build(child);
+    }
+
+    public bool TryGetDeclKey(SyntaxNode node, out DeclKey key)
+        => _map.TryGetValue(node, out key);
+
+    private bool TryCreateDeclKey(SyntaxNode node, out DeclKey key)
+    {
+        switch (node)
+        {
+            case ClassDeclarationSyntax cls:
+                key = CreateKey(SymbolKind.Type, cls.Identifier.Text, 0, cls);
+                return true;
+            case MethodDeclarationSyntax method:
+                key = CreateKey(SymbolKind.Method, method.Identifier.Text, 0, method);
+                return true;
+            case VariableDeclaratorSyntax { Parent.Parent: LocalDeclarationStatementSyntax } variable:
+                key = CreateKey(SymbolKind.Local, variable.Identifier.Text, 0, variable);
+                return true;
+            default:
+                key = default;
+                return false;
+        }
+    }
+
+    private DeclKey CreateKey(SymbolKind kind, string name, int arity, SyntaxNode node)
+    {
+        var containing = GetContainingDeclKey(node.Parent);
+        return new DeclKey(kind, name, arity, containing, ImmutableArray.Create(node.GetLocation()));
+    }
+
+    private DeclKey? GetContainingDeclKey(SyntaxNode? node)
+    {
+        while (node is not null)
+        {
+            if (_map.TryGetValue(node, out var key))
+                return key;
+            if (TryCreateDeclKey(node, out var created))
+            {
+                _map[node] = created;
+                return created;
+            }
+            node = node.Parent;
+        }
+        return null;
+    }
+}

--- a/src/Raven.CodeAnalysis/SymbolFactory.cs
+++ b/src/Raven.CodeAnalysis/SymbolFactory.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Concurrent;
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// Central cache for symbols keyed by <see cref="DeclKey"/>.
+/// </summary>
+internal sealed class SymbolFactory
+{
+    private readonly ConcurrentDictionary<DeclKey, Lazy<Symbol>> _cache = new();
+
+    public TSymbol GetOrCreate<TSymbol>(DeclKey key, Func<TSymbol> build)
+        where TSymbol : Symbol
+        => (TSymbol)_cache.GetOrAdd(key, _ => new Lazy<Symbol>(() => build(), true)).Value;
+}

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -49,7 +49,7 @@ var root = syntaxTree.GetRoot();
 
 var assemblyName = Path.GetFileNameWithoutExtension(filePath);
 
-var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir("9.0.0", "net9.0");
+var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
 
 var compilation = Compilation.Create(assemblyName, new CompilationOptions(OutputKind.ConsoleApplication))
     .AddSyntaxTrees(syntaxTree)

--- a/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Raven.CodeAnalysis;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class SampleProgramsTests
+{
+    public static IEnumerable<object[]> SamplePrograms => new[]
+    {
+        new object[] {"arrays.rav", Array.Empty<string>()},
+        new object[] {"enums.rav", Array.Empty<string>()},
+        new object[] {"general.rav", Array.Empty<string>()},
+        new object[] {"generics.rav", Array.Empty<string>()},
+        new object[] {"io.rav", new[] {"."}},
+        new object[] {"test2.rav", Array.Empty<string>()},
+        new object[] {"type-unions.rav", Array.Empty<string>()},
+        new object[] {"tuples.rav", Array.Empty<string>()},
+        new object[] {"main.rav", Array.Empty<string>()},
+        new object[] {"classes.rav", Array.Empty<string>()},
+    };
+
+    [Theory]
+    [MemberData(nameof(SamplePrograms))]
+    public void Sample_should_compile_and_run(string fileName, string[] args)
+    {
+        var projectDir = Path.GetFullPath(Path.Combine("..", "..", "..", "..", "..", "src", "Raven.Compiler"));
+        var samplePath = Path.Combine(projectDir, "samples", fileName);
+
+        var outputDir = Path.Combine(Path.GetTempPath(), "raven_samples", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(outputDir);
+        var outputDll = Path.Combine(outputDir, Path.ChangeExtension(fileName, ".dll"));
+
+        var build = Process.Start(new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"run --project \"{projectDir}\" -- \"{samplePath}\" -o \"{outputDll}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = projectDir,
+        })!;
+        build.WaitForExit();
+        Assert.Equal(0, build.ExitCode);
+
+        var testDep = Path.Combine(projectDir, "TestDep.dll");
+        if (File.Exists(testDep))
+            File.Copy(testDep, Path.Combine(outputDir, "TestDep.dll"), overwrite: true);
+
+        var refDir = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var version = new DirectoryInfo(Path.GetDirectoryName(Path.GetDirectoryName(refDir)!)!).Name;
+        File.WriteAllText(
+            Path.Combine(outputDir, Path.ChangeExtension(fileName, ".runtimeconfig.json")),
+            $@"{{
+  ""runtimeOptions"": {{
+    ""tfm"": ""net9.0"",
+    ""framework"": {{
+      ""name"": ""Microsoft.NETCore.App"",
+      ""version"": ""{version}""
+    }}
+  }}
+}}" );
+
+        var run = Process.Start(new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"\"{outputDll}\" {string.Join(' ', args)}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = outputDir,
+        })!;
+        run.WaitForExit();
+        Assert.Equal(0, run.ExitCode);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs
@@ -1,0 +1,27 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class SemanticModelDiagnosticsTests
+{
+    [Fact]
+    public void GetDiagnostics_CollectsMethodBodyDiagnostics()
+    {
+        var source = """
+class Program {
+    void M() {
+        1();
+    }
+}
+""";
+        var syntaxTree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", new[] { syntaxTree }, new CompilationOptions(OutputKind.ConsoleApplication));
+        var model = compilation.GetSemanticModel(syntaxTree);
+
+        var diagnostics = model.GetDiagnostics();
+
+        Assert.Contains(diagnostics, d => d.Descriptor == SemanticDiagnostics.InvalidInvocation);
+    }
+}


### PR DESCRIPTION
## Summary
- streamline type declaration binders and namespace binder construction
- wire semantic symbol lookup through single binder instance
- add integration test compiling and running all sample programs
- consolidate global statement binding into a single pass and simplify namespace binder
- document running NodeGenerator and requiring unit tests for changes
- bind all expressions and statements when collecting diagnostics to gather full semantic errors
- add unit test covering diagnostic collection from method bodies

## Testing
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet format --include src/Raven.CodeAnalysis/SemanticModel.cs,test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs`
- `dotnet build`
- `dotnet test -m:1` *(fails: DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, IfStatementSyntaxTest.IfStatement_MissingBlock_WithReturnStatement, SemanticModelDiagnosticsTests.GetDiagnostics_CollectsMethodBodyDiagnostics, SampleProgramsTests.Sample_should_compile_and_run, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b41857c4832fa6c49a5c3de8f64b