### PR TITLE
feat: add XML persistence for solutions and projects

### DIFF
--- a/src/Raven.CodeAnalysis/RavenFileExtensions.cs
+++ b/src/Raven.CodeAnalysis/RavenFileExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+namespace Raven.CodeAnalysis;
+
+public static class RavenFileExtensions
+{
+    public const string Raven = ".rav";
+    public const string Notebook = ".rvn";
+
+    public static readonly ImmutableArray<string> All = ImmutableArray.Create(Raven, Notebook);
+
+    public static bool HasRavenExtension(string path)
+    {
+        if (path is null) throw new ArgumentNullException(nameof(path));
+        var ext = Path.GetExtension(path);
+        return All.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
@@ -59,5 +59,8 @@ public sealed class ProjectInfo
     public ProjectInfo WithMetadataReferences(IEnumerable<MetadataReference> metadataReferences) =>
         new(Attributes, Documents, ProjectReferences, metadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
+    public ProjectInfo WithCompilationOptions(CompilationOptions? compilationOptions) =>
+        new(Attributes, Documents, ProjectReferences, MetadataReferences, FilePath, TargetFramework, compilationOptions, AssemblyName);
+
     public sealed record ProjectAttributes(ProjectId Id, string Name, VersionStamp Version);
 }

--- a/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
@@ -11,7 +11,9 @@ public sealed class ProjectInfo
         IEnumerable<ProjectReference>? projectReferences = null,
         IEnumerable<MetadataReference>? metadataReferences = null,
         string? filePath = null,
-        string? targetFramework = null)
+        string? targetFramework = null,
+        CompilationOptions? compilationOptions = null,
+        string? assemblyName = null)
     {
         Attributes = attributes;
         Documents = documents.ToImmutableArray();
@@ -19,6 +21,8 @@ public sealed class ProjectInfo
         MetadataReferences = metadataReferences?.ToImmutableArray() ?? ImmutableArray<MetadataReference>.Empty;
         FilePath = filePath;
         TargetFramework = targetFramework;
+        CompilationOptions = compilationOptions;
+        AssemblyName = assemblyName;
     }
 
     public ProjectAttributes Attributes { get; }
@@ -30,14 +34,15 @@ public sealed class ProjectInfo
 
     public ImmutableArray<ProjectReference> ProjectReferences { get; }
     public ImmutableArray<MetadataReference> MetadataReferences { get; }
-    public string? OutputFilePath { get; internal set; }
+    public CompilationOptions? CompilationOptions { get; }
+    public string? AssemblyName { get; }
     public ParseOptions? ParseOptions { get; internal set; }
     public string? DefaultNamespace { get; internal set; }
     public string? FilePath { get; }
     public string? TargetFramework { get; }
 
     public ProjectInfo WithDocuments(IEnumerable<DocumentInfo> docs) =>
-        new(Attributes, docs, ProjectReferences, MetadataReferences, FilePath, TargetFramework);
+        new(Attributes, docs, ProjectReferences, MetadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
     public ProjectInfo WithVersion(VersionStamp version)
     {
@@ -45,14 +50,14 @@ public sealed class ProjectInfo
         {
             Version = version
         };
-        return new ProjectInfo(newAttributes, Documents, ProjectReferences, MetadataReferences, FilePath, TargetFramework);
+        return new ProjectInfo(newAttributes, Documents, ProjectReferences, MetadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
     }
 
     public ProjectInfo WithProjectReferences(IEnumerable<ProjectReference> projectReferences) =>
-        new(Attributes, Documents, projectReferences, MetadataReferences, FilePath, TargetFramework);
+        new(Attributes, Documents, projectReferences, MetadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
     public ProjectInfo WithMetadataReferences(IEnumerable<MetadataReference> metadataReferences) =>
-        new(Attributes, Documents, ProjectReferences, metadataReferences, FilePath, TargetFramework);
+        new(Attributes, Documents, ProjectReferences, metadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
     public sealed record ProjectAttributes(ProjectId Id, string Name, VersionStamp Version);
 }

--- a/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
@@ -9,12 +9,16 @@ public sealed class ProjectInfo
         ProjectAttributes attributes,
         IEnumerable<DocumentInfo> documents,
         IEnumerable<ProjectReference>? projectReferences = null,
-        IEnumerable<MetadataReference>? metadataReferences = null)
+        IEnumerable<MetadataReference>? metadataReferences = null,
+        string? filePath = null,
+        string? targetFramework = null)
     {
         Attributes = attributes;
         Documents = documents.ToImmutableArray();
         ProjectReferences = projectReferences?.ToImmutableArray() ?? ImmutableArray<ProjectReference>.Empty;
         MetadataReferences = metadataReferences?.ToImmutableArray() ?? ImmutableArray<MetadataReference>.Empty;
+        FilePath = filePath;
+        TargetFramework = targetFramework;
     }
 
     public ProjectAttributes Attributes { get; }
@@ -29,9 +33,11 @@ public sealed class ProjectInfo
     public string? OutputFilePath { get; internal set; }
     public ParseOptions? ParseOptions { get; internal set; }
     public string? DefaultNamespace { get; internal set; }
+    public string? FilePath { get; }
+    public string? TargetFramework { get; }
 
     public ProjectInfo WithDocuments(IEnumerable<DocumentInfo> docs) =>
-        new(Attributes, docs, ProjectReferences, MetadataReferences);
+        new(Attributes, docs, ProjectReferences, MetadataReferences, FilePath, TargetFramework);
 
     public ProjectInfo WithVersion(VersionStamp version)
     {
@@ -39,14 +45,14 @@ public sealed class ProjectInfo
         {
             Version = version
         };
-        return new ProjectInfo(newAttributes, Documents, ProjectReferences, MetadataReferences);
+        return new ProjectInfo(newAttributes, Documents, ProjectReferences, MetadataReferences, FilePath, TargetFramework);
     }
 
     public ProjectInfo WithProjectReferences(IEnumerable<ProjectReference> projectReferences) =>
-        new(Attributes, Documents, projectReferences, MetadataReferences);
+        new(Attributes, Documents, projectReferences, MetadataReferences, FilePath, TargetFramework);
 
     public ProjectInfo WithMetadataReferences(IEnumerable<MetadataReference> metadataReferences) =>
-        new(Attributes, Documents, ProjectReferences, metadataReferences);
+        new(Attributes, Documents, ProjectReferences, metadataReferences, FilePath, TargetFramework);
 
     public sealed record ProjectAttributes(ProjectId Id, string Name, VersionStamp Version);
 }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/AdhocWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/AdhocWorkspace.cs
@@ -5,7 +5,13 @@ namespace Raven.CodeAnalysis;
 /// </summary>
 public sealed class AdhocWorkspace : Workspace
 {
-    public AdhocWorkspace() : base("Adhoc")
+    public AdhocWorkspace()
+        : base("Adhoc")
+    {
+    }
+
+    public AdhocWorkspace(HostServices services)
+        : base("Adhoc", services)
     {
     }
 }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/AdhocWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/AdhocWorkspace.cs
