### PR TITLE
refactor: decouple compiler from target framework

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -4,9 +4,9 @@ using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using System.Runtime.Versioning;
 
 using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis;
 
 namespace Raven.CodeAnalysis.CodeGen;
 
@@ -44,18 +44,12 @@ internal class CodeGenerator
 
     public void Emit(Stream peStream, Stream? pdbStream)
     {
-        var assemblyName = new AssemblyName(_compilation.AssemblyName);
-        assemblyName.Version = new Version(1, 0, 0, 0);
+        var assemblyName = new AssemblyName(_compilation.AssemblyName)
+        {
+            Version = new Version(1, 0, 0, 0)
+        };
 
-        var tfaProp = typeof(TargetFrameworkAttribute).GetProperty(nameof(TargetFrameworkAttribute.FrameworkDisplayName))!;
-        var targetFrameworkAttribute = new CustomAttributeBuilder(
-            // TODO: This should not be set here
-            typeof(TargetFrameworkAttribute).GetConstructor([typeof(string)]),
-            [".NETCoreApp,Version=v9.0"], [tfaProp],
-            [".NET 9.0"]
-        );
-
-        AssemblyBuilder = new PersistedAssemblyBuilder(assemblyName, _compilation.CoreAssembly, [targetFrameworkAttribute]);
+        AssemblyBuilder = new PersistedAssemblyBuilder(assemblyName, _compilation.CoreAssembly);
         ModuleBuilder = AssemblyBuilder.DefineDynamicModule(_compilation.AssemblyName);
 
         var globalNamespace = _compilation.SourceGlobalNamespace;
@@ -237,4 +231,5 @@ internal class CodeGenerator
         type = null!;
         return false;
     }
+
 }

