### PR TITLE
fix: enforce type arguments for open generic references

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -193,6 +193,12 @@ internal abstract class Binder
         if (typeSyntax is IdentifierNameSyntax ident)
         {
             var type = LookupType(ident.Identifier.Text);
+            if (type is INamedTypeSymbol named && named.Arity > 0)
+            {
+                _diagnostics.ReportTypeRequiresTypeArguments(named.Name, named.Arity, ident.Identifier.GetLocation());
+                return Compilation.ErrorTypeSymbol;
+            }
+
             if (type is not null)
                 return type;
         }
@@ -235,7 +241,14 @@ internal abstract class Binder
         {
             if (qualified.Right is IdentifierNameSyntax id)
             {
-                return ns.LookupType(id.Identifier.Text);
+                var type = ns.LookupType(id.Identifier.Text);
+                if (type is INamedTypeSymbol named && named.Arity > 0)
+                {
+                    _diagnostics.ReportTypeRequiresTypeArguments(named.Name, named.Arity, id.Identifier.GetLocation());
+                    return Compilation.ErrorTypeSymbol;
+                }
+
+                return type;
             }
 
             if (qualified.Right is GenericNameSyntax gen)
@@ -297,6 +310,12 @@ internal abstract class Binder
                 return ns;
 
             var type = LookupType(id.Identifier.Text);
+            if (type is INamedTypeSymbol named && named.Arity > 0)
+            {
+                _diagnostics.ReportTypeRequiresTypeArguments(named.Name, named.Arity, id.Identifier.GetLocation());
+                return Compilation.ErrorTypeSymbol;
+            }
+
             if (type is not null)
                 return type;
 

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
@@ -36,6 +36,7 @@ internal class CompilerDiagnostics
     private static DiagnosticDescriptor? _unterminatedCharacterLiteral;
     private static DiagnosticDescriptor? _invalidEscapeSequence;
     private static DiagnosticDescriptor? _memberAccessRequiresTargetType;
+    private static DiagnosticDescriptor? _typeRequiresTypeArguments;
 
     /// <summary>
     /// RAV1001: Identifier; expected
@@ -449,6 +450,19 @@ internal class CompilerDiagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// RAV0305: The type '{0}' requires {1} type argument(s)
+    /// </summary>
+    public static DiagnosticDescriptor TypeRequiresTypeArguments => _typeRequiresTypeArguments ??= DiagnosticDescriptor.Create(
+        id: "RAV0305",
+        title: "Type requires type arguments",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "The type '{0}' requires {1} type argument(s)",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public static DiagnosticDescriptor[] AllDescriptors => _allDescriptors ??=
     [
         IdentifierExpected,
@@ -478,6 +492,7 @@ internal class CompilerDiagnostics
         ThisValueIsNotMutable,
         PropertyOrIndexerCannotBeAssignedIsReadOnly,
         CannotApplyIndexingWithToAnExpressionOfType,
+        TypeRequiresTypeArguments,
         NumericLiteralOutOfRange,
         UnterminatedCharacterLiteral,
         InvalidEscapeSequence,
@@ -519,6 +534,7 @@ internal class CompilerDiagnostics
             "RAV2002" => UnterminatedCharacterLiteral,
             "RAV2003" => InvalidEscapeSequence,
             "RAV2010" => MemberAccessRequiresTargetType,
+            "RAV0305" => TypeRequiresTypeArguments,
             _ => null // Return null if the diagnostic ID is not recognized
         };
     }

--- a/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
@@ -65,6 +65,9 @@ public static class DiagnosticBagExtensions
     public static void ReportUndefinedName(this DiagnosticBag diagnostics, string name, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TheNameDoesNotExistInTheCurrentContext, location, name));
 
+    public static void ReportTypeRequiresTypeArguments(this DiagnosticBag diagnostics, string name, int arity, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TypeRequiresTypeArguments, location, name, arity));
+
     public static void ReportCannotAssignVoidToImplicitlyTypedVariable(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.CannotAssignVoidToAnImplicitlyTypedVariable, location));
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -99,6 +99,25 @@ public class ImportResolutionTest : DiagnosticTestBase
     }
 
     [Fact]
+    public void OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic()
+    {
+        string testCode =
+            """
+            import System.Collections.Generic.*
+
+            let x: List
+            """;
+
+        var verifier = CreateVerifier(
+            testCode,
+            [
+                new DiagnosticResult("RAV0305").WithLocation(3, 8).WithArguments("List", 1)
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void SpecificTypeImport_MakesTypeAvailable()
     {
         string testCode =


### PR DESCRIPTION
## Summary
- require type arguments when using imported open generic types
- add RAV0305 diagnostic for missing generic arity
- cover open generic import resolution with new unit test

## Testing
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(fails: Raven.CodeAnalysis.Tests.VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: 10 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab886cf200832fb48cdd729666b523