### PR TITLE
feat: add analyzer action registration

### DIFF
--- a/src/Raven.CodeAnalysis/Diagnostics/DiagnosticAnalyzer.cs
+++ b/src/Raven.CodeAnalysis/Diagnostics/DiagnosticAnalyzer.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Diagnostics;
+
+/// <summary>Base class for analyzers that can produce diagnostics for a compilation.</summary>
+public abstract class DiagnosticAnalyzer
+{
+    private bool _initialized;
+    private readonly List<Action<SyntaxTreeAnalysisContext>> _syntaxTreeActions = new();
+
+    /// <summary>Implement to register analysis actions.</summary>
+    public abstract void Initialize(AnalysisContext context);
+
+    /// <summary>Runs the analyzer for the specified compilation.</summary>
+    public IEnumerable<Diagnostic> Analyze(Compilation compilation, CancellationToken cancellationToken = default)
+    {
+        if (!_initialized)
+        {
+            Initialize(new AnalysisContext(_syntaxTreeActions));
+            _initialized = true;
+        }
+
+        var diagnostics = new List<Diagnostic>();
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var treeContext = new SyntaxTreeAnalysisContext(tree, compilation, diagnostics.Add, cancellationToken);
+            foreach (var action in _syntaxTreeActions)
+                action(treeContext);
+        }
+
+        return diagnostics;
+    }
+}
+
+/// <summary>Context used to register analysis actions.</summary>
+public sealed class AnalysisContext
+{
+    private readonly List<Action<SyntaxTreeAnalysisContext>> _syntaxTreeActions;
+
+    internal AnalysisContext(List<Action<SyntaxTreeAnalysisContext>> syntaxTreeActions)
+    {
+        _syntaxTreeActions = syntaxTreeActions;
+    }
+
+    /// <summary>Registers an action executed for each syntax tree in a compilation.</summary>
+    public void RegisterSyntaxTreeAction(Action<SyntaxTreeAnalysisContext> action)
+    {
+        if (action is null)
+            throw new ArgumentNullException(nameof(action));
+
+        _syntaxTreeActions.Add(action);
+    }
+}
+
+/// <summary>Context for analyzing a single syntax tree.</summary>
+public readonly struct SyntaxTreeAnalysisContext
+{
+    private readonly Action<Diagnostic> _reportDiagnostic;
+
+    internal SyntaxTreeAnalysisContext(
+        SyntaxTree syntaxTree,
+        Compilation compilation,
+        Action<Diagnostic> reportDiagnostic,
+        CancellationToken cancellationToken)
+    {
+        SyntaxTree = syntaxTree;
+        Compilation = compilation;
+        _reportDiagnostic = reportDiagnostic;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>The syntax tree being analyzed.</summary>
+    public SyntaxTree SyntaxTree { get; }
+
+    /// <summary>The compilation containing the syntax tree.</summary>
+    public Compilation Compilation { get; }
+
+    /// <summary>Cancellation token for the analysis.</summary>
+    public CancellationToken CancellationToken { get; }
+
+    /// <summary>Reports a diagnostic.</summary>
+    public void ReportDiagnostic(Diagnostic diagnostic)
+    {
+        _reportDiagnostic(diagnostic);
+    }
+}

--- a/src/Raven.CodeAnalysis/Diagnostics/IDiagnosticAnalyzer.cs
+++ b/src/Raven.CodeAnalysis/Diagnostics/IDiagnosticAnalyzer.cs
@@ -1,7 +1,0 @@
-namespace Raven.CodeAnalysis.Diagnostics;
-
-/// <summary>Defines an analyzer that can produce diagnostics for a compilation.</summary>
-public interface IDiagnosticAnalyzer
-{
-    IEnumerable<Diagnostic> Analyze(Compilation compilation, CancellationToken cancellationToken = default);
-}

--- a/src/Raven.CodeAnalysis/Workspaces/AnalyzerReference.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/AnalyzerReference.cs
@@ -7,35 +7,35 @@ namespace Raven.CodeAnalysis;
 /// <summary>Represents a reference to one or more analyzers.</summary>
 public class AnalyzerReference
 {
-    private readonly Func<IEnumerable<IDiagnosticAnalyzer>> _analyzerFactory;
+    private readonly Func<IEnumerable<DiagnosticAnalyzer>> _analyzerFactory;
 
     /// <summary>Create a reference from a specific analyzer instance.</summary>
-    public AnalyzerReference(IDiagnosticAnalyzer analyzer)
+    public AnalyzerReference(DiagnosticAnalyzer analyzer)
         : this(() => [analyzer])
     {
     }
 
     /// <summary>Create a reference from an analyzer type.</summary>
     public AnalyzerReference(Type analyzerType)
-        : this(() => [(IDiagnosticAnalyzer)Activator.CreateInstance(analyzerType)!])
+        : this(() => [(DiagnosticAnalyzer)Activator.CreateInstance(analyzerType)!])
     {
-        if (!typeof(IDiagnosticAnalyzer).IsAssignableFrom(analyzerType))
-            throw new ArgumentException("Type must implement IDiagnosticAnalyzer", nameof(analyzerType));
+        if (!typeof(DiagnosticAnalyzer).IsAssignableFrom(analyzerType))
+            throw new ArgumentException("Type must implement DiagnosticAnalyzer", nameof(analyzerType));
     }
 
     /// <summary>Create a reference from an assembly containing analyzers.</summary>
     public AnalyzerReference(Assembly assembly)
         : this(() =>
             assembly.GetTypes()
-                .Where(t => typeof(IDiagnosticAnalyzer).IsAssignableFrom(t) && !t.IsAbstract && t.GetConstructor(Type.EmptyTypes) != null)
-                .Select(t => (IDiagnosticAnalyzer)Activator.CreateInstance(t)!))
+                .Where(t => typeof(DiagnosticAnalyzer).IsAssignableFrom(t) && !t.IsAbstract && t.GetConstructor(Type.EmptyTypes) != null)
+                .Select(t => (DiagnosticAnalyzer)Activator.CreateInstance(t)!))
     {
     }
 
-    private AnalyzerReference(Func<IEnumerable<IDiagnosticAnalyzer>> analyzerFactory)
+    private AnalyzerReference(Func<IEnumerable<DiagnosticAnalyzer>> analyzerFactory)
     {
         _analyzerFactory = analyzerFactory ?? throw new ArgumentNullException(nameof(analyzerFactory));
     }
 
-    internal IEnumerable<IDiagnosticAnalyzer> GetAnalyzers() => _analyzerFactory();
+    internal IEnumerable<DiagnosticAnalyzer> GetAnalyzers() => _analyzerFactory();
 }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/AnalyzerInfrastructureTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/AnalyzerInfrastructureTests.cs
