### PR TITLE
refactor: remove unused SymbolTable

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -9,7 +9,6 @@ namespace Raven.CodeAnalysis;
 
 internal abstract class Binder
 {
-    protected readonly Dictionary<string, ISymbol> SymbolTable = new();
     protected readonly DiagnosticBag _diagnostics;
 
     protected Binder(Binder? parent, DiagnosticBag? diagnostics = null)
@@ -137,16 +136,9 @@ internal abstract class Binder
         return ParentBinder?.LookupNamespace(name);
     }
 
-    public void DeclareSymbol(string name, ISymbol symbol)
-    {
-        if (SymbolTable.ContainsKey(name))
-            throw new Exception($"Symbol '{name}' is already declared in this scope.");
-        SymbolTable[name] = symbol;
-    }
-
     public virtual ISymbol? LookupSymbol(string name)
     {
-        return SymbolTable.TryGetValue(name, out var symbol) ? symbol : ParentBinder?.LookupSymbol(name);
+        return ParentBinder?.LookupSymbol(name);
     }
 
     public virtual BoundExpression BindExpression(ExpressionSyntax expression)

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -64,11 +64,7 @@ partial class BlockBinder : Binder
         if (_localFunctions.TryGetValue(name, out var func))
             return func;
 
-        var parentSymbol1 = ParentBinder?.LookupSymbol(name);
-        if (parentSymbol1 != null)
-            return parentSymbol1;
-
-        var parentSymbol = base.LookupSymbol(name);
+        var parentSymbol = ParentBinder?.LookupSymbol(name);
         if (parentSymbol != null)
             return parentSymbol;
 
@@ -1292,12 +1288,6 @@ partial class BlockBinder : Binder
                 {
                     if (seen.Add(local.Name))
                         yield return local;
-                }
-
-                foreach (var symbol in block.SymbolTable.Values)
-                {
-                    if (seen.Add(symbol.Name))
-                        yield return symbol;
                 }
             }
 


### PR DESCRIPTION
## Summary
- drop unused `SymbolTable` field and related logic from binder infrastructure
- streamline symbol lookup to rely on parent binders and block locals

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/Binder.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs`
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet build`
- `dotnet test` *(fails: 20 failed, 136 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a74fa34cb4832f9d6742ba82aee501