### PR TITLE
fix: allow missing terminator before closing brace

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/AliasDirectiveSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/AliasDirectiveSyntaxParser.cs
@@ -31,13 +31,7 @@ internal class AliasDirectiveSyntaxParser : SyntaxParser
 
         SetTreatNewlinesAsTokens(true);
 
-        if (!TryConsumeTerminator(out var terminatorToken))
-        {
-            AddDiagnostic(
-                DiagnosticInfo.Create(
-                    CompilerDiagnostics.SemicolonExpected,
-                    GetEndOfLastToken()));
-        }
+        TryConsumeTerminator(out var terminatorToken);
 
         SetTreatNewlinesAsTokens(false);
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ImportDirectiveSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ImportDirectiveSyntaxParser.cs
@@ -31,13 +31,7 @@ internal class ImportDirectiveSyntaxParser : SyntaxParser
 
         SetTreatNewlinesAsTokens(true);
 
-        if (!TryConsumeTerminator(out var terminatorToken))
-        {
-            AddDiagnostic(
-                DiagnosticInfo.Create(
-                    CompilerDiagnostics.SemicolonExpected,
-                    GetEndOfLastToken()));
-        }
+        TryConsumeTerminator(out var terminatorToken);
 
         SetTreatNewlinesAsTokens(false);
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -55,10 +55,7 @@ internal class StatementSyntaxParser : SyntaxParser
 
         var block = new ExpressionSyntaxParser(this).ParseBlockSyntax();
 
-        if (!TryConsumeTerminator(out var terminatorToken))
-        {
-
-        }
+        TryConsumeTerminator(out var terminatorToken);
 
         return LocalFunctionStatement(funcKeyword, identifier, parameterList, returnParameterAnnotation, block, terminatorToken);
     }
@@ -118,12 +115,7 @@ internal class StatementSyntaxParser : SyntaxParser
 
         if (!TryConsumeTerminator(out var terminatorToken))
         {
-            terminatorToken = SkipUntil(SyntaxKind.NewLineToken, SyntaxKind.SemicolonToken);
-
-            AddDiagnostic(
-                DiagnosticInfo.Create(
-                    CompilerDiagnostics.SemicolonExpected,
-                    GetFullSpanOfLastToken()));
+            SkipUntil(SyntaxKind.NewLineToken, SyntaxKind.SemicolonToken);
         }
 
         return ReturnStatement(returnKeyword, expression, terminatorToken, Diagnostics);
@@ -231,13 +223,7 @@ internal class StatementSyntaxParser : SyntaxParser
         {
             SetTreatNewlinesAsTokens(true);
 
-            if (!TryConsumeTerminator(out terminatorToken))
-            {
-                AddDiagnostic(
-                    DiagnosticInfo.Create(
-                        CompilerDiagnostics.SemicolonExpected,
-                        GetEndOfLastToken()));
-            }
+            TryConsumeTerminator(out terminatorToken);
         }
 
         return terminatorToken;

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -204,7 +204,7 @@ internal class StatementSyntaxParser : SyntaxParser
             return ExpressionStatement(expression, terminatorToken2, Diagnostics);
         }
 
-        SyntaxToken? terminatorToken = ConsumeTerminator();
+        var terminatorToken = ConsumeTerminator();
 
         return ExpressionStatement(expression, terminatorToken, Diagnostics);
     }
@@ -215,7 +215,7 @@ internal class StatementSyntaxParser : SyntaxParser
     {
         var declaration = ParseVariableDeclarationSyntax();
 
-        SyntaxToken? terminatorToken = ConsumeTerminator();
+        var terminatorToken = ConsumeTerminator();
 
         return LocalDeclarationStatement(declaration, terminatorToken, Diagnostics);
     }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -124,7 +124,7 @@ internal class SyntaxParser : ParseContext
             }
         }
 
-        token = null!;
+        token = MissingToken(SyntaxKind.SemicolonToken);
         return false;
     }
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -124,7 +124,11 @@ internal class SyntaxParser : ParseContext
             }
         }
 
