### PR TITLE
feat: add basic analyzer infrastructure

### DIFF
--- a/src/Raven.CodeAnalysis/Workspaces/AnalyzerReference.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/AnalyzerReference.cs
@@ -1,5 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
 namespace Raven.CodeAnalysis;
 
+/// <summary>Represents a reference to one or more analyzers.</summary>
 public class AnalyzerReference
 {
+    private readonly Func<IEnumerable<IRavenAnalyzer>> _analyzerFactory;
+
+    /// <summary>Create a reference from a specific analyzer instance.</summary>
+    public AnalyzerReference(IRavenAnalyzer analyzer)
+        : this(() => new[] { analyzer })
+    {
+    }
+
+    /// <summary>Create a reference from an analyzer type.</summary>
+    public AnalyzerReference(Type analyzerType)
+        : this(() => new[] { (IRavenAnalyzer)Activator.CreateInstance(analyzerType)! })
+    {
+        if (!typeof(IRavenAnalyzer).IsAssignableFrom(analyzerType))
+            throw new ArgumentException("Type must implement IRavenAnalyzer", nameof(analyzerType));
+    }
+
+    /// <summary>Create a reference from an assembly containing analyzers.</summary>
+    public AnalyzerReference(Assembly assembly)
+        : this(() =>
+            assembly.GetTypes()
+                .Where(t => typeof(IRavenAnalyzer).IsAssignableFrom(t) && !t.IsAbstract && t.GetConstructor(Type.EmptyTypes) != null)
+                .Select(t => (IRavenAnalyzer)Activator.CreateInstance(t)!))
+    {
+    }
+
+    private AnalyzerReference(Func<IEnumerable<IRavenAnalyzer>> analyzerFactory)
+    {
+        _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
+    }
+
+    internal IEnumerable<IRavenAnalyzer> GetAnalyzers() => _analyzerFactory();
 }

--- a/src/Raven.CodeAnalysis/Workspaces/IRavenAnalyzer.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/IRavenAnalyzer.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Raven.CodeAnalysis;
+
+/// <summary>Defines an analyzer that can produce diagnostics for a compilation.</summary>
+public interface IRavenAnalyzer
+{
+    IEnumerable<Diagnostic> Analyze(Compilation compilation, CancellationToken cancellationToken = default);
+}

--- a/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
@@ -10,6 +10,7 @@ public sealed class ProjectInfo
         IEnumerable<DocumentInfo> documents,
         IEnumerable<ProjectReference>? projectReferences = null,
         IEnumerable<MetadataReference>? metadataReferences = null,
+        IEnumerable<AnalyzerReference>? analyzerReferences = null,
         string? filePath = null,
         string? targetFramework = null,
         CompilationOptions? compilationOptions = null,
@@ -19,6 +20,7 @@ public sealed class ProjectInfo
         Documents = documents.ToImmutableArray();
         ProjectReferences = projectReferences?.ToImmutableArray() ?? ImmutableArray<ProjectReference>.Empty;
         MetadataReferences = metadataReferences?.ToImmutableArray() ?? ImmutableArray<MetadataReference>.Empty;
+        AnalyzerReferences = analyzerReferences?.ToImmutableArray() ?? ImmutableArray<AnalyzerReference>.Empty;
         FilePath = filePath;
         TargetFramework = targetFramework;
         CompilationOptions = compilationOptions;
@@ -34,6 +36,7 @@ public sealed class ProjectInfo
 
     public ImmutableArray<ProjectReference> ProjectReferences { get; }
     public ImmutableArray<MetadataReference> MetadataReferences { get; }
+    public ImmutableArray<AnalyzerReference> AnalyzerReferences { get; }
     public CompilationOptions? CompilationOptions { get; }
     public string? AssemblyName { get; }
     public ParseOptions? ParseOptions { get; internal set; }