@@ -1,3 +1,9 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Raven.CodeAnalysis.Text;
+
 namespace Raven.CodeAnalysis;
 
 /// <summary>
@@ -13,5 +19,80 @@ public sealed class AdhocWorkspace : Workspace
     public AdhocWorkspace(HostServices services)
         : base("Adhoc", services)
     {
+    }
+
+    /// <summary>
+    /// Opens a single document from <paramref name="filePath"/> into the workspace.
+    /// If a single project already exists, the document is added to it; otherwise a new
+    /// project is created.
+    /// </summary>
+    public DocumentId OpenDocument(string filePath, string? projectName = null)
+    {
+        if (filePath is null) throw new ArgumentNullException(nameof(filePath));
+
+        var text = SourceText.From(File.ReadAllText(filePath));
+        var name = Path.GetFileName(filePath);
+
+        var solution = CurrentSolution;
+        ProjectId projectId;
+
+        if (projectName is not null)
+        {
+            var existing = solution.Projects.FirstOrDefault(p => p.Name == projectName);
+            if (existing is null)
+            {
+                projectId = ProjectId.CreateNew(solution.Id);
+                solution = solution.AddProject(projectId, projectName);
+            }
+            else
+            {
+                projectId = existing.Id;
+            }
+        }
+        else if (solution.Projects.Count() == 1)
+        {
+            projectId = solution.Projects.First().Id;
+        }
+        else
+        {
+            projectName = "Adhoc";
+            projectId = ProjectId.CreateNew(solution.Id);
+            solution = solution.AddProject(projectId, projectName);
+        }
+
+        var docId = DocumentId.CreateNew(projectId);
+        solution = solution.AddDocument(docId, name, text, filePath);
+        TryApplyChanges(solution);
+        return docId;
+    }
+
+    /// <summary>
+    /// Opens all <c>.rav</c> and <c>.rvn</c> files from <paramref name="folderPath"/>
+    /// into a new project.
+    /// </summary>
+    public ProjectId OpenFolder(string folderPath, string? projectName = null)
+    {
+        if (folderPath is null) throw new ArgumentNullException(nameof(folderPath));
+        if (!Directory.Exists(folderPath))
+            throw new DirectoryNotFoundException(folderPath);
+
+        var rav = Directory.EnumerateFiles(folderPath, "*.rav");
+        var rvn = Directory.EnumerateFiles(folderPath, "*.rvn");
+        var files = rav.Concat(rvn);
+
+        projectName ??= Path.GetFileName(folderPath);
+        var solution = CurrentSolution;
+        var projectId = ProjectId.CreateNew(solution.Id);
+        solution = solution.AddProject(projectId, projectName);
+
+        foreach (var file in files)
+        {
+            var text = SourceText.From(File.ReadAllText(file));
+            var docId = DocumentId.CreateNew(projectId);
+            solution = solution.AddDocument(docId, Path.GetFileName(file), text, file);
+        }
+
+        TryApplyChanges(solution);
+        return projectId;
     }
 }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/AdhocWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/AdhocWorkspace.cs
@@ -76,9 +76,7 @@ public sealed class AdhocWorkspace : Workspace
         if (!Directory.Exists(folderPath))
             throw new DirectoryNotFoundException(folderPath);
 
-        var rav = Directory.EnumerateFiles(folderPath, "*.rav");
-        var rvn = Directory.EnumerateFiles(folderPath, "*.rvn");
-        var files = rav.Concat(rvn);
+        var files = RavenFileExtensions.All.SelectMany(ext => Directory.EnumerateFiles(folderPath, $"*{ext}"));
 
         projectName ??= Path.GetFileName(folderPath);
         var solution = CurrentSolution;

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/HostServices.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/HostServices.cs
@@ -7,13 +7,19 @@ namespace Raven.CodeAnalysis;
 /// </summary>
 public class HostServices
 {
-    public HostServices(SyntaxTreeProvider syntaxTreeProvider)
+    public HostServices(
+        SyntaxTreeProvider syntaxTreeProvider,
+        PersistenceService? persistenceService = null)
     {
         SyntaxTreeProvider = syntaxTreeProvider ?? throw new ArgumentNullException(nameof(syntaxTreeProvider));
+        PersistenceService = persistenceService;
     }
 
     /// <summary>The <see cref="SyntaxTreeProvider"/> used to parse documents.</summary>
     public SyntaxTreeProvider SyntaxTreeProvider { get; }
+
+    /// <summary>The <see cref="PersistenceService"/> used to save and open workspaces.</summary>
+    public PersistenceService? PersistenceService { get; }
 
     /// <summary>Gets a default instance of <see cref="HostServices"/>.</summary>
     public static HostServices Default { get; } = new HostServices(new SyntaxTreeProvider());

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
@@ -37,6 +37,12 @@ public sealed class Project
     /// <summary>The current version of the project.</summary>
     public VersionStamp Version => _info.Version;
 
+    /// <summary>The path to the project file on disk.</summary>
+    public string? FilePath => _info.FilePath;
+
+    /// <summary>The target framework for this project, if any.</summary>
+    public string? TargetFramework => _info.TargetFramework;
+
     /// <summary>All documents in the project.</summary>
     public IEnumerable<Document> Documents => _documentInfos.Values.Select(info => GetDocument(info.Id)!);
 
@@ -67,22 +73,22 @@ public sealed class Project
     /// added document. To update a <see cref="Workspace"/>, apply the returned document's
     /// solution via <c>workspace.TryApplyChanges(document.Project.Solution)</c>.
     /// </remarks>
-    public Document AddDocument(DocumentId id, string name, SourceText text)
+    public Document AddDocument(DocumentId id, string name, SourceText text, string? filePath = null)
     {
         if (id.ProjectId != Id)
             throw new ArgumentException("DocumentId must belong to this project", nameof(id));
 
-        var newSolution = _solution.AddDocument(id, name, text);
+        var newSolution = _solution.AddDocument(id, name, text, filePath);
         return newSolution.GetDocument(id)!;
     }
 
     /// <summary>
     /// Adds a new document with an automatically generated identifier.
     /// </summary>
-    public Document AddDocument(string name, SourceText text)
+    public Document AddDocument(string name, SourceText text, string? filePath = null)
     {
         var id = DocumentId.CreateNew(Id);
-        return AddDocument(id, name, text);
+        return AddDocument(id, name, text, filePath);
     }
 
     /// <summary>

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
@@ -105,6 +105,15 @@ public sealed class Project
         return Solution.AddMetadataReference(Id, metadataReference).GetProject(Id);
     }
 
