### PR TITLE
test: centralize assembly loading for runtime tests

### DIFF
--- a/docs/compiler/development/testing/runtime-assembly-loading.md
+++ b/docs/compiler/development/testing/runtime-assembly-loading.md
@@ -1,0 +1,16 @@
+# Runtime assembly loading in tests
+
+Some code generation tests need to execute emitted IL. Use the `TestAssemblyLoader` helper to load compiled assemblies with dependency resolution:
+
+```csharp
+var compilation = CreateCompilation(source, references);
+using var peStream = new MemoryStream();
+compilation.Emit(peStream);
+
+using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+var type = loaded.Assembly.GetType("Program");
+```
+
+`TestAssemblyLoader` creates a collectible `AssemblyLoadContext` and resolves dependencies from the provided metadata references. This allows tests to run compiled code without polluting the default context.
+
+When compiling, reference assemblies should be resolved using the fixed target framework defined by `TestTargetFramework.Default` to avoid mismatches with locally installed SDKs.

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -40,3 +40,9 @@
       href: development/cil.md
     - name: Resources
       href: development/resources.md
+    - name: Testing
+      items:
+        - name: Verifying diagnostics
+          href: development/testing/verifying-diagnostics.md
+        - name: Runtime assembly loading
+          href: development/testing/runtime-assembly-loading.md

--- a/src/Raven.CodeAnalysis.Testing/DiagnosticTestBase.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticTestBase.cs
@@ -14,7 +14,7 @@ public abstract class DiagnosticTestBase
                 /*
                 State = new TestState
                 {
-                    var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+                    var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
                     ReferenceAssemblies = [.. TargetFrameworkResolver.GetReferenceAssemblies(version).Select(x => MetadataReference.CreateFromFile(x))],
                 }
                 */

--- a/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
@@ -241,7 +241,7 @@ public static class ReferenceAssemblies
 
     private static MetadataReference[] GeReferences()
     {
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         return TargetFrameworkResolver.GetReferenceAssemblies(version).Select(path => MetadataReference.CreateFromFile(path)).ToArray();
     }
 }

--- a/src/Raven.CodeAnalysis.Testing/TestTargetFramework.cs
+++ b/src/Raven.CodeAnalysis.Testing/TestTargetFramework.cs
@@ -1,0 +1,7 @@
+namespace Raven.CodeAnalysis.Testing;
+
+public static class TestTargetFramework
+{
+    public const string Default = "net9.0";
+}
+

--- a/test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/MetadataReferenceLoadingTests.cs
@@ -1,4 +1,5 @@
 using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Tests.Bugs;
 