--- a/src/Raven.CodeAnalysis/CompilationOptions.cs
+++ b/src/Raven.CodeAnalysis/CompilationOptions.cs
@@ -3,8 +3,8 @@ namespace Raven.CodeAnalysis;
 public class CompilationOptions
 {
     public CompilationOptions()
+        : this(OutputKind.ConsoleApplication)
     {
-        OutputKind = OutputKind.ConsoleApplication;
     }
 
     public CompilationOptions(OutputKind outputKind)

--- a/src/Raven.CodeAnalysis/TargetFrameworkMoniker.cs
+++ b/src/Raven.CodeAnalysis/TargetFrameworkMoniker.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+
+namespace Raven.CodeAnalysis;
+
+public static class TargetFrameworkMoniker
+{
+    public static string Resolve(string? tfmOrFull = null)
+    {
+        if (string.IsNullOrWhiteSpace(tfmOrFull))
+            return GetLatestFramework();
+
+        if (tfmOrFull.Contains(",Version="))
+        {
+            EnsureInstalled(ToTfm(tfmOrFull));
+            return tfmOrFull;
+        }
+
+        EnsureInstalled(tfmOrFull);
+        return ToFrameworkString(tfmOrFull);
+    }
+
+    public static string GetLatestFramework()
+    {
+        var dir = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        if (dir is null)
+            return ".NETCoreApp,Version=v9.0";
+
+        var tfm = Path.GetFileName(dir);
+        return ToFrameworkString(tfm!);
+    }
+
+    public static void EnsureInstalled(string tfm)
+    {
+        if (ReferenceAssemblyPaths.GetReferenceAssemblyDir(targetFramework: tfm) is null)
+            throw new InvalidOperationException($"The target framework '{tfm}' is not installed.");
+    }
+
+    public static string ToFrameworkString(string tfm)
+    {
+        if (tfm.Contains(",Version="))
+            return tfm;
+
+        if (tfm.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase))
+            return ".NETStandard,Version=v" + tfm["netstandard".Length..];
+
+        if (tfm.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase))
+            return ".NETCoreApp,Version=v" + tfm["netcoreapp".Length..];
+
+        if (tfm.StartsWith("net", StringComparison.OrdinalIgnoreCase))
+        {
+            var ver = tfm[3..];
+            if (ver.Length == 2 && char.IsDigit(ver[0]) && char.IsDigit(ver[1]))
+                return $".NETFramework,Version=v{ver[0]}.{ver[1]}";
+
+            return ".NETCoreApp,Version=v" + ver;
+        }
+
+        return tfm;
+    }
+
+    public static string ToTfm(string framework)
+    {
+        const string netCorePrefix = ".NETCoreApp,Version=v";
+        const string netStandardPrefix = ".NETStandard,Version=v";
+        const string netFrameworkPrefix = ".NETFramework,Version=v";
+
+        if (framework.StartsWith(netCorePrefix, StringComparison.Ordinal))
+            return "net" + framework[netCorePrefix.Length..];
+
+        if (framework.StartsWith(netStandardPrefix, StringComparison.Ordinal))
+            return "netstandard" + framework[netStandardPrefix.Length..];
+
+        if (framework.StartsWith(netFrameworkPrefix, StringComparison.Ordinal))
+            return "net" + framework[netFrameworkPrefix.Length..];
+
+        return framework;
+    }
+
+    public static string GetDisplayName(string framework)
+    {
+        const string netCorePrefix = ".NETCoreApp,Version=v";
+        const string netStandardPrefix = ".NETStandard,Version=v";
+        const string netFrameworkPrefix = ".NETFramework,Version=v";
+
+        if (framework.StartsWith(netCorePrefix, StringComparison.Ordinal))
+            return $".NET {framework[netCorePrefix.Length..]}";
+
+        if (framework.StartsWith(netStandardPrefix, StringComparison.Ordinal))
+            return $".NET Standard {framework[netStandardPrefix.Length..]}";
+
+        if (framework.StartsWith(netFrameworkPrefix, StringComparison.Ordinal))
+            return $".NET Framework {framework[netFrameworkPrefix.Length..]}";
+
+        return framework;
+    }
+}
+

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
@@ -57,9 +57,11 @@ public sealed class RavenWorkspace : Workspace
     public ProjectId AddProject(string name, string? targetFramework = null, string? filePath = null, string? assemblyName = null, CompilationOptions? compilationOptions = null)
     {
         var tfm = targetFramework ?? _defaultTargetFramework;
+        var options = compilationOptions ?? new CompilationOptions(OutputKind.ConsoleApplication);
+
         var solution = CurrentSolution;
         var projectId = ProjectId.CreateNew(solution.Id);
-        solution = solution.AddProject(projectId, name, filePath, tfm, assemblyName, compilationOptions);
+        solution = solution.AddProject(projectId, name, filePath, tfm, assemblyName, options);
         var references = tfm == _defaultTargetFramework ? _frameworkReferences : GetFrameworkReferences(tfm);
         foreach (var reference in references)
             solution = solution.AddMetadataReference(projectId, reference);

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs
@@ -171,7 +171,8 @@ public sealed class Solution
         if (!_projectInfos.TryGetValue(projectId, out var projInfo))
             throw new InvalidOperationException("Project not found");
 
-        projInfo = projInfo.WithCompilationOptions(compilationOptions).WithVersion(projInfo.Version.GetNewerVersion());
+        var attr = projInfo.Attributes with { Version = projInfo.Version.GetNewerVersion() };
+        projInfo = new ProjectInfo(attr, projInfo.Documents, projInfo.ProjectReferences, projInfo.MetadataReferences, projInfo.FilePath, projInfo.TargetFramework, compilationOptions, projInfo.AssemblyName);
         var newProjInfos = _projectInfos.SetItem(projectId, projInfo);
         var newInfo = _info.WithProjects(newProjInfos.Values).WithVersion(_info.Version.GetNewerVersion());
         return new Solution(newInfo, Services, Workspace, ImmutableDictionary<ProjectId, Project>.Empty);

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
@@ -32,9 +32,10 @@ internal static class ProjectFile
             File.WriteAllText(path, document.Text.ToString());
         }
 
+        var targetFramework = project.TargetFramework;
         var projectElement = new XElement("Project",
             new XAttribute("Name", project.Name),
-            project.TargetFramework is string tfm ? new XAttribute("TargetFramework", tfm) : null,
+            targetFramework is string tfm ? new XAttribute("TargetFramework", tfm) : null,
             project.AssemblyName is string asm ? new XAttribute("Output", asm) : null,
             project.CompilationOptions is { } opts ? new XAttribute("OutputKind", opts.OutputKind) : null);
 