+    /// <summary>
+    /// Creates a new project with the specified <see cref="CompilationOptions"/>.
+    /// </summary>
+    public Project WithCompilationOptions(CompilationOptions? options)
+    {
+        var newSolution = Solution.WithCompilationOptions(Id, options);
+        return newSolution.GetProject(Id)!;
+    }
+
     internal Project AddDocument(DocumentInfo info)
     {
         var newInfos = _documentInfos.Add(info.Id, info);

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
@@ -43,6 +43,12 @@ public sealed class Project
     /// <summary>The target framework for this project, if any.</summary>
     public string? TargetFramework => _info.TargetFramework;
 
+    /// <summary>The compilation options for this project.</summary>
+    public CompilationOptions? CompilationOptions => _info.CompilationOptions;
+
+    /// <summary>The explicit assembly name for this project, if any.</summary>
+    public string? AssemblyName => _info.AssemblyName;
+
     /// <summary>All documents in the project.</summary>
     public IEnumerable<Document> Documents => _documentInfos.Values.Select(info => GetDocument(info.Id)!);
 

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 
 namespace Raven.CodeAnalysis;
@@ -9,11 +10,15 @@ namespace Raven.CodeAnalysis;
 /// </summary>
 public sealed class RavenWorkspace : Workspace
 {
+    private readonly string _sdkVersion;
+    private readonly string _defaultTargetFramework;
     private readonly MetadataReference[] _frameworkReferences;
 
-    private RavenWorkspace(MetadataReference[] frameworkReferences)
+    private RavenWorkspace(string sdkVersion, string defaultTargetFramework, MetadataReference[] frameworkReferences)
         : base("Raven")
     {
+        _sdkVersion = sdkVersion;
+        _defaultTargetFramework = defaultTargetFramework;
         _frameworkReferences = frameworkReferences;
     }
 
@@ -23,33 +28,66 @@ public sealed class RavenWorkspace : Workspace
     /// </summary>
     public static RavenWorkspace Create(string sdkVersion = "9.0.*", string targetFramework = "net9.0")
     {
+        var refs = GetFrameworkReferencesCore(sdkVersion, targetFramework);
+        return new RavenWorkspace(sdkVersion, targetFramework, refs);
+    }
+
+    internal string DefaultTargetFramework => _defaultTargetFramework;
+
+    internal MetadataReference[] GetFrameworkReferences(string targetFramework)
+        => GetFrameworkReferencesCore(_sdkVersion, targetFramework);
+
+    private static MetadataReference[] GetFrameworkReferencesCore(string sdkVersion, string targetFramework)
+    {
         var paths = ReferenceAssemblyPaths.GetReferenceAssemblyPaths(sdkVersion, targetFramework);
-        MetadataReference[] refs;
         if (paths.Length == 0)
         {
-            // fall back to the current runtime if reference assemblies are missing
-            refs = new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) };
+            return new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) };
         }
-        else
-        {
-            refs = paths
-                .Where(p => System.IO.File.Exists(p))
-                .Select(MetadataReference.CreateFromFile)
-                .ToArray();
-        }
-        return new RavenWorkspace(refs);
+
+        return paths
+            .Where(p => File.Exists(p))
+            .Select(MetadataReference.CreateFromFile)
+            .ToArray();
     }
 
     /// <summary>
     /// Adds a new project to the workspace preloaded with framework references.
     /// </summary>
-    public ProjectId AddProject(string name)
+    public ProjectId AddProject(string name, string? targetFramework = null, string? filePath = null)
     {
+        var tfm = targetFramework ?? _defaultTargetFramework;
         var solution = CurrentSolution;
         var projectId = ProjectId.CreateNew(solution.Id);
-        solution = solution.AddProject(projectId, name);
-        foreach (var reference in _frameworkReferences)
+        solution = solution.AddProject(projectId, name, filePath, tfm);
+        var references = tfm == _defaultTargetFramework ? _frameworkReferences : GetFrameworkReferences(tfm);
+        foreach (var reference in references)
             solution = solution.AddMetadataReference(projectId, reference);
+        TryApplyChanges(solution);
+        return projectId;
+    }
+
+    public void OpenSolution(string filePath)
+    {
+        var solution = SolutionFile.Open(filePath, this);
+        base.OpenSolution(solution);
+    }
+
+    public void SaveSolution(string filePath)
+    {
+        SolutionFile.Save(CurrentSolution, filePath);
+    }
+
+    public ProjectId OpenProject(string projectFilePath)
+    {
+        var projInfo = ProjectFile.Load(projectFilePath);
+        var projectId = AddProject(projInfo.Name, projInfo.TargetFramework, projectFilePath);
+        var solution = CurrentSolution;
+        foreach (var doc in projInfo.Documents)
+        {
+            var docId = DocumentId.CreateNew(projectId);
+            solution = solution.AddDocument(docId, doc.Name, doc.Text, doc.FilePath);
+        }
         TryApplyChanges(solution);
         return projectId;
     }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
@@ -15,7 +15,7 @@ public sealed class RavenWorkspace : Workspace
     private readonly MetadataReference[] _frameworkReferences;
 
     private RavenWorkspace(string sdkVersion, string defaultTargetFramework, MetadataReference[] frameworkReferences)
-        : base("Raven")
+        : base("Raven", new HostServices(new SyntaxTreeProvider(), new PersistenceService()))
     {
         _sdkVersion = sdkVersion;
         _defaultTargetFramework = defaultTargetFramework;
@@ -67,28 +67,4 @@ public sealed class RavenWorkspace : Workspace
         return projectId;
     }
 
-    public void OpenSolution(string filePath)
-    {
-        var solution = SolutionFile.Open(filePath, this);
-        base.OpenSolution(solution);
-    }
-
-    public void SaveSolution(string filePath)
-    {
-        SolutionFile.Save(CurrentSolution, filePath);
-    }
-
-    public ProjectId OpenProject(string projectFilePath)
-    {
-        var projInfo = ProjectFile.Load(projectFilePath);
-        var projectId = AddProject(projInfo.Name, projInfo.TargetFramework, projectFilePath);
-        var solution = CurrentSolution;
-        foreach (var doc in projInfo.Documents)
-        {
-            var docId = DocumentId.CreateNew(projectId);
-            solution = solution.AddDocument(docId, doc.Name, doc.Text, doc.FilePath);
-        }
-        TryApplyChanges(solution);
-        return projectId;
-    }
 }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
@@ -54,12 +54,12 @@ public sealed class RavenWorkspace : Workspace
     /// <summary>
     /// Adds a new project to the workspace preloaded with framework references.
     /// </summary>
