### PR TITLE
fix: traverse binder hierarchy for diagnostics

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -43,14 +43,26 @@ public partial class SemanticModel
     private void EnsureDiagnosticsCollected()
     {
         var root = SyntaxTree.GetRoot();
+        var binder = GetBinder(root);
 
-        foreach (var node in root.DescendantNodesAndSelf())
+        Traverse(root, binder);
+
+        void Traverse(SyntaxNode node, Binder currentBinder)
         {
-            var binder = GetBinder(node);
-
-            if (node is ExpressionSyntax || node is StatementSyntax)
+            foreach (var child in node.ChildNodes())
             {
-                binder.GetOrBind(node);
+                if (child is GlobalStatementSyntax)
+                    continue;
+
+                var childBinder = GetBinder(child, currentBinder);
+
+                if (child is ExpressionSyntax || child is StatementSyntax)
+                {
+                    childBinder.GetOrBind(child);
+                    continue;
+                }
+
+                Traverse(child, childBinder);
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid binding every syntax node when gathering diagnostics
- traverse binder hierarchy and only bind top-level expressions and statements

## Testing
- `dotnet format --include src/Raven.CodeAnalysis/SemanticModel.cs -v diag`
- `dotnet build`
- `dotnet test` *(fails: e.g., Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run(fileName: "main.rav", args: []), Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a637e8045c832fb0a145cf358001fa