### PR TITLE
fix: support generic type invocation

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ObjectCreationTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ObjectCreationTests.cs
@@ -103,5 +103,21 @@ public class ObjectCreationTests : DiagnosticTestBase
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void GenericTypeInvocationCreatesObject()
+    {
+        string testCode =
+            """
+            import System.Collections.Generic.List<>
+
+            let list = List<int>()
+            list.Add(1)
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow invocation of generic type names to bind constructors
- test object creation for generic types

## Testing
- `dotnet build`
- `dotnet test` *(fails: VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68acc8b03cf4832fbd282c7946b947ac