-    public ProjectId AddProject(string name, string? targetFramework = null, string? filePath = null)
+    public ProjectId AddProject(string name, string? targetFramework = null, string? filePath = null, string? assemblyName = null, CompilationOptions? compilationOptions = null)
     {
         var tfm = targetFramework ?? _defaultTargetFramework;
         var solution = CurrentSolution;
         var projectId = ProjectId.CreateNew(solution.Id);
-        solution = solution.AddProject(projectId, name, filePath, tfm);
+        solution = solution.AddProject(projectId, name, filePath, tfm, assemblyName, compilationOptions);
         var references = tfm == _defaultTargetFramework ? _frameworkReferences : GetFrameworkReferences(tfm);
         foreach (var reference in references)
             solution = solution.AddMetadataReference(projectId, reference);

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspaceExtensions.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspaceExtensions.cs
@@ -13,7 +13,7 @@ public static class RavenWorkspaceExtensions
         var raven = RavenWorkspace.Create(sdkVersion, targetFramework);
         foreach (var project in workspace.CurrentSolution.Projects)
         {
-            var projectId = raven.AddProject(project.Name, project.TargetFramework, project.FilePath);
+            var projectId = raven.AddProject(project.Name, project.TargetFramework, project.FilePath, project.AssemblyName, project.CompilationOptions);
             var solution = raven.CurrentSolution;
             foreach (var reference in project.MetadataReferences)
                 solution = solution.AddMetadataReference(projectId, reference);

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspaceExtensions.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspaceExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// Extensions for converting workspaces to <see cref="RavenWorkspace"/>.
+/// </summary>
+public static class RavenWorkspaceExtensions
+{
+    public static RavenWorkspace ToRavenWorkspace(this AdhocWorkspace workspace, string sdkVersion = "9.0.*", string targetFramework = "net9.0")
+    {
+        if (workspace is null) throw new ArgumentNullException(nameof(workspace));
+        var raven = RavenWorkspace.Create(sdkVersion, targetFramework);
+        foreach (var project in workspace.CurrentSolution.Projects)
+        {
+            var projectId = raven.AddProject(project.Name, project.TargetFramework, project.FilePath);
+            var solution = raven.CurrentSolution;
+            foreach (var reference in project.MetadataReferences)
+                solution = solution.AddMetadataReference(projectId, reference);
+            foreach (var doc in project.Documents)
+            {
+                var docId = DocumentId.CreateNew(projectId);
+                solution = solution.AddDocument(docId, doc.Name, doc.Text, doc.FilePath);
+            }
+            raven.TryApplyChanges(solution);
+        }
+        return raven;
+    }
+}
+

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
@@ -165,4 +165,15 @@ public sealed class Solution
         var newInfo = _info.WithProjects(newProjInfos.Values).WithVersion(_info.Version.GetNewerVersion());
         return new Solution(newInfo, Services, Workspace, ImmutableDictionary<ProjectId, Project>.Empty);
     }
+
+    public Solution WithCompilationOptions(ProjectId projectId, CompilationOptions? compilationOptions)
+    {
+        if (!_projectInfos.TryGetValue(projectId, out var projInfo))
+            throw new InvalidOperationException("Project not found");
+
+        projInfo = projInfo.WithCompilationOptions(compilationOptions).WithVersion(projInfo.Version.GetNewerVersion());
+        var newProjInfos = _projectInfos.SetItem(projectId, projInfo);
+        var newInfo = _info.WithProjects(newProjInfos.Values).WithVersion(_info.Version.GetNewerVersion());
+        return new Solution(newInfo, Services, Workspace, ImmutableDictionary<ProjectId, Project>.Empty);
+    }
 }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
@@ -53,18 +53,18 @@ public sealed class Solution
     public Document? GetDocument(DocumentId id) => GetProject(id.ProjectId)?.GetDocument(id);
 
     /// <summary>Adds a new project with the specified name.</summary>
-    public Solution AddProject(string name, string? filePath = null, string? targetFramework = null)
+    public Solution AddProject(string name, string? filePath = null, string? targetFramework = null, string? assemblyName = null, CompilationOptions? compilationOptions = null)
     {
         var projectId = ProjectId.CreateNew(Id);
-        return AddProject(projectId, name, filePath, targetFramework);
+        return AddProject(projectId, name, filePath, targetFramework, assemblyName, compilationOptions);
     }
 
     /// <summary>Adds a new project with the specified id and name.</summary>
-    public Solution AddProject(ProjectId id, string name, string? filePath = null, string? targetFramework = null)
+    public Solution AddProject(ProjectId id, string name, string? filePath = null, string? targetFramework = null, string? assemblyName = null, CompilationOptions? compilationOptions = null)
     {
         if (_projectInfos.ContainsKey(id)) return this;
         var projAttr = new ProjectInfo.ProjectAttributes(id, name, VersionStamp.Create());
-        var projInfo = new ProjectInfo(projAttr, Array.Empty<DocumentInfo>(), filePath: filePath, targetFramework: targetFramework);
+        var projInfo = new ProjectInfo(projAttr, Array.Empty<DocumentInfo>(), filePath: filePath, targetFramework: targetFramework, compilationOptions: compilationOptions, assemblyName: assemblyName);
         var newInfos = _projectInfos.Add(id, projInfo);
         var newInfo = _info.WithProjects(newInfos.Values).WithVersion(_info.Version.GetNewerVersion());
         return new Solution(newInfo, Services, Workspace, ImmutableDictionary<ProjectId, Project>.Empty);

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
@@ -53,29 +53,29 @@ public sealed class Solution
     public Document? GetDocument(DocumentId id) => GetProject(id.ProjectId)?.GetDocument(id);
 
     /// <summary>Adds a new project with the specified name.</summary>
-    public Solution AddProject(string name)
+    public Solution AddProject(string name, string? filePath = null, string? targetFramework = null)
     {
         var projectId = ProjectId.CreateNew(Id);
-        return AddProject(projectId, name);
+        return AddProject(projectId, name, filePath, targetFramework);
     }
 
     /// <summary>Adds a new project with the specified id and name.</summary>
-    public Solution AddProject(ProjectId id, string name)
+    public Solution AddProject(ProjectId id, string name, string? filePath = null, string? targetFramework = null)
     {
         if (_projectInfos.ContainsKey(id)) return this;
         var projAttr = new ProjectInfo.ProjectAttributes(id, name, VersionStamp.Create());
-        var projInfo = new ProjectInfo(projAttr, Array.Empty<DocumentInfo>());
+        var projInfo = new ProjectInfo(projAttr, Array.Empty<DocumentInfo>(), filePath: filePath, targetFramework: targetFramework);
         var newInfos = _projectInfos.Add(id, projInfo);
         var newInfo = _info.WithProjects(newInfos.Values).WithVersion(_info.Version.GetNewerVersion());
         return new Solution(newInfo, Services, Workspace, ImmutableDictionary<ProjectId, Project>.Empty);
     }
 
     /// <summary>Adds a new document to the specified project.</summary>
-    public Solution AddDocument(DocumentId id, string name, SourceText text)
+    public Solution AddDocument(DocumentId id, string name, SourceText text, string? filePath = null)
     {
         if (!_projectInfos.TryGetValue(id.ProjectId, out var projInfo))
             throw new InvalidOperationException("Project not found");
-        var docInfo = DocumentInfo.Create(id, name, text);
+        var docInfo = DocumentInfo.Create(id, name, text, filePath);
         projInfo = projInfo.WithDocuments(projInfo.Documents.Add(docInfo)).WithVersion(projInfo.Version.GetNewerVersion());
         var newProjInfos = _projectInfos.SetItem(id.ProjectId, projInfo);
         var newInfo = _info.WithProjects(newProjInfos.Values).WithVersion(_info.Version.GetNewerVersion());

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/SyntaxTreeProvider.cs
@@ -12,11 +12,7 @@ namespace Raven.CodeAnalysis;
 /// </summary>
 public class SyntaxTreeProvider
 {
-    private static readonly HashSet<string> s_sourceExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".rvn",
-        ".rav"
-    };
+    private static readonly HashSet<string> s_sourceExtensions = new(RavenFileExtensions.All, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Determines whether the specified document supports a syntax tree.</summary>
     public virtual bool SupportsSyntaxTree(string name, string? filePath = null)

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
@@ -184,7 +184,8 @@ public class Workspace
             references.Add(compRef);
         }
 
-        var compilation = Compilation.Create(project.Name, syntaxTrees.ToArray(), references.ToArray());
+        var compilation = Compilation.Create(project.AssemblyName ?? project.Name,
+            syntaxTrees.ToArray(), references.ToArray(), project.CompilationOptions);
 
         state.Version = project.Version;
         state.Compilation = compilation;

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
@@ -91,8 +91,18 @@ public class Workspace
                     if (oldDoc.Version != doc.Version)
                         return (WorkspaceChangeKind.DocumentChanged, proj.Id, doc.Id);
                 }
+                foreach (var oldDoc in oldProj.Documents)
+                {
+                    if (proj.GetDocument(oldDoc.Id) is null)
+                        return (WorkspaceChangeKind.DocumentRemoved, proj.Id, oldDoc.Id);
+                }
                 return (WorkspaceChangeKind.ProjectChanged, proj.Id, null);
             }
