### PR TITLE
fix: support target-typed collection expressions

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class CollectionExpressionTests
+{
+    [Fact]
+    public void ListCollectionExpressions_AreInitializedCorrectly()
+    {
+        var code = """
+class MyList {
+    var count: int = 0
+    public Add(int item) -> void { count = count + 1 }
+    public Count: int { get => count }
+}
+
+class Foo {
+    var items: MyList = [1, 2, 3]
+    var empty: MyList = []
+    public ItemsCount: int { get => items.Count }
+    public EmptyCount: int { get => empty.Count }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
+
+        MetadataReference[] references = [
+            MetadataReference.CreateFromFile(runtimePath)
+        ];
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        peStream.Seek(0, SeekOrigin.Begin);
+
+        var resolver = new PathAssemblyResolver(references.Select(r => ((PortableExecutableReference)r).FilePath));
+        using var mlc = new MetadataLoadContext(resolver);
+
+        var assembly = mlc.LoadFromStream(peStream);
+        var type = assembly.GetType("Foo", true);
+        var instance = Activator.CreateInstance(type!);
+        var itemsCountProp = type!.GetProperty("ItemsCount");
+        var emptyCountProp = type!.GetProperty("EmptyCount");
+
+        Assert.Equal(3, (int)itemsCountProp!.GetValue(instance)!);
+        Assert.Equal(0, (int)emptyCountProp!.GetValue(instance)!);
+    }
+}


### PR DESCRIPTION
## Summary
- bind collection expressions based on assignment target type
- emit collection initializers for arbitrary collection types with Add methods
- add regression test ensuring target-typed collection expressions initialize custom lists

## Testing
- `dotnet build`
- `dotnet test` *(fails: PropertyBindingTests.AccessingStaticPropertyAsInstance_ProducesDiagnostic, PropertyBindingTests.AccessingInstancePropertyAsStatic_ProducesDiagnostic, VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal, FieldInitializationTests.InstanceAndStaticFieldInitializers_AreEmitted, SampleProgramsTests.Sample_should_compile_and_run)*
- `dotnet test --filter Sample_should_compile_and_run` *(logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68ac569dc1d0832fbfaf7b562376b9fe