### PR TITLE
fix: emit return opcode in statement generator

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -38,7 +38,7 @@ internal class StatementGenerator : Generator
             new ExpressionGenerator(this, returnStatement.Expression).Emit();
         }
 
-        //ILGenerator.Emit(OpCodes.Ret);
+        ILGenerator.Emit(OpCodes.Ret);
     }
 
     private void EmitExpressionStatement(BoundExpressionStatement expressionStatement)

--- a/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
@@ -67,12 +67,6 @@ public partial class SampleProgramsTests(ITestOutputHelper testOutput)
         run.WaitForExit(TimeSpan.FromSeconds(2));
         testOutput.WriteLine(await run.StandardOutput.ReadToEndAsync());
 
-        if (run.ExitCode == 134 && fileName is "classes.rav")
-        {
-            // Assume this is case worked
-            return;
-        }
-
         Assert.Equal(0, run.ExitCode);
     }
 


### PR DESCRIPTION
## Summary
- emit `OpCodes.Ret` for `return` statements
- require samples to run successfully by removing special-case in sample test

## Testing
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Tests.VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal, Raven.CodeAnalysis.Semantics.Tests.PropertyBindingTests.AccessingStaticPropertyAsInstance_ProducesDiagnostic, Raven.CodeAnalysis.Semantics.Tests.PropertyBindingTests.AccessingInstancePropertyAsStatic_ProducesDiagnostic, Raven.CodeAnalysis.Tests.FieldInitializationTests.InstanceAndStaticFieldInitializers_AreEmitted, Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run(fileName: "generics.rav", args: []))*
- `dotnet test --filter Sample_should_compile_and_run` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4bc97fcc832f81081c110e228cb6