### PR TITLE
fix: emit indexer bodies with Item property

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -23,6 +23,7 @@ class BinderFactory
             NamespaceDeclarationSyntax ns => CreateNamespaceBinder(ns, parentBinder!),
             MethodDeclarationSyntax => parentBinder,
             BlockSyntax => CreateBlockBinder(parentBinder),
+            ArrowExpressionClauseSyntax => CreateBlockBinder(parentBinder),
             IfExpressionSyntax expr => new LocalScopeBinder(parentBinder!),
             ElseClauseSyntax elseClause => new LocalScopeBinder(parentBinder!),
             WhileExpressionSyntax expr => new LocalScopeBinder(parentBinder!),

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1201,7 +1201,7 @@ partial class BlockBinder : Binder
             return new BoundPropertyAssignmentExpression(GetReceiver(left), propertySymbol, right2);
         }
 
-        throw new Exception();
+        return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.NotFound);
     }
 
     private BoundExpression? GetReceiver(BoundExpression left)

--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -313,7 +313,7 @@ internal class TypeMemberBinder : Binder
         var propertyType = ResolveType(indexerDecl.Type.Type);
 
         var propertySymbol = new SourcePropertySymbol(
-            indexerDecl.Identifier.Text,
+            "Item",
             propertyType,
             _containingType,
             _containingType,

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -126,9 +126,29 @@ internal class MethodBodyGenerator
 
             case AccessorDeclarationSyntax accessorDeclaration:
                 if (boundBody != null)
+                {
                     EmitBoundBlock(boundBody);
-                else
+                }
+                else if (accessorDeclaration.ExpressionBody is not null)
+                {
+                    var boundExpr = (BoundExpression)semanticModel.GetBoundNode(accessorDeclaration.ExpressionBody.Expression)!;
+
+                    if (MethodSymbol.MethodKind == MethodKind.PropertyGet)
+                    {
+                        new ExpressionGenerator(baseGenerator, boundExpr).Emit();
+                    }
+                    else
+                    {
+                        var stmt = new BoundExpressionStatement(boundExpr);
+                        new StatementGenerator(baseGenerator, stmt).Emit();
+                    }
+
                     ILGenerator.Emit(OpCodes.Ret);
+                }
+                else
+                {
+                    ILGenerator.Emit(OpCodes.Ret);
+                }
                 break;
 
             case ClassDeclarationSyntax:

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/IndexerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/IndexerTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class IndexerTests
+{
+    [Fact]
+    public void Indexer_EmitsItemPropertyWithBodies()
+    {
+        var code = """
+class Box {
+    var data: int
+    public self[index: int]: int {
+        get => data;
+        set => data = value;
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
+        MetadataReference[] references = [
+            MetadataReference.CreateFromFile(runtimePath)
+        ];
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        peStream.Seek(0, SeekOrigin.Begin);
+        var assembly = Assembly.Load(peStream.ToArray());
+        var type = assembly.GetType("Box", true);
+        var instance = Activator.CreateInstance(type!);
+        var indexer = type!.GetProperty("Item");
+        Assert.NotNull(indexer);
+
+        // Verify getter
+        var initial = indexer!.GetValue(instance, new object[] { 0 });
+        Assert.Equal(0, (int)initial!);
+
+        // Verify setter
+        indexer.SetValue(instance, 42, new object[] { 0 });
+        var updated = indexer.GetValue(instance, new object[] { 0 });
+        Assert.Equal(42, (int)updated!);
+    }
+}


### PR DESCRIPTION
## Summary
- name indexers `Item` to match .NET convention
- emit IL bodies for expression-bodied indexer accessors
- avoid binder crash on unsupported assignments
- add regression test for indexer emission
- ensure arrow-expression accessors get a method body binder

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BinderFactory.cs`
- `dotnet build` (failed: 1723 Warning(s))
- `dotnet test` (failed: FieldInitializationTests.InstanceAndStaticFieldInitializers_AreEmitted)
- `dotnet test --filter Sample_should_compile_and_run` (failed: Assert.Equal() Failure / unexpected logger failure)


------
https://chatgpt.com/codex/tasks/task_e_68ac4e5cff7c832f8cad435293cb03df