### PR TITLE
feat: allow implicit void return

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/LocalFunctionBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/LocalFunctionBinder.cs
@@ -33,7 +33,9 @@ class LocalFunctionBinder : Binder
         //ISymbol container = null; //this.ContainingSymbol;
         var container = Compilation.SourceGlobalNamespace.LookupType("Program") as INamedTypeSymbol;
 
-        var returnType = ResolveType(_syntax.ReturnType.Type);
+        var returnType = _syntax.ReturnType is null
+            ? Compilation.GetSpecialType(SpecialType.System_Void)
+            : ResolveType(_syntax.ReturnType.Type);
 
         _methodSymbol = new SourceMethodSymbol(
             _syntax.Identifier.Text,

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -362,7 +362,7 @@
     <Slot Name="FuncKeyword" Type="Token" />
     <Slot Name="Identifier" Type="Token" />
     <Slot Name="ParameterList" Type="ParameterList" />
-    <Slot Name="ReturnType" Type="ArrowTypeClause" />
+    <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="Body" Type="Block" IsNullable="true" />
     <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
   </Node>
@@ -375,7 +375,7 @@
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" />
     <Slot Name="ParameterList" Type="ParameterList" IsInherited="true" />
-    <Slot Name="ReturnType" Type="ArrowTypeClause" />
+    <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="Body" Type="Block" IsNullable="true" IsInherited="true" />
     <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" IsInherited="true" />
     <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -218,8 +218,10 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
         var parameterList = (ParameterListSyntax)VisitParameterList(node.ParameterList)!
             .WithTrailingTrivia(SyntaxFactory.Space);
 
-        var returnType = (ArrowTypeClauseSyntax)VisitArrowTypeClause(node.ReturnType)!
-            .WithTrailingTrivia(SyntaxFactory.Space);
+        ArrowTypeClauseSyntax? returnType = null;
+        if (node.ReturnType is not null)
+            returnType = (ArrowTypeClauseSyntax)VisitArrowTypeClause(node.ReturnType)!
+                .WithTrailingTrivia(SyntaxFactory.Space);
 
         return node.Update(node.Modifiers, identifier, parameterList, returnType, (BlockSyntax?)VisitBlock(node.Body), null, node.TerminatorToken)
             .WithLeadingTrivia(SyntaxFactory.TriviaList(

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LocalFunctionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LocalFunctionTests.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Tests;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class LocalFunctionTests
+{
+    [Fact]
+    public void LocalFunction_WithoutReturnType_DefaultsToVoid()
+    {
+        var source = """
+func outer() {
+    func inner() { }
+}
+""";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var model = compilation.GetSemanticModel(tree);
+        var inner = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single(l => l.Identifier.Text == "inner");
+        var symbol = (IMethodSymbol)model.GetDeclaredSymbol(inner)!;
+        Assert.Equal(SpecialType.System_Void, symbol.ReturnType.SpecialType);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs
@@ -13,7 +13,7 @@ public class SemanticModelDiagnosticsTests
     {
         var source = """
 class Test {
-    M() -> void {
+    M() {
         1();
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs
@@ -10,7 +10,7 @@ public class SymbolQueryTests : DiagnosticTestBase
         string testCode =
             """
             class Foo {
-                M() -> void {}
+                M() {}
             }
 
             Foo.M();


### PR DESCRIPTION
## Summary
- make return type arrow optional for methods and local functions
- normalize and bind methods with implicit void returns
- cover implicit void via local function and semantic tests

## Testing
- `dotnet build`
- `dotnet test` *(fails: VersionStampTests and SampleProgramsTests failures)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: sample programs fail to run)*

------
https://chatgpt.com/codex/tasks/task_e_68ac71051674832f976fb86b71912b65