+        }
+        foreach (var oldProj in oldSolution.Projects)
+        {
+            if (newSolution.GetProject(oldProj.Id) is null)
+                return (WorkspaceChangeKind.ProjectRemoved, oldProj.Id, null);
         }
         return (WorkspaceChangeKind.SolutionChanged, null, null);
     }

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceExtensions.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceExtensions.cs
@@ -46,5 +46,14 @@ public static class PersistenceExtensions
         Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
         File.WriteAllText(filePath, document.Text.ToString());
     }
+
+    public static IDisposable EnableFileWatching(this Workspace workspace)
+    {
+        var service = workspace.Services.PersistenceService
+            ?? throw new NotSupportedException("Persistence service is not available.");
+        if (workspace is not RavenWorkspace raven)
+            throw new NotSupportedException("File watching requires a RavenWorkspace.");
+        return service.EnableFileWatching(raven);
+    }
 }
 

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceExtensions.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceExtensions.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// Extension methods for saving and opening solutions, projects, and documents.
+/// </summary>
+public static class PersistenceExtensions
+{
+    public static void OpenSolution(this Workspace workspace, string filePath)
+    {
+        var service = workspace.Services.PersistenceService
+            ?? throw new NotSupportedException("Persistence service is not available.");
+        var solution = service.OpenSolution(filePath, workspace);
+        workspace.OpenSolution(solution);
+    }
+
+    public static void SaveSolution(this Workspace workspace, string filePath)
+    {
+        var service = workspace.Services.PersistenceService
+            ?? throw new NotSupportedException("Persistence service is not available.");
+        service.SaveSolution(workspace.CurrentSolution, filePath);
+    }
+
+    public static ProjectId OpenProject(this Workspace workspace, string projectFilePath)
+    {
+        var service = workspace.Services.PersistenceService
+            ?? throw new NotSupportedException("Persistence service is not available.");
+        return service.OpenProject(workspace, projectFilePath);
+    }
+
+    public static void SaveProject(this Workspace workspace, ProjectId projectId, string filePath)
+    {
+        var service = workspace.Services.PersistenceService
+            ?? throw new NotSupportedException("Persistence service is not available.");
+        var project = workspace.CurrentSolution.GetProject(projectId)
+            ?? throw new ArgumentException("Project not found", nameof(projectId));
+        service.SaveProject(project, filePath);
+    }
+
+    public static void SaveDocument(this Document document, string filePath)
+    {
+        if (document is null) throw new ArgumentNullException(nameof(document));
+        if (filePath is null) throw new ArgumentNullException(nameof(filePath));
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        File.WriteAllText(filePath, document.Text.ToString());
+    }
+}
+

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceService.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceService.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>
+/// Provides solution and project persistence for workspaces.
+/// </summary>
+public class PersistenceService
+{
+    public virtual Solution OpenSolution(string filePath, Workspace workspace)
+    {
+        if (workspace is RavenWorkspace raven)
+            return SolutionFile.Open(filePath, raven);
+        throw new NotSupportedException("Solution persistence requires a RavenWorkspace.");
+    }
+
+    public virtual void SaveSolution(Solution solution, string filePath)
+        => SolutionFile.Save(solution, filePath);
+
+    public virtual ProjectId OpenProject(Workspace workspace, string projectFilePath)
+    {
+        if (workspace is not RavenWorkspace raven)
+            throw new NotSupportedException("Project persistence requires a RavenWorkspace.");
+        var projInfo = ProjectFile.Load(projectFilePath);
+        var projectId = raven.AddProject(projInfo.Name, projInfo.TargetFramework, projectFilePath);
+        var solution = workspace.CurrentSolution;
+        foreach (var doc in projInfo.Documents)
+        {
+            var docId = DocumentId.CreateNew(projectId);
+            solution = solution.AddDocument(docId, doc.Name, doc.Text, doc.FilePath);
+        }
+        workspace.TryApplyChanges(solution);
+        return projectId;
+    }
+
+    public virtual void SaveProject(Project project, string filePath)
+        => ProjectFile.Save(project, filePath);
+}
+

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceService.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceService.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Raven.CodeAnalysis.Text;
 
 namespace Raven.CodeAnalysis;
 
@@ -35,5 +40,124 @@ public class PersistenceService
 
     public virtual void SaveProject(Project project, string filePath)
         => ProjectFile.Save(project, filePath);
