### PR TITLE
refactor: consolidate reference path resolution

### DIFF
--- a/src/Raven.CodeAnalysis.Testing/DiagnosticTestBase.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticTestBase.cs
@@ -14,7 +14,7 @@ public abstract class DiagnosticTestBase
                 /*
                 State = new TestState
                 {
-                    ReferenceAssemblies = [.. ReferenceAssemblyPaths.GetReferenceAssemblyPaths().Select(x => MetadataReference.CreateFromFile(x))],
+                    ReferenceAssemblies = [.. TargetFrameworkResolver.GetReferenceAssemblyPaths().Select(x => MetadataReference.CreateFromFile(x))],
                 }
                 */
             }

--- a/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
@@ -241,6 +241,6 @@ public static class ReferenceAssemblies
 
     private static MetadataReference[] GeReferences()
     {
-        return ReferenceAssemblyPaths.GetReferenceAssemblyPaths().Select(path => MetadataReference.CreateFromFile(path)).ToArray();
+        return TargetFrameworkResolver.GetReferenceAssemblyPaths().Select(path => MetadataReference.CreateFromFile(path)).ToArray();
     }
 }

--- a/src/Raven.CodeAnalysis/TargetFrameworkResolver.cs
+++ b/src/Raven.CodeAnalysis/TargetFrameworkResolver.cs
@@ -56,4 +56,31 @@ public static class TargetFrameworkResolver
         // e.g., "net8.0" -> same; ".NETCoreApp,Version=v8.0" folder wouldn't normally appear here
         return folder;
     }
+
+    /// <summary>
+    /// Returns full paths to all reference assemblies for the resolved SDK version and target framework.
+    /// </summary>
+    public static string[] GetReferenceAssemblyPaths(string? sdkVersion = null, string? targetFramework = null, string packId = "Microsoft.NETCore.App.Ref")
+    {
+        var tfm = TargetFrameworkMoniker.Parse(Resolve(targetFramework)).ToTfm();
+        return ReferenceAssemblyPaths.GetReferenceAssemblyPaths(sdkVersion, tfm, packId);
+    }
+
+    /// <summary>
+    /// Resolves the reference assemblies directory for the chosen SDK version and target framework.
+    /// </summary>
+    public static string? GetReferenceAssemblyDir(string? sdkVersion = null, string? targetFramework = null, string packId = "Microsoft.NETCore.App.Ref")
+    {
+        var tfm = TargetFrameworkMoniker.Parse(Resolve(targetFramework)).ToTfm();
+        return ReferenceAssemblyPaths.GetReferenceAssemblyDir(sdkVersion, tfm, packId);
+    }
+
+    /// <summary>
+    /// Gets the path to System.Runtime.dll for the resolved SDK version and target framework.
+    /// </summary>
+    public static string GetRuntimeDll(string? sdkVersion = null, string? targetFramework = null, string packId = "Microsoft.NETCore.App.Ref")
+    {
+        var dir = GetReferenceAssemblyDir(sdkVersion, targetFramework, packId);
+        return Path.Combine(dir!, "System.Runtime.dll");
+    }
 }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs
@@ -39,7 +39,7 @@ public sealed class RavenWorkspace : Workspace
 
     private static MetadataReference[] GetFrameworkReferencesCore(string sdkVersion, string targetFramework)
     {
-        var paths = ReferenceAssemblyPaths.GetReferenceAssemblyPaths(sdkVersion, targetFramework);
+        var paths = TargetFrameworkResolver.GetReferenceAssemblyPaths(sdkVersion, targetFramework);
         if (paths.Length == 0)
         {
             return new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) };

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -55,7 +55,7 @@ var targetFramework = "net9.0";
 //var tfm = TargetFrameworkMoniker.Parse(targetFramework);
 
 var options = new CompilationOptions(OutputKind.ConsoleApplication);
-var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir(/* tfm.Version.ToString() + ".*" */);
+var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir(/* tfm.Version.ToString() + ".*" */);
 
 var compilation = Compilation.Create(assemblyName, options)
     .AddSyntaxTrees(syntaxTree)

