### PR TITLE
feat: parse interpolated strings

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -50,6 +50,9 @@ internal class BoundTreeWalker : BoundTreeVisitor
             case BoundBlockExpression block:
                 VisitBlockExpression(block);
                 break;
+            case BoundParenthesizedExpression paren:
+                VisitParenthesizedExpression(paren);
+                break;
             case BoundMemberAccessExpression memberAccess:
                 VisitMemberAccessExpression(memberAccess);
                 break;
@@ -118,5 +121,10 @@ internal class BoundTreeWalker : BoundTreeVisitor
         {
             VisitStatement(s);
         }
+    }
+
+    public override void VisitParenthesizedExpression(BoundParenthesizedExpression node)
+    {
+        VisitExpression(node.Expression);
     }
 }

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -137,6 +137,18 @@
   <Node Name="LiteralExpression" Inherits="Expression" HasExplicitKind="true">
     <Slot Name="Token" Type="Token" />
   </Node>
+  <Node Name="InterpolatedStringExpression" Inherits="Expression">
+    <Slot Name="Contents" Type="List" ElementType="InterpolatedStringContent" />
+  </Node>
+  <Node Name="InterpolatedStringContent" Inherits="Node" IsAbstract="true" />
+  <Node Name="InterpolatedStringText" Inherits="InterpolatedStringContent">
+    <Slot Name="Token" Type="Token" />
+  </Node>
+  <Node Name="Interpolation" Inherits="InterpolatedStringContent">
+    <Slot Name="OpenBraceToken" Type="Token" />
+    <Slot Name="Expression" Type="Expression" />
+    <Slot Name="CloseBraceToken" Type="Token" />
+  </Node>
   <Node Name="BaseNamespaceDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
     <Slot Name="Name" Type="Name" IsAbstract="true" />
     <Slot Name="Imports" Type="List" ElementType="ImportDirective" IsAbstract="true" />

--- a/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
+++ b/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
@@ -8,6 +8,9 @@
   <NodeKind Name="CharacterLiteralExpression" Type="LiteralExpression" />
   <NodeKind Name="StringLiteralExpression" Type="LiteralExpression" />
   <NodeKind Name="NullLiteralExpression" Type="LiteralExpression" />
+  <NodeKind Name="InterpolatedStringExpression" Type="Expression" />
+  <NodeKind Name="InterpolatedStringText" Type="InterpolatedStringContent" />
+  <NodeKind Name="Interpolation" Type="InterpolatedStringContent" />
   <NodeKind Name="UnaryPlusExpression" Type="UnaryExpression" />
   <NodeKind Name="UnaryMinusExpression" Type="UnaryExpression" />
   <NodeKind Name="LogicalNotExpression" Type="UnaryExpression" />

--- a/src/Raven.Compiler/samples/main.rav
+++ b/src/Raven.Compiler/samples/main.rav
@@ -6,7 +6,7 @@ let builder = new StringBuilder()
 
 for each value in data {
     let status = getStatus(value)
-    builder.AppendLine("Value: " + value.ToString() + ", Status: " + status.ToString())
+    builder.AppendLine("Value: ${value.ToString()}, Status: ${status.ToString()}")
 
     if status == .Error {
         Console.WriteLine("Critical value: " + value.ToString())

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/StringInterpolationTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/StringInterpolationTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class StringInterpolationTests
+{
+    [Fact]
+    public void InterpolatedString_FormatsCorrectly()
+    {
+        var code = """
+class Test {
+    GetInfo(name: string, age: int, year: int) -> string {
+        return "Name: ${name}, Age in ${year}: ${year - (System.DateTime.Now.Year - age)}";
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var type = loaded.Assembly.GetType("Test", true);
+        var instance = Activator.CreateInstance(type!);
+        var method = type!.GetMethod("GetInfo");
+
+        var name = "Alice";
+        var age = 30;
+        var year = 2030;
+        var expected = $"Name: {name}, Age in {year}: {year - (System.DateTime.Now.Year - age)}";
+        var actual = (string)method!.Invoke(instance, new object[] { name, age, year })!;
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary
- add syntax nodes for interpolated strings
- parse `${...}` segments into `InterpolatedStringExpression`
- bind interpolated strings by concatenating text and expression parts

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/NodeKinds.xml,src/Raven.CodeAnalysis/Syntax/Model.xml,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` (fails: VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal)
- `dotnet test --filter Sample_should_compile_and_run` (fails: SampleProgramsTests.Sample_should_compile_and_run)
- `dotnet test --filter InterpolatedString_FormatsCorrectly`

------
https://chatgpt.com/codex/tasks/task_e_68acf11e759c832f8852e50e0e4054a5