### PR TITLE
Fix solution persistence test to use cached metadata references

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/TestMetadataReferences.cs
+++ b/test/Raven.CodeAnalysis.Tests/TestMetadataReferences.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using Raven.CodeAnalysis;
+using System.Linq;
+
+namespace Raven.CodeAnalysis.Tests;
+
+internal static class TestMetadataReferences
+{
+    private static readonly Lazy<MetadataReference[]> s_default = new(() =>
+    {
+        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        return TargetFrameworkResolver.GetReferenceAssemblies(version)
+            .Where(File.Exists)
+            .Select(MetadataReference.CreateFromFile)
+            .ToArray();
+    });
+
+    public static MetadataReference[] Default => s_default.Value;
+}
+


### PR DESCRIPTION
## Summary
- cache framework metadata references for tests
- update SaveAndOpenSolution_RoundTripsProject to add references and file paths manually

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet test --filter FullyQualifiedName~SaveAndOpenSolution_RoundTripsProject`


------
https://chatgpt.com/codex/tasks/task_e_68a71f9ffcc8832f894c38fb7341ddc5