### PR TITLE
feat: track TypeUnion flow through variables

### DIFF
--- a/test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs
+++ b/test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs
@@ -105,4 +105,25 @@ public static class External {
         var diagnostics = await GetDiagnosticsAsync(testSource, libRef);
         Assert.Contains(diagnostics, d => d.Id == "TU005");
     }
+
+    [Fact]
+    public async Task VariableDeclarationAndUsage_ReportInfoDiagnostics()
+    {
+        var source = @"
+using System;
+[AttributeUsage(AttributeTargets.ReturnValue | AttributeTargets.Parameter)]
+class TypeUnionAttribute : Attribute { public TypeUnionAttribute(params Type[] types) {} }
+class C {
+    [return: TypeUnion(typeof(int), typeof(string))]
+    static object M() => 1;
+    static void Test() {
+        object x = M();
+        var y = x;
+        Console.WriteLine(y);
+    }
+}";
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Contains(diagnostics, d => d.Id == "TU001" && d.GetMessage().Contains("Variable 'x'"));
+        Assert.Contains(diagnostics, d => d.Id == "TU001" && d.GetMessage().Contains("Variable 'y'"));
+    }
 }


### PR DESCRIPTION
## Summary
- propagate TypeUnion info through local variables
- report TU001 info on variable declarations and usages
- cover variable flow with unit test

## Testing
- `dotnet format Raven.sln --include src/TypeUnionAnalyzer/Analyzer.cs,test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs`
- `dotnet build`
- `dotnet test` *(fails: VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal; Sample_should_compile_and_run)*
- `dotnet test test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzer.Tests.csproj`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68ad90e651f0832fa01b7c54bf6eafad