### PR TITLE
feat: require wildcard for namespace imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ See the pseudo-specification [here](/docs/lang/spec/language-specification.md).
 ### Example
 
 ```raven
-import System
-import System.Text
+import System.*
+import System.Text.*
 
 let list = [1, 42, 3]
 var i = 0

--- a/docs/compiler/development/debugging.md
+++ b/docs/compiler/development/debugging.md
@@ -13,7 +13,7 @@ Assuming you have a syntax node that represent this code:
 ```csharp
   var sourceCode = 
             """
-            import System
+            import System.*
 
             let no = 2;
 
@@ -41,13 +41,17 @@ root.PrintSyntaxTree(new PrinterOptions { IncludeNames = true, IncludeTokens = t
 Will give you this:
 
 ```
-CompilationUnit [0..70] (1,1) - (7,2)
-├── ImportDirective [0..14] (1,1) - (2,1)
+CompilationUnit [0..72] (1,1) - (7,2)
+├── ImportDirective [0..16] (1,1) - (2,1)
 │   ├── ImportKeyword: import ImportKeyword [0..6] (1,1) - (1,7)
 │   │   └── ␣ WhitespaceTrivia [6..7] (1,7) - (1,8)
-│   ├── NamespaceOrType: IdentifierName [7..13] (1,8) - (1,14)
-│   │   └── Identifier: System IdentifierToken [7..13] (1,8) - (1,14)
-│   └── TerminatorToken: \n NewLineToken [13..14] (1,14) - (2,1)
+│   ├── NamespaceOrType: QualifiedName [7..15] (1,8) - (1,16)
+│   │   ├── Left: IdentifierName [7..13] (1,8) - (1,14)
+│   │   │   └── Identifier: System IdentifierToken [7..13] (1,8) - (1,14)
+│   │   ├── DotToken: . DotToken [13..14] (1,14) - (1,15)
+│   │   └── Right: WildcardName [14..15] (1,15) - (1,16)
+│   │       └── Identifier: * StarToken [14..15] (1,15) - (1,16)
+│   └── TerminatorToken: \n NewLineToken [15..16] (1,16) - (2,1)
 ├── GlobalStatement [15..26] (3,1) - (3,12)
 │   └── Statement: LocalDeclaration [15..26] (3,1) - (3,12)
 │       ├── Declaration: VariableDeclaration [15..25] (3,1) - (3,11)

--- a/docs/lang/README.md
+++ b/docs/lang/README.md
@@ -10,7 +10,7 @@
 These examples show the envisioned syntax of the language:
 
 ```csharp
-import System
+import System.*
 
 Console.Write("What is your name? ")
 

--- a/docs/lang/proposals/import-directive.md
+++ b/docs/lang/proposals/import-directive.md
@@ -21,6 +21,17 @@ import System.StringBuilder
 import System.*
 ```
 
+### Import members of a type
+
+Applying the wildcard to a type name brings its nested types and static
+members into scope:
+
+```raven
+import System.Math.*
+
+let pi = PI
+```
+
 ### Resolution
 
 Resolution works like this:

--- a/docs/lang/proposals/import-directive.md
+++ b/docs/lang/proposals/import-directive.md
@@ -7,6 +7,7 @@ This document outlines the import directive.
 ## Syntax
 
 The `import` directive appears at the top of a file, either outside or inside a namespace declaration.
+Importing all types from a namespace requires a trailing `.*` wildcard.
 
 ### Import a specific type
 

--- a/docs/lang/proposals/rejected/indentation.md
+++ b/docs/lang/proposals/rejected/indentation.md
@@ -15,7 +15,7 @@ Would distinguish the language from other languages that are C-style, in particu
 C-like style that has been implemented to this date:
 
 ```csharp
-import System;
+import System.*;
 
 Console.Write("What is your name? ");
 
@@ -32,7 +32,7 @@ if name is not null {
 Using Python-like indentation (and no mandatory semicolons):
 
 ```csharp
-import System
+import System.*
 
 Console.Write("What is your name? ")
 

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -5,7 +5,7 @@
 
 CompilationUnit          ::= {ImportDirective | Declaration | Statement} EOF ;
 
-ImportDirective          ::= 'import' QualifiedName ('.' '*')? ;
+ImportDirective          ::= 'import' QualifiedName ('.' '*')? ; (* Namespace imports require a trailing '.*' *)
 
 (* ---------- Modifiers ---------- *)
 

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -5,7 +5,7 @@
 
 CompilationUnit          ::= {ImportDirective | Declaration | Statement} EOF ;
 
-ImportDirective          ::= 'import' QualifiedName ('.' '*')? ; (* Namespace imports require a trailing '.*' *)
+ImportDirective          ::= 'import' QualifiedName ('.' '*')? ; (* Namespace imports require '.*'; applying '.*' to a type imports its static members and nested types *)
 
 (* ---------- Modifiers ---------- *)
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -193,6 +193,15 @@ import System.*
 // Members here
 ```
 
+The wildcard may also be applied to a type name to bring its static members
+and nested types into scope:
+
+```raven
+import System.Math.*
+
+let pi = PI
+```
+
 ### Scoped namespaces
 
 You may define multiple namespaces (including nested) in one file using

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -54,7 +54,7 @@ When used for their side effects in statement position, they appear as expressio
 Top-level statements are supported—no `Main` method is required.
 
 ```raven
-import System
+import System.*
 
 Console.WriteLine("Hello, World!")
 ```
@@ -187,8 +187,8 @@ namespace Foo
 ```raven
 namespace Foo
 
-import System
-// or import System.Collections.*  // wildcard supported by the binder
+import System.*
+// or import System.Collections.*
 
 // Members here
 ```
@@ -203,8 +203,8 @@ block scopes:
 
 namespace A1
 {
-    import System
-    import System.IO
+    import System.*
+    import System.IO.*
 
     // Members here
 

--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -77,7 +77,7 @@ class BinderFactory
             var namespaceSymbol = ResolveNamespace(nsSymbol!, importName);
             if (namespaceSymbol != null)
             {
-                nsBinder.AddUsingDirective(namespaceSymbol);
+                nsBinder.Diagnostics.ReportTypeExpectedWithoutWildcard(importDirective.Name.GetLocation());
                 continue;
             }
 

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
@@ -23,6 +23,7 @@ internal class CompilerDiagnostics
     private static DiagnosticDescriptor? _cannotConvertFromTypeToType;
     private static DiagnosticDescriptor? _noOverloadForMethod;
     private static DiagnosticDescriptor? _typeOrNamespaceNameDoesNotExistInTheNamespace;
+    private static DiagnosticDescriptor? _typeExpectedWithoutWildcard;
     private static DiagnosticDescriptor? _invalidExpressionTerm;
     private static DiagnosticDescriptor? _theNameDoesNotExistInTheCurrentContext;
     private static DiagnosticDescriptor? _cannotAssignVoidToAnImplicitlyTypedVariable;
@@ -284,6 +285,19 @@ internal class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
+    /// RAV0235: Type is expected without wildcard
+    /// </summary>
+    public static DiagnosticDescriptor TypeExpectedWithoutWildcard => _typeExpectedWithoutWildcard ??= DiagnosticDescriptor.Create(
+        id: "RAV0235",
+        title: "Type expected without wildcard",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Type is expected without wildcard",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// RAV1525: Invalid expression term '{0}'
     /// </summary>
     public static DiagnosticDescriptor InvalidExpressionTerm => _invalidExpressionTerm ??= DiagnosticDescriptor.Create(
@@ -455,6 +469,7 @@ internal class CompilerDiagnostics
         CannotConvertFromTypeToType,
         NoOverloadForMethod,
         TypeOrNamespaceNameDoesNotExistInTheNamespace,
+        TypeExpectedWithoutWildcard,
         InvalidExpressionTerm,
         TheNameDoesNotExistInTheCurrentContext,
         CannotAssignVoidToAnImplicitlyTypedVariable,
@@ -491,6 +506,7 @@ internal class CompilerDiagnostics
             "RAV1503" => CannotConvertFromTypeToType,
             "RAV1501" => NoOverloadForMethod,
             "RAV0234" => TypeOrNamespaceNameDoesNotExistInTheNamespace,
+            "RAV0235" => TypeExpectedWithoutWildcard,
             "RAV1525" => InvalidExpressionTerm,
             "RAV0103" => TheNameDoesNotExistInTheCurrentContext,
             "RAV0815" => CannotAssignVoidToAnImplicitlyTypedVariable,

--- a/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
@@ -56,6 +56,9 @@ public static class DiagnosticBagExtensions
     public static void ReportTypeOrNamespaceNameDoesNotExistInTheNamespace(this DiagnosticBag diagnostics, string typeOrNs, string container, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TypeOrNamespaceNameDoesNotExistInTheNamespace, location, typeOrNs, container));
 
+    public static void ReportTypeExpectedWithoutWildcard(this DiagnosticBag diagnostics, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TypeExpectedWithoutWildcard, location));
+
     public static void ReportInvalidExpressionTerm(this DiagnosticBag diagnostics, string tokenText, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.InvalidExpressionTerm, location, tokenText));
 

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -242,7 +242,7 @@ public partial class SemanticModel
             var nsSymbol = ResolveNamespace(targetNamespace, name);
             if (nsSymbol != null)
             {
-                namespaceImports.Add(nsSymbol);
+                namespaceBinder.Diagnostics.ReportTypeExpectedWithoutWildcard(import.Name.GetLocation());
                 continue;
             }
 

--- a/src/Raven.Compiler/samples/arrays.rav
+++ b/src/Raven.Compiler/samples/arrays.rav
@@ -2,8 +2,8 @@
  * Array type declaration
  * * * */
 
-import System
-import System.Text
+import System.*
+import System.Text.*
 
 let list = [1, 42, 3]
 

--- a/src/Raven.Compiler/samples/classes.rav
+++ b/src/Raven.Compiler/samples/classes.rav
@@ -4,8 +4,8 @@
  
 //namespace Test
 
-import System
-import System.Collections.Generic
+import System.*
+import System.Collections.Generic.*
 
 Console.WriteLine("Hello"); let x = 2
 

--- a/src/Raven.Compiler/samples/enums.rav
+++ b/src/Raven.Compiler/samples/enums.rav
@@ -1,4 +1,4 @@
-import System
+import System.*
 
 var foo : Grades = .B
 foo = .C

--- a/src/Raven.Compiler/samples/general.rav
+++ b/src/Raven.Compiler/samples/general.rav
@@ -2,8 +2,8 @@
  * Declarations, control flow, and usage of framework types
  * * * */
 
-import System
-import System.Text
+import System.*
+import System.Text.*
 
 let list = [1, 42, 3]
 var i = 0

--- a/src/Raven.Compiler/samples/generics.rav
+++ b/src/Raven.Compiler/samples/generics.rav
@@ -2,8 +2,8 @@
  * Generics - instantiation of generic type and accessing members
  * * * */
 
-import System
-import System.Collections.Generic
+import System.*
+import System.Collections.Generic.*
 
 let list = new List<int>()
 list.Add(2)

--- a/src/Raven.Compiler/samples/io.rav
+++ b/src/Raven.Compiler/samples/io.rav
@@ -1,6 +1,6 @@
-import System
-import System.Collections.Generic
-import System.IO
+import System.*
+import System.Collections.Generic.*
+import System.IO.*
 
 let fileList = new List<string>()
 

--- a/src/Raven.Compiler/samples/main.rav
+++ b/src/Raven.Compiler/samples/main.rav
@@ -1,5 +1,5 @@
-import System
-import System.Text
+import System.*
+import System.Text.*
 
 let data = [3, 27, 51]
 let builder = new StringBuilder()

--- a/src/Raven.Compiler/samples/test.rav
+++ b/src/Raven.Compiler/samples/test.rav
@@ -1,4 +1,4 @@
-import System
+import System.*
 
 let arg = if args.Length > 0 { args[0]; } else { "0"; }
 

--- a/src/Raven.Compiler/samples/test2.rav
+++ b/src/Raven.Compiler/samples/test2.rav
@@ -1,4 +1,4 @@
-import System
+import System.*
 
 Console.WriteLine(40 + 2)
 

--- a/src/Raven.Compiler/samples/tokenizer.rav
+++ b/src/Raven.Compiler/samples/tokenizer.rav
@@ -1,5 +1,5 @@
-import System
-import System.Text
+import System.*
+import System.Text.*
 
 /*
  *. let lexer = Lexer.WithSource(TextReader(...))

--- a/src/Raven.Compiler/samples/type-unions.rav
+++ b/src/Raven.Compiler/samples/type-unions.rav
@@ -2,7 +2,7 @@
  * Demonstrates type unions, patterns, and support for assembly references
  * * * */
 
-import System
+import System.*
 
 let w = 352342342
 

--- a/test/Raven.CodeAnalysis.Tests/Bugs/Issue84_MemberResolutionBug.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/Issue84_MemberResolutionBug.cs
@@ -11,7 +11,7 @@ public class Issue84_MemberResolutionBug : DiagnosticTestBase
     {
         string testCode =
             """