+
+    /// <summary>
+    /// Enables file system watching for project documents. Caller is responsible
+    /// for disposing the returned handle to stop watching.
+    /// </summary>
+    public virtual IDisposable EnableFileWatching(RavenWorkspace workspace)
+    {
+        if (workspace is null) throw new ArgumentNullException(nameof(workspace));
+        return new FileWatcher(workspace);
+    }
+
+    private sealed class FileWatcher : IDisposable
+    {
+        private readonly RavenWorkspace _workspace;
+        private readonly Dictionary<ProjectId, FileSystemWatcher> _watchers = new();
+
+        public FileWatcher(RavenWorkspace workspace)
+        {
+            _workspace = workspace;
+            foreach (var project in workspace.CurrentSolution.Projects)
+                WatchProject(project);
+            _workspace.WorkspaceChanged += OnWorkspaceChanged;
+        }
+
+        private static bool IsSource(string path) =>
+            path.EndsWith(".rav", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".rvn", StringComparison.OrdinalIgnoreCase);
+
+        private void WatchProject(Project project)
+        {
+            var path = project.FilePath;
+            if (string.IsNullOrEmpty(path))
+                return;
+            var dir = Path.GetDirectoryName(path)!;
+            var watcher = new FileSystemWatcher(dir)
+            {
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                IncludeSubdirectories = true,
+                EnableRaisingEvents = true,
+                Filter = "*.*"
+            };
+            watcher.Created += (s, e) => OnChanged(project.Id, e);
+            watcher.Changed += (s, e) => OnChanged(project.Id, e);
+            watcher.Deleted += (s, e) => OnDeleted(project.Id, e);
+            watcher.Renamed += (s, e) => OnRenamed(project.Id, e);
+            _watchers[project.Id] = watcher;
+        }
+
+        private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
+        {
+            if (e.Kind == WorkspaceChangeKind.ProjectAdded && e.ProjectId is { } pid)
+            {
+                var project = _workspace.CurrentSolution.GetProject(pid);
+                if (project is not null)
+                    WatchProject(project);
+            }
+            else if (e.Kind == WorkspaceChangeKind.ProjectRemoved && e.ProjectId is { } rid)
+            {
+                if (_watchers.Remove(rid, out var watcher))
+                    watcher.Dispose();
+            }
+        }
+
+        private void OnChanged(ProjectId projectId, FileSystemEventArgs e)
+        {
+            if (!IsSource(e.FullPath))
+                return;
+            try
+            {
+                var solution = _workspace.CurrentSolution;
+                var project = solution.GetProject(projectId);
+                if (project is null)
+                    return;
+                var doc = project.Documents.FirstOrDefault(d => string.Equals(d.FilePath, e.FullPath, StringComparison.OrdinalIgnoreCase));
+                var text = SourceText.From(File.ReadAllText(e.FullPath));
+                if (doc is null)
+                {
+                    var docId = DocumentId.CreateNew(projectId);
+                    solution = solution.AddDocument(docId, Path.GetFileName(e.FullPath), text, e.FullPath);
+                }
+                else
+                {
+                    solution = solution.WithDocumentText(doc.Id, text);
+                }
+                _workspace.TryApplyChanges(solution);
+            }
+            catch
+            {
+                // ignore file read errors
+            }
+        }
+
+        private void OnDeleted(ProjectId projectId, FileSystemEventArgs e)
+        {
+            if (!IsSource(e.FullPath))
+                return;
+            var solution = _workspace.CurrentSolution;
+            var project = solution.GetProject(projectId);
+            var doc = project?.Documents.FirstOrDefault(d => string.Equals(d.FilePath, e.FullPath, StringComparison.OrdinalIgnoreCase));
+            if (doc is null)
+                return;
+            solution = solution.RemoveDocument(doc.Id);
+            _workspace.TryApplyChanges(solution);
+        }
+
+        private void OnRenamed(ProjectId projectId, RenamedEventArgs e)
+        {
+            OnDeleted(projectId, new FileSystemEventArgs(WatcherChangeTypes.Deleted, Path.GetDirectoryName(e.OldFullPath)!, Path.GetFileName(e.OldFullPath)));
+            OnChanged(projectId, new FileSystemEventArgs(WatcherChangeTypes.Created, Path.GetDirectoryName(e.FullPath)!, Path.GetFileName(e.FullPath)));
+        }
+
+        public void Dispose()
+        {
+            _workspace.WorkspaceChanged -= OnWorkspaceChanged;
+            foreach (var watcher in _watchers.Values)
+                watcher.Dispose();
+            _watchers.Clear();
+        }
+    }
 }
 

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceService.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/PersistenceService.cs
@@ -72,8 +72,7 @@ public class PersistenceService
         }
 
         private static bool IsSource(string path) =>