@@ -63,6 +64,8 @@ internal static class ProjectFile
         CompilationOptions? options = null;
         if (outputKindAttr is string ok && Enum.TryParse<OutputKind>(ok, out var kind))
             options = new CompilationOptions(kind);
+        else
+            options = new CompilationOptions(OutputKind.ConsoleApplication);
         var tempSolutionId = SolutionId.CreateNew();
         var projectId = ProjectId.CreateNew(tempSolutionId);
         var projectDir = Path.GetDirectoryName(filePath)!;

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -49,9 +49,12 @@ var root = syntaxTree.GetRoot();
 
 var assemblyName = Path.GetFileNameWithoutExtension(filePath);
 
-var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir("9.*");
+var targetFramework = "net9.0";
+var tfm = TargetFrameworkMoniker.ToTfm(targetFramework);
+var options = new CompilationOptions(OutputKind.ConsoleApplication);
+var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir(targetFramework: tfm);
 
-var compilation = Compilation.Create(assemblyName, new CompilationOptions(OutputKind.ConsoleApplication))
+var compilation = Compilation.Create(assemblyName, options)
     .AddSyntaxTrees(syntaxTree)
     .AddReferences([
         MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
@@ -152,10 +155,10 @@ if (result is not null)
         {
             Succeeded(stopwatch.Elapsed);
         }
+
+        CreateAppHost(compilation, outputPath, targetFramework);
     }
 }
-
-//CreateAppHost(compilation);
 
 //Console.WriteLine(compilation.GlobalNamespace.ToSymbolHierarchyString());
 

--- a/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
@@ -52,19 +52,7 @@ public partial class SampleProgramsTests(ITestOutputHelper testOutput)
         if (File.Exists(testDep))
             File.Copy(testDep, Path.Combine(outputDir, "TestDep.dll"), overwrite: true);
 
-        var refDir = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
-        var version = new DirectoryInfo(Path.GetDirectoryName(Path.GetDirectoryName(refDir)!)!).Name;
-        File.WriteAllText(
-            Path.Combine(outputDir, Path.ChangeExtension(fileName, ".runtimeconfig.json")),
-            $@"{{
-  ""runtimeOptions"": {{
-    ""tfm"": ""net9.0"",
-    ""framework"": {{
-      ""name"": ""Microsoft.NETCore.App"",
-      ""version"": ""{version}""
-    }}
-  }}
-}}");
+        Assert.True(File.Exists(Path.Combine(outputDir, Path.ChangeExtension(fileName, ".runtimeconfig.json"))));
 
         var run = Process.Start(new ProcessStartInfo
         {

--- a/test/Raven.CodeAnalysis.Tests/TargetFrameworkMonikerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/TargetFrameworkMonikerTests.cs
@@ -1,0 +1,29 @@
+using Raven.CodeAnalysis;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class TargetFrameworkMonikerTests
+{
+    [Fact]
+    public void ToFrameworkString_converts_net_tfm()
+    {
+        var full = TargetFrameworkMoniker.ToFrameworkString("net9.0");
+        Assert.Equal(".NETCoreApp,Version=v9.0", full);
+    }
+
+    [Fact]
+    public void ToTfm_converts_full_string()
+    {
+        var tfm = TargetFrameworkMoniker.ToTfm(".NETCoreApp,Version=v9.0");
+        Assert.Equal("net9.0", tfm);
+    }
+
+    [Fact]
+    public void Resolve_defaults_to_installed()
+    {
+        var full = TargetFrameworkMoniker.Resolve();
+        Assert.False(string.IsNullOrWhiteSpace(full));
+    }
+}
+


### PR DESCRIPTION
## Summary
- remove target framework from `CompilationOptions`
- stop emitting `TargetFrameworkAttribute` during codegen
- handle runtime config target framework externally in CLI and workspace

## Testing
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompilationOptions.cs,src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs,src/Raven.Compiler/Program.cs,src/Raven.Compiler/AppHostBuilder.cs,src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs,src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs,src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs`
- `dotnet build`
- `dotnet test` *(fails: ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df0ec708832fb42b998e95eb9b21