-            import System;
+            import System.*
 
             let a = DateTime.Parse("2015-03-21").Day;
             """;
@@ -26,7 +26,7 @@ public class Issue84_MemberResolutionBug : DiagnosticTestBase
     {
         string testCode =
             """
-            import System;
+            import System.*
 
             let a = DateTime.Now.ToString();
             """;

--- a/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
@@ -112,7 +112,7 @@ public partial class SampleProgramsTests(ITestOutputHelper testOutput)
     public void Test()
     {
         var source = """
-        //import System
+        //import System.*
 
         System.Console.WriteLine("Test")
         """;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs
@@ -9,7 +9,7 @@ public class ExpressionSemanticTest : DiagnosticTestBase
     {
         string testCode =
             """
-            import System;
+            import System.*
 
             Console.WriteLine(Console.WriteLine());
             """;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -26,7 +26,7 @@ public class ImportResolutionTest : DiagnosticTestBase
     {
         string testCode =
             """
-            import System
+            import System.*
 
             String
             """;
@@ -60,7 +60,7 @@ public class ImportResolutionTest : DiagnosticTestBase
     {
         string testCode =
             """
-            import System.Collections.Generic
+            import System.Collections.Generic.*
 
             List<string>
             """;
@@ -109,6 +109,26 @@ public class ImportResolutionTest : DiagnosticTestBase
             """;
 
         var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void NamespaceImportWithoutWildcard_Should_ProduceDiagnostic()
