### PR TITLE
feat: support aliasing members and overloads

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1353,6 +1353,20 @@ partial class BlockBinder : Binder
                         if (seen.Add(member))
                             yield return member;
                 }
+
+                foreach (var type in importBinder.GetImportedTypes())
+                {
+                    if (type.Name == name && seen.Add(type))
+                        yield return type;
+                }
+
+                var aliasMap = importBinder.GetAliases();
+                if (aliasMap.TryGetValue(name, out var symbols))
+                {
+                    foreach (var symbol in symbols)
+                        if (seen.Add(symbol))
+                            yield return symbol;
+                }
             }
 
             current = current.ParentBinder;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -34,4 +34,19 @@ public class AliasResolutionTest : DiagnosticTestBase
         verifier.Verify();
     }
 
+    [Fact]
+    public void AliasDirective_UsesMemberAlias_Method()
+    {
+        string testCode =
+            """
+            alias PrintLine = System.Console.WriteLine
+
+            PrintLine(123)
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
 }


### PR DESCRIPTION
## Summary
- allow aliasing methods, fields and properties by mapping identifiers to lists of symbols
- ensure overload sets for method aliases are discoverable during binding
- add regression test for member alias invocation

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs,src/Raven.CodeAnalysis/Binder/ImportBinder.cs,src/Raven.CodeAnalysis/Binder/BinderFactory.cs,src/Raven.CodeAnalysis/SemanticModel.cs,test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: Could not observe local increment within the same tick)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run(fileName: "test2.rav", args: []))*

------
https://chatgpt.com/codex/tasks/task_e_68acc198d07c832f843717b085b0e6d9