### PR TITLE
fix: support generic type aliases in annotations

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -685,6 +685,21 @@ partial class BlockBinder : Binder
 
         if (symbol is ITypeSymbol type && type is INamedTypeSymbol named)
         {
+            // If the resolved symbol is already a constructed generic type (e.g., from an alias
+            // like `alias StringList = System.Collections.Generic.List<string>`), then we don't
+            // expect any additional type arguments when the alias is used. Return the constructed
+            // type directly.
+            if (named.ConstructedFrom is not null)
+            {
+                if (!typeArguments.IsEmpty)
+                {
+                    //_diagnostics.ReportTypeArityMismatch(name, named.Arity, typeArguments.Length, location);
+                    return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.TypeMismatch);
+                }
+
+                return new BoundTypeExpression(named);
+            }
+
             if (named.Arity != typeArguments.Length)
             {
                 //_diagnostics.ReportTypeArityMismatch(name, named.Arity, typeArguments.Length, location);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -35,6 +35,21 @@ public class AliasResolutionTest : DiagnosticTestBase
     }
 
     [Fact]
+    public void AliasDirective_UsesAlias_AsTypeAnnotation()
+    {
+        string testCode =
+            """
+            alias StringList = System.Collections.Generic.List<string>
+
+            let list: StringList
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void AliasDirective_UsesMemberAlias_Method()
     {
         string testCode =


### PR DESCRIPTION
## Summary
- allow use of generic type aliases as type annotations
- test alias resolution when used in type annotations

## Testing
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: Could not observe local increment within the same tick)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run(fileName: "test2.rav", args: []), Sample_should_compile_and_run(fileName: "enums.rav", args: []), Sample_should_compile_and_run(fileName: "arrays.rav", args: []), Sample_should_compile_and_run(fileName: "tuples.rav", args: []), Sample_should_compile_and_run(fileName: "io.rav", args: ["."]), Sample_should_compile_and_run(fileName: "general.rav", args: []))*

------
https://chatgpt.com/codex/tasks/task_e_68acc510d6b8832f8b0ada66fd666d8a