@@ -42,7 +45,7 @@ public sealed class ProjectInfo
     public string? TargetFramework { get; }
 
     public ProjectInfo WithDocuments(IEnumerable<DocumentInfo> docs) =>
-        new(Attributes, docs, ProjectReferences, MetadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
+        new(Attributes, docs, ProjectReferences, MetadataReferences, AnalyzerReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
     public ProjectInfo WithVersion(VersionStamp version)
     {
@@ -50,17 +53,20 @@ public sealed class ProjectInfo
         {
             Version = version
         };
-        return new ProjectInfo(newAttributes, Documents, ProjectReferences, MetadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
+        return new ProjectInfo(newAttributes, Documents, ProjectReferences, MetadataReferences, AnalyzerReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
     }
 
     public ProjectInfo WithProjectReferences(IEnumerable<ProjectReference> projectReferences) =>
-        new(Attributes, Documents, projectReferences, MetadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
+        new(Attributes, Documents, projectReferences, MetadataReferences, AnalyzerReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
     public ProjectInfo WithMetadataReferences(IEnumerable<MetadataReference> metadataReferences) =>
-        new(Attributes, Documents, ProjectReferences, metadataReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
+        new(Attributes, Documents, ProjectReferences, metadataReferences, AnalyzerReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
     public ProjectInfo WithCompilationOptions(CompilationOptions? compilationOptions) =>
-        new(Attributes, Documents, ProjectReferences, MetadataReferences, FilePath, TargetFramework, compilationOptions, AssemblyName);
+        new(Attributes, Documents, ProjectReferences, MetadataReferences, AnalyzerReferences, FilePath, TargetFramework, compilationOptions, AssemblyName);
+
+    public ProjectInfo WithAnalyzerReferences(IEnumerable<AnalyzerReference> analyzerReferences) =>
+        new(Attributes, Documents, ProjectReferences, MetadataReferences, analyzerReferences, FilePath, TargetFramework, CompilationOptions, AssemblyName);
 
     public sealed record ProjectAttributes(ProjectId Id, string Name, VersionStamp Version);
 }

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs
@@ -58,6 +58,9 @@ public sealed class Project
     /// <summary>Metadata references for this project.</summary>
     public IReadOnlyList<MetadataReference> MetadataReferences => _info.MetadataReferences;
 
+    /// <summary>An analyzer references for this project.</summary>
+    public IReadOnlyList<AnalyzerReference> AnalyzerReferences => _info.AnalyzerReferences;
+
     /// <summary>Gets a document by its identifier.</summary>
     public Document? GetDocument(DocumentId id)
     {
@@ -103,6 +106,12 @@ public sealed class Project
     public Project AddMetadataReference(MetadataReference metadataReference)
     {
         return Solution.AddMetadataReference(Id, metadataReference).GetProject(Id);
+    }
+
+    /// <summary>Adds an analyzer reference to this project.</summary>
+    public Project AddAnalyzerReference(AnalyzerReference analyzerReference)
+    {
+        return Solution.AddAnalyzerReference(Id, analyzerReference).GetProject(Id);
     }
 
     /// <summary>

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+
 using Raven.CodeAnalysis.Syntax;
 
 namespace Raven.CodeAnalysis;
@@ -214,7 +215,7 @@ public class Workspace
             ?? throw new ArgumentException("Project not found", nameof(projectId));
 
         var compilation = GetCompilation(projectId);
-        var diagnostics = compilation.GetDiagnostics(cancellationToken).ToList();
+        var diagnostics = compilation.GetDiagnostics(cancellationToken).ToHashSet();
 
         foreach (var reference in project.AnalyzerReferences)
         {

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
@@ -100,7 +100,7 @@ internal static class ProjectFile
             .ToImmutableArray();
 
         var attrInfo = new ProjectInfo.ProjectAttributes(projectId, name, VersionStamp.Create());
-        var info = new ProjectInfo(attrInfo, documents, filePath: filePath, targetFramework: targetFramework, compilationOptions: options, assemblyName: output);
+        var info = new ProjectInfo(attrInfo, documents, filePath: filePath, analyzerReferences: null, targetFramework: targetFramework, compilationOptions: options, assemblyName: output);
         return new ProjectFileInfo(info, projectRefs);
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/AnalyzerInfrastructureTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/AnalyzerInfrastructureTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Tests;
+using Raven.CodeAnalysis.Text;
+
+namespace Raven.CodeAnalysis.Tests.Workspaces;
+
+public class AnalyzerInfrastructureTests
+{
+    private sealed class TodoAnalyzer : IRavenAnalyzer
+    {
+        public static readonly DiagnosticDescriptor Descriptor = DiagnosticDescriptor.Create(
+            id: "AN0001",
+            title: "TODO found",
+            description: null,
+            helpLinkUri: string.Empty,
+            messageFormat: "TODO found",
+            category: "Testing",
+            defaultSeverity: DiagnosticSeverity.Info);
+
+        public IEnumerable<Diagnostic> Analyze(Compilation compilation, CancellationToken cancellationToken = default)
+        {
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                var text = tree.GetText()?.ToString();
+                if (text is not null && text.Contains("TODO"))
+                    yield return Diagnostic.Create(Descriptor, Location.None);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetDiagnostics_IncludesCompilerAndAnalyzerDiagnostics()
+    {
+        var workspace = RavenWorkspace.Create(targetFramework: TestMetadataReferences.TargetFramework);
+        var solutionWithProject = workspace.CurrentSolution.AddProject("Test");
+        var projectId = solutionWithProject.Projects.Single().Id;
+        workspace.TryApplyChanges(solutionWithProject);
+
+        var docId = DocumentId.CreateNew(projectId);
+        var initial = SourceText.From("\"unterminated");
+        var solution = workspace.CurrentSolution.AddDocument(docId, "test.rav", initial);
+        workspace.TryApplyChanges(solution);
+
+        var project = workspace.CurrentSolution.GetProject(projectId)!;
+        project = project.AddAnalyzerReference(new AnalyzerReference(new TodoAnalyzer()));
+        foreach (var reference in TestMetadataReferences.Default)
+            project = project.AddMetadataReference(reference);
+        workspace.TryApplyChanges(project.Solution);
+
+        var diagnostics1 = workspace.GetDiagnostics(projectId);
+        Assert.Contains(diagnostics1, d => d.Descriptor.Id == "RAV1010");
+        Assert.DoesNotContain(diagnostics1, d => d.Descriptor.Id == TodoAnalyzer.Descriptor.Id);
+
+        var updated = workspace.CurrentSolution.WithDocumentText(docId, SourceText.From("TODO \"unterminated"));
+        workspace.TryApplyChanges(updated);
+
+        var diagnostics2 = workspace.GetDiagnostics(projectId);
+        Assert.Contains(diagnostics2, d => d.Descriptor.Id == "RAV1010");
+        Assert.Contains(diagnostics2, d => d.Descriptor.Id == TodoAnalyzer.Descriptor.Id);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce IRavenAnalyzer and AnalyzerReference for plugin analyzers
- allow projects to manage analyzer references and aggregate analyzer diagnostics
- add test proving analyzer diagnostics are captured alongside compiler errors

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Workspaces/IRavenAnalyzer.cs,src/Raven.CodeAnalysis/Workspaces/AnalyzerReference.cs,src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs,src/Raven.CodeAnalysis/Workspaces/Objects/Project.cs,src/Raven.CodeAnalysis/Workspaces/Objects/Solution.cs,src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs,src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs,test/Raven.CodeAnalysis.Tests/Workspaces/AnalyzerInfrastructureTests.cs`
- `dotnet build`
- `dotnet test` *(fails: Failed: 18, Passed: 138)*

------
https://chatgpt.com/codex/tasks/task_e_68a74065fb30832f80cf66e55469337e