-        token = MissingToken(SyntaxKind.SemicolonToken);
+        token = MissingToken(SyntaxKind.NewLineToken);
+        AddDiagnostic(
+            DiagnosticInfo.Create(
+                CompilerDiagnostics.SemicolonExpected,
+                GetEndOfLastToken()));
         return false;
     }
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -105,6 +105,13 @@ internal class SyntaxParser : ParseContext
         if (ConsumeToken(SyntaxKind.EndOfFileToken, out token))
             return true;
 
+        // Allow end of block when statement is last in a block
+        if (IsNextToken(SyntaxKind.CloseBraceToken))
+        {
+            token = Token(SyntaxKind.None);
+            return true;
+        }
+
         // If newlines are tokens, check if it's a valid terminator
         if (TreatNewlinesAsTokens && IsNewLineToken(PeekToken()))
         {

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -407,13 +407,7 @@ internal class TypeDeclarationParser : SyntaxParser
 
         SetTreatNewlinesAsTokens(true);
 
-        if (!TryConsumeTerminator(out var terminatorToken))
-        {
-            AddDiagnostic(
-                DiagnosticInfo.Create(
-                    CompilerDiagnostics.SemicolonExpected,
-                    GetEndOfLastToken()));
-        }
+        TryConsumeTerminator(out var terminatorToken);
 
         return FieldDeclaration(modifiers, declaration, terminatorToken, Diagnostics);
     }

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -52,7 +52,7 @@
     <Slot Name="Aliases" Type="List" ElementType="AliasDirective" IsInherited="true" />
     <Slot Name="Members" Type="List" ElementType="MemberDeclaration" IsInherited="true" />
     <Slot Name="CloseBraceToken" Type="Token" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="UnaryExpression" Inherits="Expression" HasExplicitKind="true">
     <Slot Name="OperatorToken" Type="Token" />
@@ -73,21 +73,21 @@
     <Slot Name="OpenBraceToken" Type="Token" IsInherited="true" />
     <Slot Name="Members" Type="List" ElementType="MemberDeclaration" IsInherited="true" />
     <Slot Name="CloseBraceToken" Type="Token" IsInherited="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" IsInherited="true" />
+    <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
   <Node Name="ExpressionStatement" Inherits="Statement">
     <Slot Name="Expression" Type="Expression" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="LocalDeclarationStatement" Inherits="Statement">
     <Slot Name="Declaration" Type="VariableDeclaration" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BaseTypeDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
     <Slot Name="Identifier" Type="Token" IsAbstract="true" />
     <Slot Name="OpenBraceToken" Type="Token" IsAbstract="true" />
     <Slot Name="CloseBraceToken" Type="Token" IsAbstract="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" IsAbstract="true" />
+    <Slot Name="TerminatorToken" Type="Token" IsAbstract="true" />
   </Node>
   <Node Name="TupleExpression" Inherits="Expression">
     <Slot Name="OpenParenToken" Type="Token" />
@@ -104,7 +104,7 @@
   </Node>
   <Node Name="BaseConstructorDeclaration" Inherits="BaseMethodDeclaration" IsAbstract="true">
     <Slot Name="InitKeyword" Type="Token" IsAbstract="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" IsAbstract="true" />
+    <Slot Name="TerminatorToken" Type="Token" IsAbstract="true" />
   </Node>
   <Node Name="ConstructorDeclaration" Inherits="BaseConstructorDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
@@ -112,7 +112,7 @@
     <Slot Name="ParameterList" Type="ParameterList" IsInherited="true" />
     <Slot Name="Body" Type="Block" IsNullable="true" IsInherited="true" />
     <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" IsInherited="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" IsInherited="true" />
+    <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
   <Node Name="NamedConstructorDeclaration" Inherits="BaseConstructorDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
@@ -121,12 +121,12 @@
     <Slot Name="ParameterList" Type="ParameterList" IsInherited="true" />
     <Slot Name="Body" Type="Block" IsNullable="true" IsInherited="true" />
     <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" IsInherited="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" IsInherited="true" />
+    <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
   <Node Name="ReturnStatement" Inherits="Statement">
     <Slot Name="ReturnKeyword" Type="Token" />
     <Slot Name="Expression" Type="Expression" IsNullable="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="CompilationUnit" Inherits="Node">
     <Slot Name="Imports" Type="List" ElementType="ImportDirective" />