-            path.EndsWith(".rav", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".rvn", StringComparison.OrdinalIgnoreCase);
+            RavenFileExtensions.HasRavenExtension(path);
 
         private void WatchProject(Project project)
         {

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
@@ -24,7 +24,7 @@ internal static class ProjectFile
         {
             var path = document.FilePath;
             if (string.IsNullOrEmpty(path))
-                path = Path.Combine(dir, document.Name.EndsWith(".rav", StringComparison.OrdinalIgnoreCase) || document.Name.EndsWith(".rvn", StringComparison.OrdinalIgnoreCase) ? document.Name : document.Name + ".rav");
+                path = Path.Combine(dir, RavenFileExtensions.HasRavenExtension(document.Name) ? document.Name : document.Name + RavenFileExtensions.Raven);
             else if (!Path.IsPathRooted(path))
                 path = Path.Combine(dir, path);
 
@@ -81,9 +81,7 @@ internal static class ProjectFile
         }
         else
         {
-            var rav = Directory.EnumerateFiles(projectDir, "*.rav");
-            var rvn = Directory.EnumerateFiles(projectDir, "*.rvn");
-            paths = rav.Concat(rvn);
+            paths = RavenFileExtensions.All.SelectMany(ext => Directory.EnumerateFiles(projectDir, $"*{ext}"));
         }
 
         var documents = paths.Select(p =>

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Raven.CodeAnalysis.Text;
+
+namespace Raven.CodeAnalysis;
+
+internal static class ProjectFile
+{
+    public static void Save(Project project, string filePath)
+    {
+        if (project is null) throw new ArgumentNullException(nameof(project));
+
+        var dir = Path.GetDirectoryName(filePath)!;
+        Directory.CreateDirectory(dir);
+
+        foreach (var document in project.Documents)
+        {
+            var path = document.FilePath;
+            if (string.IsNullOrEmpty(path))
+                path = Path.Combine(dir, document.Name.EndsWith(".rav", StringComparison.OrdinalIgnoreCase) || document.Name.EndsWith(".rvn", StringComparison.OrdinalIgnoreCase) ? document.Name : document.Name + ".rav");
+            else if (!Path.IsPathRooted(path))
+                path = Path.Combine(dir, path);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, document.Text.ToString());
+        }
+
+        var projectElement = new XElement("Project",
+            new XAttribute("Name", project.Name),
+            project.TargetFramework is string tfm ? new XAttribute("TargetFramework", tfm) : null);
+
+        var doc = new XDocument(projectElement);
+        doc.Save(filePath);
+    }
+
+    public static ProjectInfo Load(string filePath)
+    {
+        var xdoc = XDocument.Load(filePath);
+        var root = xdoc.Root ?? throw new InvalidDataException("Invalid project file.");
+        var name = (string?)root.Attribute("Name") ?? Path.GetFileNameWithoutExtension(filePath);
+        var targetFramework = (string?)root.Attribute("TargetFramework");
+        var tempSolutionId = SolutionId.CreateNew();
+        var projectId = ProjectId.CreateNew(tempSolutionId);
+        var projectDir = Path.GetDirectoryName(filePath)!;
+
+        var docElements = root.Elements("Document").ToList();
+        IEnumerable<string> paths;
+        if (docElements.Count > 0)
+        {
+            paths = docElements.Select(e =>
+            {
+                var attr = (string?)e.Attribute("FilePath") ?? (string?)e.Attribute("Path");
+                if (attr is null)
+                    throw new InvalidDataException("Document path missing.");
+                return Path.IsPathRooted(attr) ? attr : Path.Combine(projectDir, attr);
+            });
+        }
+        else
+        {
+            var rav = Directory.EnumerateFiles(projectDir, "*.rav");
+            var rvn = Directory.EnumerateFiles(projectDir, "*.rvn");
+            paths = rav.Concat(rvn);
+        }
+
+        var documents = paths.Select(p =>
+        {
+            var docId = DocumentId.CreateNew(projectId);
+            var text = SourceText.From(File.ReadAllText(p));
+            return DocumentInfo.Create(docId, Path.GetFileName(p), text, p);
+        }).ToList();
+
+        var attrInfo = new ProjectInfo.ProjectAttributes(projectId, name, VersionStamp.Create());
+        return new ProjectInfo(attrInfo, documents, filePath: filePath, targetFramework: targetFramework);
+    }
+}

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/SolutionFile.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/SolutionFile.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -30,21 +31,34 @@ internal static class SolutionFile
         var xdoc = XDocument.Load(filePath);
         var root = xdoc.Root ?? throw new InvalidDataException("Invalid solution file.");
         var solution = new Solution(workspace.Services, workspace);
+        var loaded = new List<(ProjectId Id, ProjectFile.ProjectFileInfo Info, string Path)>();
         foreach (var projElem in root.Elements("Project"))
         {
             var rel = (string?)projElem.Attribute("Path") ?? throw new InvalidDataException("Project path missing.");
             var projPath = Path.Combine(dir, rel);
             var projInfo = ProjectFile.Load(projPath);
             var projId = ProjectId.CreateNew(solution.Id);
-            solution = solution.AddProject(projId, projInfo.Name, projPath, projInfo.TargetFramework);
-            foreach (var doc in projInfo.Documents)
+            solution = solution.AddProject(projId, projInfo.Info.Name, projPath, projInfo.Info.TargetFramework, projInfo.Info.AssemblyName, projInfo.Info.CompilationOptions);
+            foreach (var doc in projInfo.Info.Documents)
             {
                 var docId = DocumentId.CreateNew(projId);
                 solution = solution.AddDocument(docId, doc.Name, doc.Text, doc.FilePath);
             }
-            var tfm = projInfo.TargetFramework ?? workspace.DefaultTargetFramework;
+            var tfm = projInfo.Info.TargetFramework ?? workspace.DefaultTargetFramework;
             foreach (var reference in workspace.GetFrameworkReferences(tfm))
                 solution = solution.AddMetadataReference(projId, reference);
+            loaded.Add((projId, projInfo, projPath));
+        }
+
+        var pathMap = loaded.ToDictionary(x => x.Path, x => x.Id, StringComparer.OrdinalIgnoreCase);
+        foreach (var (id, info, projPath) in loaded)
+        {
+            foreach (var refPath in info.ProjectReferences)
+            {
+                var full = Path.IsPathRooted(refPath) ? refPath : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projPath)!, refPath));
+                if (pathMap.TryGetValue(full, out var refId))
+                    solution = solution.AddProjectReference(id, new ProjectReference(refId));
+            }
         }
         return solution;
     }

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/SolutionFile.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/SolutionFile.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Raven.CodeAnalysis;
+
+internal static class SolutionFile
+{
+    public static void Save(Solution solution, string filePath)
+    {
+        if (solution is null) throw new ArgumentNullException(nameof(solution));
+        var dir = Path.GetDirectoryName(filePath)!;
+        Directory.CreateDirectory(dir);
+        var projects = solution.Projects.Select(p =>
+        {
+            var projectPath = p.FilePath ?? Path.Combine(dir, $"{p.Name}.ravenproj");
+            ProjectFile.Save(p, projectPath);
+            var relative = Path.GetRelativePath(dir, projectPath);
+            return new XElement("Project", new XAttribute("Path", relative));
+        });
+        var doc = new XDocument(new XElement("Solution", projects));
+        doc.Save(filePath);
+    }
+
+    public static Solution Open(string filePath, RavenWorkspace workspace)
+    {
+        if (workspace is null) throw new ArgumentNullException(nameof(workspace));
+        var dir = Path.GetDirectoryName(filePath)!;
+        var xdoc = XDocument.Load(filePath);
+        var root = xdoc.Root ?? throw new InvalidDataException("Invalid solution file.");
+        var solution = new Solution(workspace.Services, workspace);
+        foreach (var projElem in root.Elements("Project"))
+        {
+            var rel = (string?)projElem.Attribute("Path") ?? throw new InvalidDataException("Project path missing.");
+            var projPath = Path.Combine(dir, rel);
+            var projInfo = ProjectFile.Load(projPath);
+            var projId = ProjectId.CreateNew(solution.Id);
+            solution = solution.AddProject(projId, projInfo.Name, projPath, projInfo.TargetFramework);
+            foreach (var doc in projInfo.Documents)
+            {
+                var docId = DocumentId.CreateNew(projId);
+                solution = solution.AddDocument(docId, doc.Name, doc.Text, doc.FilePath);
+            }
+            var tfm = projInfo.TargetFramework ?? workspace.DefaultTargetFramework;
+            foreach (var reference in workspace.GetFrameworkReferences(tfm))
+                solution = solution.AddMetadataReference(projId, reference);
+        }
+        return solution;
+    }
+}

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
@@ -6,8 +6,8 @@ using Raven.CodeAnalysis.Text;
 
 using Spectre.Console;
 
-using static Raven.ConsoleEx;
 using static Raven.AppHostBuilder;
+using static Raven.ConsoleEx;
 
 // ONLY FOR DEVELOPMENT
 bool debug = true;
@@ -21,7 +21,7 @@ var stopwatch = Stopwatch.StartNew();
 // -s - display the syntax tree
 // -d - dump syntax (highlighted)
 