--- a/test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs
@@ -7,7 +7,7 @@ public class MetadataReferenceLoadingTests
     [Fact]
     public void GetTypeByMetadataName_LoadsReferences_WhenNoSyntaxTrees()
     {
-        var referencePaths = ReferenceAssemblyPaths.GetReferenceAssemblyPaths();
+        var referencePaths = TargetFrameworkResolver.GetReferenceAssemblyPaths();
         var references = referencePaths.Select(MetadataReference.CreateFromFile).ToArray();
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
@@ -19,9 +19,9 @@ class Foo {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyPaths();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyPaths();
 
-        var runtimePath = ReferenceAssemblyPaths.GetRuntimeDll();
+        var runtimePath = TargetFrameworkResolver.GetRuntimeDll();
 
         MetadataReference[] references = [
                 MetadataReference.CreateFromFile(runtimePath)];

--- a/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
@@ -88,7 +88,7 @@ public partial class SampleProgramsTests(ITestOutputHelper testOutput)
         if (File.Exists(testDep))
             File.Copy(testDep, testDepOutputPath, overwrite: true);
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir();
 
         var compilation = Compilation.Create("samples", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
                 .AddReferences([
@@ -112,7 +112,7 @@ public partial class SampleProgramsTests(ITestOutputHelper testOutput)
 
         var tree = SyntaxTree.ParseText(source);
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir();
 
         var compilation = Compilation.Create("samples", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
                 .AddReferences([

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
@@ -62,7 +62,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         #region Compilation
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir();
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -109,7 +109,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir();
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -139,7 +139,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir();
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -169,7 +169,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir();
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)

--- a/test/Raven.CodeAnalysis.Tests/TargetFrameworkMonikerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/TargetFrameworkMonikerTests.cs
@@ -8,21 +8,21 @@ public class TargetFrameworkMonikerTests
     [Fact]
     public void ToFrameworkString_converts_net_tfm()
     {
-        var full = TargetFrameworkMoniker.ToFrameworkString("net9.0");
+        var full = TargetFrameworkMoniker.Parse("net9.0").ToFrameworkString();
         Assert.Equal(".NETCoreApp,Version=v9.0", full);
     }
 
     [Fact]
     public void ToTfm_converts_full_string()
     {
-        var tfm = TargetFrameworkMoniker.ToTfm(".NETCoreApp,Version=v9.0");
+        var tfm = TargetFrameworkMoniker.Parse(".NETCoreApp,Version=v9.0").ToTfm();
         Assert.Equal("net9.0", tfm);
     }
 
     [Fact]
     public void Resolve_defaults_to_installed()
     {
-        var full = TargetFrameworkMoniker.Resolve();
+        var full = TargetFrameworkResolver.Resolve();
         Assert.False(string.IsNullOrWhiteSpace(full));
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
@@ -92,7 +92,7 @@ public class DocumentTests
         solution = solution.AddDocument(docId, "Test.rvn", source);
         var document = solution.GetDocument(docId)!;
 
-        var refAssembliesPath = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refAssembliesPath = TargetFrameworkResolver.GetReferenceAssemblyDir();
 
         var project = document.Project.AddMetadataReference(
             MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")));

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -9,7 +9,7 @@ class Program
     static void Main()
     {
         var compilation = Compilation.Create("test", options: new CompilationOptions(OutputKind.ConsoleApplication));
-        var refDir = ReferenceAssemblyPaths.GetReferenceAssemblyDir();
+        var refDir = TargetFrameworkResolver.GetReferenceAssemblyDir();
         var references = new[]
         {
             MetadataReference.CreateFromFile(Path.Combine(refDir!, "System.Runtime.dll")),


### PR DESCRIPTION
## Summary
- add reference assembly helpers to `TargetFrameworkResolver`
- use `TargetFrameworkResolver` in workspace and tests

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/TargetFrameworkResolver.cs,src/Raven.CodeAnalysis/Workspaces/Objects/RavenWorkspace.cs,src/Raven.Compiler/Program.cs,src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs,src/Raven.CodeAnalysis.Testing/DiagnosticTestBase.cs,test/TestApp/Program.cs,test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs,test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs,test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs,test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs,test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs`
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/TargetFrameworkMonikerTests.cs`
- `dotnet build`
- `dotnet test` *(fails: DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fe8d14b0832fae7e15836e2646e3