### PR TITLE
fix: avoid duplicate method builders for property accessors

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -84,7 +84,7 @@ internal class TypeGenerator
         {
             switch (memberSymbol)
             {
-                case IMethodSymbol methodSymbol:
+                case IMethodSymbol methodSymbol when methodSymbol.MethodKind is not (MethodKind.PropertyGet or MethodKind.PropertySet):
                     {
                         var methodGenerator = new MethodGenerator(this, methodSymbol);
                         _methodGenerators[methodSymbol] = methodGenerator;


### PR DESCRIPTION
## Summary
- ignore property getters/setters when enumerating methods
- prevent dangling method builders and missing IL for accessors

## Testing
- `dotnet build -v minimal`
- `dotnet test -v minimal --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal)*
- `dotnet run -- samples/classes.rav -o /tmp/classes.dll`


------
https://chatgpt.com/codex/tasks/task_e_68ac48246538832f991d398fb6040cc6