-var filePath = args.Length > 0 ? args[0] : "../../../samples/classes.rav";
+var filePath = args.Length > 0 ? args[0] : $"../../../samples/classes{RavenFileExtensions.Raven}";
 var outputPath = args.Contains("-o") ? args[Array.IndexOf(args, "-o") + 1] : "test.dll"; //: null;
 
 var shouldPrintSyntaxTree = args.Contains("-s");

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/AdhocWorkspaceFileLoadingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/AdhocWorkspaceFileLoadingTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Raven.CodeAnalysis;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class AdhocWorkspaceFileLoadingTests
+{
+    [Fact]
+    public void OpenDocument_ShouldAddDocumentToProject()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "test.rvn");
+        File.WriteAllText(file, "x = 1");
+        try
+        {
+            var ws = new AdhocWorkspace();
+            var docId = ws.OpenDocument(file);
+            var doc = ws.CurrentSolution.GetDocument(docId);
+            Assert.NotNull(doc);
+            Assert.Equal(file, doc!.FilePath);
+            Assert.Equal("test.rvn", doc.Name);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void OpenDocument_MultipleCalls_ShouldReuseProject()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var file1 = Path.Combine(dir, "a.rav");
+        var file2 = Path.Combine(dir, "b.rvn");
+        File.WriteAllText(file1, "a");
+        File.WriteAllText(file2, "b");
+        try
+        {
+            var ws = new AdhocWorkspace();
+            ws.OpenDocument(file1);
+            ws.OpenDocument(file2);
+            var project = Assert.Single(ws.CurrentSolution.Projects);
+            Assert.Equal(2, project.Documents.Count());
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void OpenFolder_ShouldLoadRavAndRvnFiles()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "a.rav"), "a");
+        File.WriteAllText(Path.Combine(dir, "b.rvn"), "b");
+        try
+        {
+            var ws = new AdhocWorkspace();
+            var projectId = ws.OpenFolder(dir);
+            var project = ws.CurrentSolution.GetProject(projectId)!;
+            var names = project.Documents.Select(d => d.Name).ToArray();
+            Assert.Equal(2, names.Length);
+            Assert.Contains("a.rav", names);
+            Assert.Contains("b.rvn", names);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/PersistenceFileWatcherTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/PersistenceFileWatcherTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+using Raven.CodeAnalysis;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests.Workspaces;
+
+public class PersistenceFileWatcherTests
+{
+    [Fact]
+    public void WatcherTracksFileChanges()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var workspace = RavenWorkspace.Create();
+            var projectId = workspace.AddProject("Test", filePath: Path.Combine(dir, "Test.ravenproj"));
+            using var watcher = workspace.EnableFileWatching();
+
+            var file = Path.Combine(dir, "main.rav");
+            File.WriteAllText(file, "print 1");
+
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                var doc = workspace.CurrentSolution.GetProject(projectId)!
+                    .Documents.FirstOrDefault(d => d.FilePath == file);
+                return doc is not null && doc.Text.ToString() == "print 1";
+            }, TimeSpan.FromSeconds(2)));
+
+            File.WriteAllText(file, "print 2");
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                var doc = workspace.CurrentSolution.GetProject(projectId)!
+                    .Documents.FirstOrDefault(d => d.FilePath == file);
+                return doc is not null && doc.Text.ToString() == "print 2";
+            }, TimeSpan.FromSeconds(2)));
+
+            File.Delete(file);
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                return !workspace.CurrentSolution.GetProject(projectId)!
+                    .Documents.Any(d => d.FilePath == file);
+            }, TimeSpan.FromSeconds(2)));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/SolutionProjectPersistenceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/SolutionProjectPersistenceTests.cs
@@ -97,4 +97,18 @@ public class SolutionProjectPersistenceTests
         Assert.Single(proj.Documents);
         Assert.Equal("Program.rav", proj.Documents.Single().Name);
     }
+
+    [Fact]
+    public void Project_WithCompilationOptions_UpdatesSolution()
+    {
+        var ws = RavenWorkspace.Create();
+        var projectId = ws.AddProject("App");
+        var project = ws.CurrentSolution.GetProject(projectId)!;
+        var updated = project.WithCompilationOptions(new CompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        ws.TryApplyChanges(updated.Solution);
+        var result = ws.CurrentSolution.GetProject(projectId)!;
+        Assert.Equal(OutputKind.DynamicallyLinkedLibrary, result.CompilationOptions?.OutputKind);
+        var comp = ws.GetCompilation(projectId);
+        Assert.Equal(OutputKind.DynamicallyLinkedLibrary, comp.Options.OutputKind);
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/SolutionProjectPersistenceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/SolutionProjectPersistenceTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Text;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class SolutionProjectPersistenceTests
+{
+    [Fact]
+    public void SaveAndOpenSolution_RoundTripsProject()
+    {
+        var ws = RavenWorkspace.Create();
+        var projectId = ws.AddProject("App", targetFramework: "net9.0");
+        var project = ws.CurrentSolution.GetProject(projectId)!;
+        var document = project.AddDocument("Program.rav", SourceText.From("System.Console.WriteLine(\"Hi\");"), "Program.rav");
+        ws.TryApplyChanges(document.Project.Solution);
+
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var solutionPath = Path.Combine(dir, "App.ravensln");
+        ws.SaveSolution(solutionPath);
+
+        var programPath = Path.Combine(dir, "Program.rav");
+        Assert.True(File.Exists(programPath));
+        Assert.Contains("WriteLine", File.ReadAllText(programPath));
+
+        var ws2 = RavenWorkspace.Create();
+        ws2.OpenSolution(solutionPath);
+
+        var proj2 = ws2.CurrentSolution.Projects.Single();
+        Assert.Equal("App", proj2.Name);
+        Assert.Equal("net9.0", proj2.TargetFramework);
+        Assert.Single(proj2.Documents);
+        var doc2 = proj2.Documents.Single();
+        Assert.Equal("Program.rav", doc2.Name);
+        Assert.Equal(programPath, doc2.FilePath);
+        var text = doc2.GetTextAsync().Result.ToString();
+        Assert.Contains("WriteLine", text);
+        var comp = ws2.GetCompilation(proj2.Id);
+        Assert.NotEmpty(comp.References);
+    }
+}


### PR DESCRIPTION
## Summary
- add file path and target framework tracking to project metadata
- implement XML save/load for solutions and projects
- extend RavenWorkspace with project TFM support and open/save APIs
- write project documents to disk and auto-include .rav/.rvn files on load

## Testing
- `dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --include src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs --no-restore --verbosity diagnostic`
- `dotnet format test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --include test/Raven.CodeAnalysis.Tests/Workspaces/SolutionProjectPersistenceTests.cs --no-restore --verbosity diagnostic`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_WithIgnoredDiagnostics, Raven.CodeAnalysis.Syntax.Tests.SyntaxNodeTest.ReplaceNodeWithMultipleNodes; logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a66054166c832f9adc89ebf2a41b5b