### PR TITLE
fix: support wildcard static method imports

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -166,4 +166,19 @@ public class ImportResolutionTest : DiagnosticTestBase
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void WildcardTypeImport_MakesStaticMembersAvailable()
+    {
+        string testCode =
+            """
+            import System.Console.*
+
+            WriteLine("test")
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- resolve methods from wildcard imports when invoked without receivers
- query in-scope symbols across binders for overload resolution
- test importing static methods via `import System.Console.*`

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test` *(fails: VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal; SampleProgramsTests.Sample_should_compile_and_run)*
- `dotnet test --filter WildcardTypeImport_MakesStaticMembersAvailable`


------
https://chatgpt.com/codex/tasks/task_e_68ac0825db30832f83f19f97d38ef66e