@@ -5,7 +5,7 @@ namespace Raven.CodeAnalysis.Tests.Workspaces;
 
 public class AnalyzerInfrastructureTests
 {
-    private sealed class TodoAnalyzer : IDiagnosticAnalyzer
+    private sealed class TodoAnalyzer : DiagnosticAnalyzer
     {
         public static readonly DiagnosticDescriptor Descriptor = DiagnosticDescriptor.Create(
             id: "AN0001",
@@ -16,14 +16,14 @@ public class AnalyzerInfrastructureTests
             category: "Testing",
             defaultSeverity: DiagnosticSeverity.Info);
 
-        public IEnumerable<Diagnostic> Analyze(Compilation compilation, CancellationToken cancellationToken = default)
+        public override void Initialize(AnalysisContext context)
         {
-            foreach (var tree in compilation.SyntaxTrees)
+            context.RegisterSyntaxTreeAction(ctx =>
             {
-                var text = tree.GetText()?.ToString();
+                var text = ctx.SyntaxTree.GetText()?.ToString();
                 if (text is not null && text.Contains("TODO"))
-                    yield return Diagnostic.Create(Descriptor, Location.None);
-            }
+                    ctx.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None));
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- replace `IDiagnosticAnalyzer` interface with extensible `DiagnosticAnalyzer` class
- allow analyzers to register syntax tree actions via `AnalysisContext`
- update workspace analyzer references and tests for new API

## Testing
- `dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --no-restore --include src/Raven.CodeAnalysis/Diagnostics/DiagnosticAnalyzer.cs src/Raven.CodeAnalysis/Workspaces/AnalyzerReference.cs`
- `dotnet build`
- `dotnet test --no-build` *(fails: Raven.CodeAnalysis.Tests...)*

------
https://chatgpt.com/codex/tasks/task_e_68a762a673ac832fb8ffcfdce7be1910