### PR TITLE
fix: load metadata references before type lookup

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -458,6 +458,8 @@ public class Compilation
 
     public INamedTypeSymbol? GetTypeByMetadataName(string metadataName)
     {
+        EnsureSetup();
+
         return _metadataReferenceSymbols
             .Select(x => x.Value)
             .Select(x => x.GetTypeByMetadataName(metadataName))

--- a/test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs
@@ -1,0 +1,22 @@
+using Raven.CodeAnalysis;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class MetadataReferenceLoadingTests
+{
+    [Fact]
+    public void GetTypeByMetadataName_LoadsReferences_WhenNoSyntaxTrees()
+    {
+        var referencePaths = ReferenceAssemblyPaths.GetReferenceAssemblyPaths();
+        var references = referencePaths.Select(MetadataReference.CreateFromFile).ToArray();
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(references);
+
+        var consoleType = compilation.GetTypeByMetadataName("System.Console");
+        Assert.NotNull(consoleType);
+
+        var stringType = compilation.GetTypeByMetadataName("System.String");
+        Assert.NotNull(stringType);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure compilation setup runs before resolving metadata type names
- add regression test for metadata reference loading without syntax trees

## Testing
- `dotnet format --include src/Raven.CodeAnalysis/Compilation.cs,test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs`
- `dotnet build`
- `dotnet test` *(fails: The method or operation is not implemented.)*
- `dotnet run --project test/TestApp/TestApp.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a62d267678832fb127e59527f58e05