### PR TITLE
feat: support invocation operator

### DIFF
--- a/docs/lang/proposals/invocation-operator.md
+++ b/docs/lang/proposals/invocation-operator.md
@@ -1,10 +1,10 @@
 # Proposal: Invocation operator
 
-> ℹ️ This proposal has **NOT** been implemented
+> ℹ️ This feature has been implemented
 
 This document outlines how to define an invocation operator which makes an object behave like a callable function object.
 
-Yoy can define one or more unique invocation operators for your type.
+You can define one or more unique invocation operators for your type.
 
 ## Syntax
 
@@ -50,3 +50,4 @@ var x = test.Invoke(2);
 ## Notes
 
 The `Invoke` method mirrors the one of delegates.
+

--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -53,9 +53,11 @@ internal class TypeMemberBinder : Binder
 
     private ISymbol? BindMethodSymbol(MethodDeclarationSyntax method)
     {
+        var name = method.Identifier.Kind == SyntaxKind.SelfKeyword ? "Invoke" : method.Identifier.Text;
+
         return _containingType.GetMembers()
             .OfType<IMethodSymbol>()
-            .FirstOrDefault(m => m.Name == method.Identifier.Text &&
+            .FirstOrDefault(m => m.Name == name &&
                                  m.DeclaringSyntaxReferences.Any(r => r.GetSyntax() == method));
     }
 
@@ -138,8 +140,10 @@ internal class TypeMemberBinder : Binder
             ? Compilation.GetSpecialType(SpecialType.System_Void)
             : ResolveType(methodDecl.ReturnType.Type);
 
+        var name = methodDecl.Identifier.Kind == SyntaxKind.SelfKeyword ? "Invoke" : methodDecl.Identifier.Text;
+
         var methodSymbol = new SourceMethodSymbol(
-            methodDecl.Identifier.Text,
+            name,
             returnType,
             ImmutableArray<SourceParameterSymbol>.Empty,
             _containingType,

--- a/src/Raven.Compiler/samples/classes.rav
+++ b/src/Raven.Compiler/samples/classes.rav
@@ -19,6 +19,9 @@ let user2 = Person.WithName("John")
 
 PrintLine(user2.Name)
 
+user2(2003);
+user2("test");
+
 class Person {
     let species = "Homo sapiens"
     var age: int = 0
@@ -59,12 +62,12 @@ class Person {
         set => roles[index] = value
     }
 
-    /*
-
     // Invocation operator: e.g., person(2025)
     public self(year: int) -> string {
-        return $"Name: {name}, Age in {year}: {year - (System.DateTime.Now.Year - age)}"
+        return "Name: ${name}, Age in ${year}: ${year - (System.DateTime.Now.Year - age)}"
     }
 
-    */
+    public self(str: string) {
+
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs
@@ -1,0 +1,31 @@
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class InvocationOperatorTests
+{
+    [Fact]
+    public void InvocationOperator_BindsToInvokeMethod()
+    {
+        var source = """
+class Test {
+    public self(no: int) -> int {
+        return no + 1;
+    }
+}
+let t = Test()
+let x = t(2)
+""";
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Last();
+        var symbol = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;
+        Assert.Equal("Invoke", symbol.Name);
+    }
+}
+


### PR DESCRIPTION
## Summary
- treat `self` methods as invocation operators emitting `Invoke`
- allow invoking objects with a `self` method
- document invocation operator and add semantic tests

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter InvocationOperatorTests`


------
https://chatgpt.com/codex/tasks/task_e_68acf7f6316c832f861792c7b5ed0769