@@ -250,7 +250,7 @@
   <Node Name="FieldDeclaration" Inherits="MemberDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Declaration" Type="VariableDeclaration" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BasePropertyDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
     <Slot Name="Identifier" Type="Token" IsAbstract="true" />
@@ -301,7 +301,7 @@
     <Slot Name="OpenBraceToken" Type="Token" IsInherited="true" />
     <Slot Name="Members" Type="SeparatedList" ElementType="EnumMemberDeclaration" />
     <Slot Name="CloseBraceToken" Type="Token" IsInherited="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" IsInherited="true" />
+    <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
   <Node Name="IndexerDeclaration" Inherits="BasePropertyDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
@@ -310,7 +310,7 @@
     <Slot Name="Type" Type="TypeAnnotationClause" IsInherited="true" />
     <Slot Name="AccessorList" Type="AccessorList" IsNullable="true" IsInherited="true" />
     <Slot Name="Initializer" Type="EqualsValueClause" IsNullable="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="WhileExpression" Inherits="Expression">
     <Slot Name="WhileKeyword" Type="Token" />
@@ -335,7 +335,7 @@
     <Slot Name="Type" Type="TypeAnnotationClause" IsInherited="true" />
     <Slot Name="AccessorList" Type="AccessorList" IsNullable="true" IsInherited="true" />
     <Slot Name="Initializer" Type="EqualsValueClause" IsNullable="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BinaryExpression" Inherits="Expression" HasExplicitKind="true">
     <Slot Name="LeftHandSide" Type="Expression" />
@@ -364,7 +364,7 @@
     <Slot Name="ParameterList" Type="ParameterList" />
     <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="Body" Type="Block" IsNullable="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="ObjectCreationExpression" Inherits="Expression">
     <Slot Name="NewKeyword" Type="Token" />
@@ -378,7 +378,7 @@
     <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="Body" Type="Block" IsNullable="true" IsInherited="true" />
     <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" IsInherited="true" />
-    <Slot Name="TerminatorToken" Type="Token" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BracketedParameterList" Inherits="Node">
     <Slot Name="OpenBracketToken" Type="Token" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
@@ -138,7 +138,6 @@ public class ParserNewlineTests
         var returnStatement = block.Statements.OfType<ReturnStatementSyntax>().Single();
 
         var terminator = returnStatement.TerminatorToken;
-        Assert.True(terminator.HasValue);
-        Assert.Equal(SyntaxKind.None, terminator.GetValueOrDefault().Kind);
+        Assert.Equal(SyntaxKind.None, terminator.Kind);
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
@@ -126,6 +126,29 @@ public class ParserNewlineTests
     }
 
     [Fact]
+    public void Statement_MissingTerminator_ReturnsMissingNewLineToken()
+    {
+        var source = "let x = 1 let y = 2";
+        var lexer = new Lexer(new StringReader(source));
+        var context = new BaseParseContext(lexer);
+        context.SetTreatNewlinesAsTokens(true);
+
+        var parser = new SyntaxParser(context);
+
+        parser.ExpectToken(SyntaxKind.LetKeyword);
+        parser.ExpectToken(SyntaxKind.IdentifierToken);
+        parser.ExpectToken(SyntaxKind.EqualsToken);
+        parser.ExpectToken(SyntaxKind.NumericLiteralToken);
+
+        var result = parser.TryConsumeTerminator(out var terminator);
+
+        Assert.False(result);
+        Assert.Equal(SyntaxKind.NewLineToken, terminator.Kind);
+        var diagnostic = Assert.Single(parser.Diagnostics);
+        Assert.Equal(CompilerDiagnostics.SemicolonExpected, diagnostic.Descriptor);
+    }
+
+    [Fact]
     public void Block_LastStatementWithoutTerminator_UsesNoneToken()
     {
         var source = "{ return \"\" }";


### PR DESCRIPTION
## Summary
- treat `}` as a valid statement terminator by returning a `SyntaxKind.None` token
- add parser tests for block statements without terminators

## Testing
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(failed: VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal)*
- `dotnet test --filter Sample_should_compile_and_run` *(failed: Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75b12ccc832f93fd02f72d2f0a25