@@ -7,7 +8,7 @@ public class MetadataReferenceLoadingTests
     [Fact]
     public void GetTypeByMetadataName_LoadsReferences_WhenNoSyntaxTrees()
     {
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var referencePaths = TargetFrameworkResolver.GetReferenceAssemblies(version);
         var references = referencePaths.Select(MetadataReference.CreateFromFile).ToArray();
 

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 
 using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Tests;
 
@@ -19,7 +20,7 @@ class Foo {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
 
         var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
 

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System.IO;
 using System.Reflection;
 
 using Raven.CodeAnalysis.Syntax;
@@ -26,13 +26,7 @@ class Foo {
 """;
 
         var syntaxTree = SyntaxTree.ParseText(code);
-
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-            MetadataReference.CreateFromFile(runtimePath)
-        ];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -42,12 +36,8 @@ class Foo {
         var result = compilation.Emit(peStream);
         Assert.True(result.Success);
 
-        peStream.Seek(0, SeekOrigin.Begin);
-
-        var resolver = new PathAssemblyResolver(references.Select(r => ((PortableExecutableReference)r).FilePath));
-        using var mlc = new MetadataLoadContext(resolver);
-
-        var assembly = mlc.LoadFromStream(peStream);
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
         var type = assembly.GetType("Foo", true);
         var instance = Activator.CreateInstance(type!);
         var itemsCountProp = type!.GetProperty("ItemsCount");

--- a/test/Raven.CodeAnalysis.Tests/ReferenceAssemblyPathsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/ReferenceAssemblyPathsTests.cs
@@ -1,4 +1,5 @@
 using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Testing;
 using Xunit;
 
 namespace Raven.CodeAnalysis.Tests;
@@ -8,7 +9,7 @@ public class ReferenceAssemblyPathsTests
     [Fact]
     public void GetReferenceAssemblyDir_accepts_version_without_wildcard()
     {
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var shortVer = version.Moniker.Version.ToString();
         var dir = ReferenceAssemblyPaths.GetReferenceAssemblyDir(shortVer, version.Moniker.ToTfm());
         Assert.False(string.IsNullOrEmpty(dir));

--- a/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 using Raven.CodeAnalysis.Syntax;
-
+using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Tests;
 
@@ -88,7 +88,7 @@ public partial class SampleProgramsTests(ITestOutputHelper testOutput)
         if (File.Exists(testDep))
             File.Copy(testDep, testDepOutputPath, overwrite: true);
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
         var compilation = Compilation.Create("samples", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
@@ -113,7 +113,7 @@ public partial class SampleProgramsTests(ITestOutputHelper testOutput)
 
         var tree = SyntaxTree.ParseText(source);
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
         var compilation = Compilation.Create("samples", [tree], new CompilationOptions(OutputKind.ConsoleApplication))

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
@@ -1,4 +1,5 @@
 using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Syntax.Tests;
 
@@ -62,7 +63,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         #region Compilation
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
@@ -110,7 +111,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
@@ -141,7 +142,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
@@ -174,7 +175,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))

--- a/test/Raven.CodeAnalysis.Tests/TargetFrameworkResolverTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/TargetFrameworkResolverTests.cs
@@ -1,0 +1,14 @@
+using Raven.CodeAnalysis;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class TargetFrameworkResolverTests
+{
+    [Fact]
+    public void ResolveLatestInstalledVersion_returns_installed_framework()
+    {
+        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        Assert.False(string.IsNullOrWhiteSpace(version.ToFrameworkString()));
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/TestAssemblyLoader.cs
+++ b/test/Raven.CodeAnalysis.Tests/TestAssemblyLoader.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+using Raven.CodeAnalysis;
+
+namespace Raven.CodeAnalysis.Tests;
+
+internal static class TestAssemblyLoader
+{
+    internal sealed class LoadedAssembly : IDisposable
+    {
+        private readonly AssemblyLoadContext _context;
+        public Assembly Assembly { get; }
+
+        public LoadedAssembly(Assembly assembly, AssemblyLoadContext context)
+        {
+            Assembly = assembly;
+            _context = context;
+        }
+
+        public void Dispose() => _context.Unload();
+    }
+
+    public static LoadedAssembly LoadFromStream(Stream peStream, IEnumerable<MetadataReference> references)
+    {
+        peStream.Position = 0;
+
+        var refPaths = references
+            .OfType<PortableExecutableReference>()
+            .Select(r => r.FilePath)
+            .Where(p => p is not null)
+            .ToArray();
+
+        var alc = new AssemblyLoadContext("RavenTests", isCollectible: true);
+        alc.Resolving += (context, name) =>
+        {
+            var candidate = refPaths.FirstOrDefault(p =>
+                string.Equals(Path.GetFileNameWithoutExtension(p), name.Name, StringComparison.OrdinalIgnoreCase));
+            return candidate is not null ? context.LoadFromAssemblyPath(candidate) : null;
+        };
+
+        var assembly = alc.LoadFromStream(peStream);
+        return new LoadedAssembly(assembly, alc);
+    }
+}
+

--- a/test/Raven.CodeAnalysis.Tests/TestMetadataReferences.cs
+++ b/test/Raven.CodeAnalysis.Tests/TestMetadataReferences.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
-using Raven.CodeAnalysis;
 using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Tests;
 
@@ -9,15 +11,14 @@ internal static class TestMetadataReferences
 {
     private static readonly Lazy<(string tfm, MetadataReference[] refs)> s_default = new(() =>
     {
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refs = TargetFrameworkResolver.GetReferenceAssemblies(version)
             .Where(File.Exists)
             .Select(MetadataReference.CreateFromFile)
             .ToArray();
-        return (version.Moniker.ToTfm(), refs);
+        return (TestTargetFramework.Default, refs);
     });
 
     public static string TargetFramework => s_default.Value.tfm;
     public static MetadataReference[] Default => s_default.Value.refs;
 }
-

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/DocumentTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
+using Raven.CodeAnalysis.Testing;
 
 using Xunit;
 
@@ -92,7 +93,7 @@ public class DocumentTests
         solution = solution.AddDocument(docId, "Test.rvn", source);
         var document = solution.GetDocument(docId)!;
 
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
         var project = document.Project.AddMetadataReference(

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -6,10 +6,11 @@ using Raven.CodeAnalysis;
 
 class Program
 {
+    private const string TargetFramework = "net9.0";
     static void Main()
     {
         var compilation = Compilation.Create("test", options: new CompilationOptions(OutputKind.ConsoleApplication));
-        var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
+        var version = TargetFrameworkResolver.ResolveVersion(TargetFramework);
         var refDir = TargetFrameworkResolver.GetDirectoryPath(version);
         var references = new[]
         {


### PR DESCRIPTION
## Summary
- add `TestAssemblyLoader` to load compiled assemblies with dependency resolution
- refactor runtime codegen tests to use new assembly loader and pin reference assemblies to `net9.0`
- add coverage for `ResolveLatestInstalledVersion` and document runtime assembly loading for tests

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/TargetFrameworkResolverTests.cs,docs/compiler/development/testing/runtime-assembly-loading.md,docs/compiler/toc.yml --verbosity diagnostic`
- `dotnet build`
- `dotnet test` *(fails: ArgumentOutOfRangeException in MSBuild TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67ccbf50832f81a5ed45b0502c9b