+    {
+        string testCode =
+            """
+            import System
+
+            String
+            """;
+
+        var verifier = CreateVerifier(
+            testCode,
+            [
+                new DiagnosticResult("RAV0235").WithLocation(1, 8),
+                new DiagnosticResult("RAV0103").WithLocation(3, 1).WithArguments("String"),
+            ]);
 
         verifier.Verify();
     }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Foo.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Foo.cs
@@ -9,8 +9,8 @@ public class Foo(ITestOutputHelper testOutputHelper)
     {
         var code =
         """
-        import System;
-        import System.Text;
+        import System.*;
+        import System.Text.*;
 
         let list = [1, 42, 3];
         var i = 0; 

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
@@ -9,8 +9,8 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
     {
         var code =
         """
-        import System;
-        import System.Text;
+        import System.*;
+        import System.Text.*;
 
         let list = [1, 42, 3];
         var i = 0; 
@@ -103,7 +103,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
     {
         var code =
         """
-        import System;
+        import System.*;
 
         Console.Wri;
         """;
@@ -134,7 +134,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
     {
         var code =
             """
-            import System;
+            import System.*;
 
             Con
             """;
@@ -163,7 +163,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
     {
         var code =
             """
-            import System;
+            import System.*;
 
             let x = args;
             var i = 0;


### PR DESCRIPTION
## Summary
- enforce wildcard when importing namespaces and add diagnostic RAV0235
- update import handling and unit tests for wildcard semantics
- document wildcard requirement in language grammar

## Testing
- `dotnet format Raven.sln --include README.md,docs/compiler/development/debugging.md,docs/lang/README.md,docs/lang/proposals/import-directive.md,docs/lang/proposals/rejected/indentation.md,docs/lang/spec/grammar.ebnf,docs/lang/spec/language-specification.md,src/Raven.CodeAnalysis/Binder/BinderFactory.cs,src/Raven.CodeAnalysis/CompilerDiagnostics.cs,src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs,src/Raven.CodeAnalysis/SemanticModel.cs,src/Raven.Compiler/samples/arrays.rav,src/Raven.Compiler/samples/classes.rav,src/Raven.Compiler/samples/enums.rav,src/Raven.Compiler/samples/general.rav,src/Raven.Compiler/samples/generics.rav,src/Raven.Compiler/samples/io.rav,src/Raven.Compiler/samples/main.rav,src/Raven.Compiler/samples/test.rav,src/Raven.Compiler/samples/test2.rav,src/Raven.Compiler/samples/tokenizer.rav,src/Raven.Compiler/samples/type-unions.rav,test/Raven.CodeAnalysis.Tests/Bugs/Issue84_MemberResolutionBug.cs,test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs,test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs,test/Raven.CodeAnalysis.Tests/Syntax/Foo.cs,test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs`
- `dotnet build`
- `dotnet test`
- `dotnet test --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68ab76d32908832f8a9cd244ed14d9b3