### PR TITLE
feat: add alias symbols to semantic model

### DIFF
--- a/docs/compiler/architecture/semantic-binding.md
+++ b/docs/compiler/architecture/semantic-binding.md
@@ -15,11 +15,32 @@ Binders are an implementation detail of the `SemanticModel`, which is responsibl
 
 Due to their chained nature, they can ask a parent binder for a symbol if they cannot find it in their own scope. This allows for a hierarchical resolution of symbols
 
-Here are some of the key binder types:
+Binders are chained together so that each scope can fall back to its parent. The compiler creates them lazily as semantic analysis walks the syntax tree. The table below lists the main binder kinds, their responsibilities, and when they come into play.
 
-* `GlobalBinder` is the top-level binder that represents the entire compilation. It is responsible for binding global symbols, such as namespaces and types, and serves as the entry point for symbol resolution.
+| Binder | Responsibility | Created When | Parent |
+| --- | --- | --- | --- |
+| `GlobalBinder` | Root binder for the entire compilation and entry point for symbol lookup. | Once per compilation. | – |
+| `NamespaceBinder` | Tracks the current namespace and collects declared types. | Entering a namespace declaration or the global namespace. | `GlobalBinder` or another `NamespaceBinder` |
+| `ImportBinder` | Applies `import` directives and alias declarations. | After a `NamespaceBinder` is created for the file. | `NamespaceBinder` |
+| `CompilationUnitBinder` | Associates a syntax tree with its `SemanticModel`. | For each compilation unit. | `ImportBinder` |
+| `TopLevelBinder` | Binds global statements and synthesizes the entry point. | When a file contains top‑level statements. | `ImportBinder` |
+| `TypeDeclarationBinder` | Base binder for type declarations, establishing member scope. | For each type (class, enum, etc.). | `ImportBinder` or containing `TypeDeclarationBinder` |
+| `TypeMemberBinder` | Base binder for members declared in a type. | When binding a member. | `TypeDeclarationBinder` |
+| `MethodBinder` | Provides parameter symbols and method context. | Entering a method or local function declaration. | `TypeMemberBinder` |
+| `MethodBodyBinder` | Binds statements and locals inside a method body. | When binding a method's block. | `MethodBinder` |
+| `BlockBinder` | Represents a block scope. | Encountering a `{}` block. | `MethodBinder` or another `BlockBinder` |
+| `LocalScopeBinder` | Tracks nested scopes such as `if`, `while`, or `for` statements. | Entering a nested statement scope. | `BlockBinder` |
+| `LambdaBinder` | Binds lambda expressions. | Encountering a lambda expression. | `BlockBinder` or `MethodBinder` |
+| `LocalFunctionBinder` | Binds local function declarations. | Encountering a local function. | `BlockBinder` |
 
-* `BlockBinder` is a specific type of binder that is responsible for binding local variables and parameters within a method or block of code. It uses the `SemanticModel` to resolve symbols and check for any potential conflicts or errors.
+### Typical order
+From the outermost scope inward, binders typically appear in the following order:
+
+`GlobalBinder → NamespaceBinder → ImportBinder → CompilationUnitBinder → [TopLevelBinder] → TypeDeclarationBinder → MethodBinder → MethodBodyBinder → BlockBinder → LocalScopeBinder`
+
+### Visualizing binder hierarchy
+For debugging, a semantic model instance can print the active binder chain with `semanticModel.PrintBinderTree();`.
+The method produces a textual tree that shows how binders are nested for the current syntax tree.
 
 ## Bound tree
 

--- a/docs/lang/proposals/aliases.md
+++ b/docs/lang/proposals/aliases.md
@@ -2,11 +2,21 @@
 
 > ⚠️ 🧩 This proposal has been partly implemented
 
-This document outlines aliases - which allows you to define alternative names for types (incl. closed generic types) and static members.
+This document outlines aliases - which allow you to define alternative names for
+namespaces, types (including closed generic types), and static members.
 
 ## Syntax
 
-The `alias` directive appears at the top of a file, either outside or inside a namespace declaration.
+The `alias` directive appears at the top of a file, either outside or inside a
+namespace declaration.
+
+### Namespace alias
+
+```raven
+alias IO = System.IO
+```
+
+The name `IO` will be an alias for the `System.IO` namespace.
 
 ### Type alias
 
@@ -18,14 +28,18 @@ alias IntList = System.Collections.Generic.List<int>
 
 The name `SB` will be an alias for `System.StringBuilder`.
 
-The type aliased is required to be specified in fully qualified form (`System.StringBuilder`). This is to resolve ambiguities.
+The type aliased is required to be specified in fully qualified form
+(`System.StringBuilder`). This is to resolve ambiguities.
 
 ### Member alias
 
-For static members such as: methods, fields, or properties.
+For static members such as methods, fields, or properties. Aliasing a method
+binds a specific overload; repeat the directive with the same alias name to
+alias additional overloads.
 
 ```raven
 alias PrintLine = System.Console.WriteLine
 
 PrintLine("Test")
 ```
+

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -237,16 +237,22 @@ let pi = PI
 
 ### Alias directive
 
-The `alias` directive assigns an alternative name to a fully qualified type or
-static member.
+The `alias` directive assigns an alternative name to a fully qualified
+**namespace**, type, or static member.
 
 ```raven
+alias IO = System.IO
 alias SB = System.Text.StringBuilder
 alias PrintLine = System.Console.WriteLine
 
 let sb = SB()
 PrintLine("Hi")
+let tmp = IO.Path.GetTempPath()
 ```
+
+Aliasing a method binds a specific overload. Multiple directives using the
+same alias name may appear to alias additional overloads, forming an overload
+set.
 
 Aliases require fully qualified names to avoid ambiguity and may appear at the
 top of a file or inside a namespace alongside import directives.

--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -66,15 +66,23 @@ class BinderFactory
         var nsSymbol = _compilation.GetNamespaceSymbol(nsSyntax.Name.ToString());
         var nsBinder = new NamespaceBinder(parentBinder, nsSymbol!);
 
+        var namespaceImports = new List<INamespaceOrTypeSymbol>();
+        var typeImports = new List<ITypeSymbol>();
+        var aliases = new Dictionary<string, IReadOnlyList<IAliasSymbol>>();
+
+        var provisionalImportBinder = new ImportBinder(nsBinder, namespaceImports, typeImports, aliases);
+
         foreach (var importDirective in nsSyntax.Imports)
         {
             var importName = importDirective.Name.ToString();
 
             if (IsWildcard(importDirective.Name, out var nsName))
             {
-                var nsImport = ResolveNamespace(nsSymbol!, nsName.ToString());
+                INamespaceOrTypeSymbol? nsImport =
+                    (INamespaceOrTypeSymbol?)ResolveNamespace(nsSymbol!, nsName.ToString())
+                    ?? ResolveType(nsSymbol!, nsName.ToString());
                 if (nsImport != null)
-                    nsBinder.AddUsingDirective(nsImport);
+                    namespaceImports.Add(nsImport);
                 continue;
             }
 
@@ -86,14 +94,11 @@ class BinderFactory
             }
 
             ITypeSymbol? typeSymbol = HasTypeArguments(importDirective.Name)
-                ? ResolveGenericType(nsSymbol!, importDirective.Name)
+                ? ResolveOpenGenericType(nsSymbol!, importDirective.Name)
                 : ResolveType(nsSymbol!, importName);
 
             if (typeSymbol != null)
-            {
-                var alias = GetRightmostIdentifier(importDirective.Name);
-                nsBinder.AddAlias(alias, [typeSymbol]);
-            }
+                typeImports.Add(typeSymbol);
         }
 
         foreach (var aliasDirective in nsSyntax.Aliases)
@@ -101,11 +106,19 @@ class BinderFactory
             var symbols = ResolveAlias(nsSymbol!, aliasDirective.Name);
             if (symbols.Count > 0)
             {
-                nsBinder.AddAlias(aliasDirective.Identifier.Text, symbols);
+                var aliasSymbols = symbols
+                    .Select(s => AliasSymbolFactory.Create(aliasDirective.Identifier.Text, s))
+                    .ToArray();
+                aliases[aliasDirective.Identifier.Text] = aliasSymbols;
             }
         }
 
-        return nsBinder;
+        var importBinder = new ImportBinder(nsBinder, namespaceImports, typeImports, aliases);
+
+        foreach (var diagnostic in nsBinder.Diagnostics.AsEnumerable())
+            importBinder.Diagnostics.Report(diagnostic);
+
+        return importBinder;
 
         INamespaceSymbol? ResolveNamespace(INamespaceSymbol current, string name)
         {
@@ -121,14 +134,16 @@ class BinderFactory
 
         IReadOnlyList<ISymbol> ResolveAlias(INamespaceSymbol current, NameSyntax name)
         {
-            // First, attempt to resolve as a type
+            var nsSymbol = ResolveNamespace(current, name.ToString());
+            if (nsSymbol != null)
+                return [nsSymbol];
+
             ITypeSymbol? typeSymbol = HasTypeArguments(name)
                 ? ResolveGenericType(current, name)
                 : ResolveType(current, name.ToString());
             if (typeSymbol != null)
                 return [typeSymbol];
 
-            // Otherwise, attempt to resolve as a static member of a type
             if (name is QualifiedNameSyntax qn)
             {
                 var memberName = GetRightmostIdentifier(name);
@@ -166,7 +181,7 @@ class BinderFactory
                     return null;
 
                 var args = g.TypeArgumentList.Arguments
-                    .Select(a => nsBinder.ResolveType(a.Type))
+                    .Select(a => provisionalImportBinder.ResolveType(a.Type))
                     .ToArray();
                 return _compilation.ConstructGenericType(unconstructed, args);
             }
@@ -182,9 +197,40 @@ class BinderFactory
                     return null;
 
                 var args = gen.TypeArgumentList.Arguments
-                    .Select(a => nsBinder.ResolveType(a.Type))
+                    .Select(a => provisionalImportBinder.ResolveType(a.Type))
                     .ToArray();
                 return _compilation.ConstructGenericType(unconstructed, args);
+            }
+
+            return null;
+        }
+
+        ITypeSymbol? ResolveOpenGenericType(INamespaceSymbol current, NameSyntax name)
+        {
+            if (name is GenericNameSyntax g)
+            {
+                var baseName = g.Identifier.Text + "`" + g.TypeArgumentList.Arguments.SeparatorCount + 1;
+                var full = Combine(current, baseName);
+                var unconstructed = (INamedTypeSymbol?)_compilation.GetTypeByMetadataName(full)
+                    ?? (INamedTypeSymbol?)_compilation.GetTypeByMetadataName(baseName);
+                if (unconstructed is null)
+                    return null;
+
+                var args = g.TypeArgumentList.Arguments
+                    .Select(a => provisionalImportBinder.ResolveType(a.Type))
+                    .ToArray();
+                return _compilation.ConstructGenericType(unconstructed, args);
+            }
+
+            if (name is QualifiedNameSyntax { Right: GenericNameSyntax gen })
+            {
+                var leftName = ((QualifiedNameSyntax)name).Left.ToString();
+                var baseName = leftName + "." + gen.Identifier.Text + "`" + gen.TypeArgumentList.Arguments.SeparatorCount + 1;
+                var full = Combine(current, baseName);
+                var unconstructed = (INamedTypeSymbol?)_compilation.GetTypeByMetadataName(full)
+                    ?? (INamedTypeSymbol?)_compilation.GetTypeByMetadataName(baseName);
+                if (unconstructed is not null)
+                    return unconstructed;
             }
 
             return null;

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis;
@@ -7,8 +6,6 @@ namespace Raven.CodeAnalysis;
 class NamespaceBinder : Binder
 {
     private readonly INamespaceSymbol _namespaceSymbol;
-    private readonly List<INamespaceSymbol> _imports = new(); // Stores `using` directives
-    private readonly Dictionary<string, IReadOnlyList<ISymbol>> _aliases = new();
     private readonly List<SourceNamedTypeSymbol> _declaredTypes = [];
 
     public NamespaceBinder(Binder parent, INamespaceSymbol ns)
@@ -17,58 +14,7 @@ class NamespaceBinder : Binder
         _namespaceSymbol = ns;
     }
 
-    /// <summary>
-    /// Adds a namespace to the list of imports (`using System;`).
-    /// </summary>
-    public void AddUsingDirective(INamespaceSymbol importedNamespace)
-    {
-        if (!_imports.Contains(importedNamespace))
-            _imports.Add(importedNamespace);
-    }
-
-    public void AddAlias(string alias, IEnumerable<ISymbol> symbols)
-    {
-        if (!_aliases.ContainsKey(alias))
-            _aliases[alias] = symbols.ToArray();
-    }
-
-    /// <summary>
-    /// Looks up a type, checking imported namespaces before the current namespace.
-    /// </summary>
-    public override ITypeSymbol? LookupType(string name)
-    {
-        if (_aliases.TryGetValue(name, out var importedSymbols))
-            return importedSymbols.OfType<ITypeSymbol>().FirstOrDefault();
-
-        var type = NamespaceSymbol.LookupType(name);
-        if (type != null)
-            return type;
-
-        foreach (var ns in _imports)
-        {
-            type = ns.LookupType(name);
-            if (type != null)
-                return type;
-        }
-
-        return Compilation.GlobalNamespace.LookupType(name) ?? base.LookupType(name);
-    }
-
-    public override ISymbol? LookupSymbol(string name)
-    {
-        if (_aliases.TryGetValue(name, out var symbols))
-            return symbols.FirstOrDefault();
-
-        return base.LookupSymbol(name);
-    }
-
-    public override IEnumerable<ISymbol> LookupSymbols(string name)
-    {
-        if (_aliases.TryGetValue(name, out var symbols))
-            return symbols;
-
-        return base.LookupSymbols(name);
-    }
+    public override INamespaceSymbol? CurrentNamespace => _namespaceSymbol;
 
     public void DeclareType(SourceNamedTypeSymbol type)
     {

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 
+using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis.CodeGen;
@@ -1404,6 +1405,9 @@ internal class ExpressionGenerator : Generator
 
     public MethodInfo GetMethodInfo(IMethodSymbol methodSymbol)
     {
+        if (methodSymbol.IsAlias && methodSymbol is IAliasSymbol alias)
+            return GetMethodInfo((IMethodSymbol)alias.UnderlyingSymbol);
+
         if (methodSymbol is PEMethodSymbol pEMethodSymbol)
             return pEMethodSymbol.GetMethodInfo();
 

--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Immutable;
+
+namespace Raven.CodeAnalysis.Symbols;
+
+internal abstract class AliasSymbol : IAliasSymbol
+{
+    protected AliasSymbol(string name, ISymbol underlying)
+    {
+        Name = name;
+        UnderlyingSymbol = underlying;
+    }
+
+    public SymbolKind Kind => UnderlyingSymbol.Kind;
+
+    public string Name { get; }
+
+    public string MetadataName => UnderlyingSymbol.MetadataName;
+
+    public ISymbol? ContainingSymbol => UnderlyingSymbol.ContainingSymbol;
+
+    public IAssemblySymbol? ContainingAssembly => UnderlyingSymbol.ContainingAssembly;
+
+    public IModuleSymbol? ContainingModule => UnderlyingSymbol.ContainingModule;
+
+    public INamedTypeSymbol? ContainingType => UnderlyingSymbol.ContainingType;
+
+    public INamespaceSymbol? ContainingNamespace => UnderlyingSymbol.ContainingNamespace;
+
+    public ImmutableArray<Location> Locations => UnderlyingSymbol.Locations;
+
+    public Accessibility DeclaredAccessibility => UnderlyingSymbol.DeclaredAccessibility;
+
+    public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => UnderlyingSymbol.DeclaringSyntaxReferences;
+
+    public bool IsImplicitlyDeclared => UnderlyingSymbol.IsImplicitlyDeclared;
+
+    public bool IsStatic => UnderlyingSymbol.IsStatic;
+
+    public ISymbol UnderlyingSymbol { get; }
+
+    public bool IsAlias => true;
+
+    public bool Equals(ISymbol? other) =>
+        UnderlyingSymbol.Equals(other is IAliasSymbol alias ? alias.UnderlyingSymbol : other);
+
+    public bool Equals(ISymbol? other, SymbolEqualityComparer comparer) =>
+        UnderlyingSymbol.Equals(other is IAliasSymbol alias ? alias.UnderlyingSymbol : other, comparer);
+
+    public void Accept(SymbolVisitor visitor) => UnderlyingSymbol.Accept(visitor);
+
+    public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => UnderlyingSymbol.Accept(visitor);
+}
+
+internal sealed class AliasNamespaceSymbol : AliasSymbol, INamespaceSymbol
+{
+    private readonly INamespaceSymbol _namespace;
+
+    public AliasNamespaceSymbol(string name, INamespaceSymbol underlying)
+        : base(name, underlying)
+    {
+        _namespace = underlying;
+    }
+
+    public bool IsNamespace => _namespace.IsNamespace;
+
+    public bool IsType => _namespace.IsType;
+
+    public ImmutableArray<ISymbol> GetMembers() => _namespace.GetMembers();
+
+    public ImmutableArray<ISymbol> GetMembers(string name) => _namespace.GetMembers(name);
+
+    public ITypeSymbol? LookupType(string name) => _namespace.LookupType(name);
+
+    public bool IsMemberDefined(string name, out ISymbol? symbol) => _namespace.IsMemberDefined(name, out symbol);
+
+    public bool IsGlobalNamespace => _namespace.IsGlobalNamespace;
+
+    public INamespaceSymbol? LookupNamespace(string name) => _namespace.LookupNamespace(name);
+
+    public string? ToMetadataName() => _namespace.ToMetadataName();
+}
+
+internal sealed class AliasNamedTypeSymbol : AliasSymbol, INamedTypeSymbol
+{
+    private readonly INamedTypeSymbol _type;
+
+    public AliasNamedTypeSymbol(string name, INamedTypeSymbol underlying)
+        : base(name, underlying)
+    {
+        _type = underlying;
+    }
+
+    public bool IsNamespace => _type.IsNamespace;
+
+    public bool IsType => _type.IsType;
+
+    public ImmutableArray<ISymbol> GetMembers() => _type.GetMembers();
+
+    public ImmutableArray<ISymbol> GetMembers(string name) => _type.GetMembers(name);
+
+    public ITypeSymbol? LookupType(string name) => _type.LookupType(name);
+
+    public bool IsMemberDefined(string name, out ISymbol? symbol) => _type.IsMemberDefined(name, out symbol);
+
+    public INamedTypeSymbol? BaseType => _type.BaseType;
+
+    public ITypeSymbol? OriginalDefinition => _type.OriginalDefinition;
+
+    public SpecialType SpecialType => _type.SpecialType;
+
+    public TypeKind TypeKind => _type.TypeKind;
+
+    public bool IsReferenceType => _type.IsReferenceType;
+
+    public bool IsValueType => _type.IsValueType;
+
+    public bool IsTupleType => _type.IsTupleType;
+
+    public bool IsUnion => _type.IsUnion;
+
+    public int Arity => _type.Arity;
+
+    public ImmutableArray<IMethodSymbol> Constructors => _type.Constructors;
+
+    public IMethodSymbol? StaticConstructor => _type.StaticConstructor;
+
+    public INamedTypeSymbol UnderlyingTupleType => _type.UnderlyingTupleType;
+
+    public ImmutableArray<IFieldSymbol> TupleElements => _type.TupleElements;
+
+    public ImmutableArray<ITypeSymbol> TypeArguments => _type.TypeArguments;
+
+    public ImmutableArray<ITypeParameterSymbol> TypeParameters => _type.TypeParameters;
+
+    public ITypeSymbol? ConstructedFrom => _type.ConstructedFrom;
+
+    public bool IsAbstract => _type.IsAbstract;
+
+    public bool IsGenericType => _type.IsGenericType;
+
+    public bool IsUnboundGenericType => _type.IsUnboundGenericType;
+
+    public ITypeSymbol Construct(params ITypeSymbol[] typeArguments) => _type.Construct(typeArguments);
+}
+
+internal sealed class AliasMethodSymbol : AliasSymbol, IMethodSymbol
+{
+    private readonly IMethodSymbol _method;
+
+    public AliasMethodSymbol(string name, IMethodSymbol underlying)
+        : base(name, underlying)
+    {
+        _method = underlying;
+    }
+
+    public MethodKind MethodKind => _method.MethodKind;
+
+    public ITypeSymbol ReturnType => _method.ReturnType;
+
+    public ImmutableArray<IParameterSymbol> Parameters => _method.Parameters;
+
+    public IMethodSymbol? OriginalDefinition => _method.OriginalDefinition;
+
+    public bool IsAbstract => _method.IsAbstract;
+
+    public bool IsAsync => _method.IsAsync;
+
+    public bool IsCheckedBuiltin => _method.IsCheckedBuiltin;
+
+    public bool IsDefinition => _method.IsDefinition;
+
+    public bool IsExtensionMethod => _method.IsExtensionMethod;
+
+    public bool IsExtern => _method.IsExtern;
+
+    public bool IsGenericMethod => _method.IsGenericMethod;
+
+    public bool IsOverride => _method.IsOverride;
+
+    public bool IsReadOnly => _method.IsReadOnly;
+
+    public bool IsSealed => _method.IsSealed;
+
+    public bool IsVirtual => _method.IsVirtual;
+}
+
+internal sealed class AliasPropertySymbol : AliasSymbol, IPropertySymbol
+{
+    private readonly IPropertySymbol _property;
+
+    public AliasPropertySymbol(string name, IPropertySymbol underlying)
+        : base(name, underlying)
+    {
+        _property = underlying;
+    }
+
+    public ITypeSymbol Type => _property.Type;
+
+    public IMethodSymbol? GetMethod => _property.GetMethod;
+
+    public IMethodSymbol? SetMethod => _property.SetMethod;
+
+    public bool IsIndexer => _property.IsIndexer;
+}
+
+internal sealed class AliasFieldSymbol : AliasSymbol, IFieldSymbol
+{
+    private readonly IFieldSymbol _field;
+
+    public AliasFieldSymbol(string name, IFieldSymbol underlying)
+        : base(name, underlying)
+    {
+        _field = underlying;
+    }
+
+    public ITypeSymbol Type => _field.Type;
+
+    public bool IsLiteral => _field.IsLiteral;
+
+    public object? GetConstantValue() => _field.GetConstantValue();
+}
+
+internal static class AliasSymbolFactory
+{
+    public static IAliasSymbol Create(string name, ISymbol underlying) => underlying switch
+    {
+        INamespaceSymbol n => new AliasNamespaceSymbol(name, n),
+        INamedTypeSymbol t => new AliasNamedTypeSymbol(name, t),
+        IMethodSymbol m => new AliasMethodSymbol(name, m),
+        IPropertySymbol p => new AliasPropertySymbol(name, p),
+        IFieldSymbol f => new AliasFieldSymbol(name, f),
+        _ => throw new ArgumentException("Unsupported alias target", nameof(underlying))
+    };
+}

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
@@ -76,6 +76,8 @@ internal sealed class ConstructedNamedTypeSymbol : INamedTypeSymbol
     public bool CanBeReferencedByName => true;
     public ImmutableArray<Location> Locations => _originalDefinition.Locations;
     public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
+    public ISymbol UnderlyingSymbol => this;
+    public bool IsAlias => false;
     public int Arity => TypeArguments.Length;
     public ImmutableArray<ITypeSymbol> GetTypeArguments() => TypeArguments;
     public ITypeSymbol? OriginalDefinition => _originalDefinition;
@@ -164,6 +166,8 @@ internal sealed class SubstitutedMethodSymbol : IMethodSymbol
     public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _original.DeclaringSyntaxReferences;
     public bool IsImplicitlyDeclared => _original.IsImplicitlyDeclared;
     public bool IsStatic => _original.IsStatic;
+    public ISymbol UnderlyingSymbol => this;
+    public bool IsAlias => false;
 
     public void Accept(SymbolVisitor visitor)
     {
@@ -256,6 +260,8 @@ internal sealed class SubstitutedFieldSymbol : IFieldSymbol
     public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _original.DeclaringSyntaxReferences;
     public bool IsImplicitlyDeclared => _original.IsImplicitlyDeclared;
     public bool IsStatic => _original.IsStatic;
+    public ISymbol UnderlyingSymbol => this;
+    public bool IsAlias => false;
 
     public void Accept(SymbolVisitor visitor) => visitor.VisitField(this);
     public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.VisitField(this);
@@ -306,6 +312,8 @@ internal sealed class SubstitutedPropertySymbol : IPropertySymbol
     public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _original.DeclaringSyntaxReferences;
     public bool IsImplicitlyDeclared => _original.IsImplicitlyDeclared;
     public bool IsStatic => _original.IsStatic;
+    public ISymbol UnderlyingSymbol => this;
+    public bool IsAlias => false;
 
     public void Accept(SymbolVisitor visitor) => visitor.VisitProperty(this);
     public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.VisitProperty(this);
@@ -351,6 +359,8 @@ internal sealed class SubstitutedParameterSymbol : IParameterSymbol
     public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _original.DeclaringSyntaxReferences;
     public bool IsImplicitlyDeclared => _original.IsImplicitlyDeclared;
     public bool IsStatic => false;
+    public ISymbol UnderlyingSymbol => this;
+    public bool IsAlias => false;
     public bool IsParams => _original.IsParams;
     public RefKind RefKind => _original.RefKind;
 

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -90,6 +90,16 @@ public interface ISymbol : IEquatable<ISymbol?>
     /// </summary>
     bool IsStatic { get; }
 
+    /// <summary>
+    /// Gets the symbol that this symbol ultimately represents. For non-alias symbols, this returns <c>this</c>.
+    /// </summary>
+    ISymbol UnderlyingSymbol { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this symbol is an alias.
+    /// </summary>
+    bool IsAlias { get; }
+
     bool CanBeReferencedByName => this switch
     {
         INamespaceOrTypeSymbol => true,
@@ -215,6 +225,11 @@ public interface INamespaceSymbol : INamespaceOrTypeSymbol
 public interface ILambdaSymbol : IMethodSymbol
 {
     ITypeSymbol? DelegateType { get; }
+}
+
+public interface IAliasSymbol : ISymbol
+{
+    new ISymbol UnderlyingSymbol { get; }
 }
 
 public interface IMethodSymbol : ISymbol

--- a/src/Raven.CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Symbol.cs
@@ -130,6 +130,10 @@ internal abstract class Symbol : ISymbol
 
     public virtual bool IsStatic => false;
 
+    public virtual ISymbol UnderlyingSymbol => this;
+
+    public virtual bool IsAlias => false;
+
     public virtual bool CanBeReferencedByName { get; } = false;
 
     public bool Equals(ISymbol? other, SymbolEqualityComparer comparer)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -1,3 +1,7 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
@@ -16,7 +20,17 @@ public class AliasResolutionTest : DiagnosticTestBase
 
         var verifier = CreateVerifier(testCode);
 
+        var result = verifier.GetResult();
         verifier.Verify();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last();
+        var symbol = model.GetSymbolInfo(identifier).Symbol;
+        Assert.NotNull(symbol);
+        Assert.True(symbol!.IsAlias);
+        var alias = Assert.IsAssignableFrom<IAliasSymbol>(symbol);
+        Assert.Equal("SB", alias.Name);
+        Assert.Equal("StringBuilder", alias.UnderlyingSymbol.Name);
     }
 
     [Fact]
@@ -61,7 +75,73 @@ public class AliasResolutionTest : DiagnosticTestBase
 
         var verifier = CreateVerifier(testCode);
 
+        var result = verifier.GetResult();
         verifier.Verify();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
+        var symbol = model.GetSymbolInfo(invocation).Symbol;
+        Assert.NotNull(symbol);
+        Assert.True(symbol!.IsAlias);
+        var alias = Assert.IsAssignableFrom<IAliasSymbol>(symbol);
+        Assert.Equal("WriteLine", alias.UnderlyingSymbol.Name);
     }
 
+    [Fact]
+    public void AliasDirective_UsesNamespaceAlias()
+    {
+        string testCode =
+            """
+            alias ST = System.Text
+
+            ST.StringBuilder
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        var result = verifier.GetResult();
+        verifier.Verify();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var identifier = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .First(id => id.Identifier.Text == "ST");
+        var symbol = model.GetSymbolInfo(identifier).Symbol;
+        Assert.NotNull(symbol);
+        Assert.True(symbol!.IsAlias);
+        var alias = Assert.IsAssignableFrom<IAliasSymbol>(symbol);
+        Assert.Equal("ST", alias.Name);
+        Assert.Equal(SymbolKind.Namespace, alias.UnderlyingSymbol.Kind);
+    }
+
+    [Fact]
+    public void AliasDirective_UsesAlias_InsideClass()
+    {
+        string testCode =
+            """
+            alias SB = System.Text.StringBuilder
+
+            class C
+            {
+                let sb: SB
+            }
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        var result = verifier.GetResult();
+        verifier.Verify();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var identifier = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .First(id => id.Identifier.Text == "SB");
+        var symbol = model.GetSymbolInfo(identifier).Symbol;
+        Assert.NotNull(symbol);
+        Assert.True(symbol!.IsAlias);
+        var alias = Assert.IsAssignableFrom<IAliasSymbol>(symbol);
+        Assert.Equal("StringBuilder", alias.UnderlyingSymbol.Name);
+    }
 }


### PR DESCRIPTION
## Summary
- introduce `IAliasSymbol` and expose alias info via `ISymbol.UnderlyingSymbol` and `IsAlias`
- wrap alias directives in dedicated symbol implementations and use them during binding
- support namespace aliases alongside type and member aliases
- centralize import and alias handling in `ImportBinder` for namespaces and types
- test alias symbols for type, method, namespace, and class-level aliases
- document alias directive, including namespace aliases and overload behavior
- add compilation-unit aliases to namespace binder for lookup
- wire compilation units through `ImportBinder` and fix namespace alias test
- forward namespace import diagnostics so invalid namespace imports are reported
- unwrap alias methods in the code generator so alias invocations compile
- document binder responsibilities, creation points, and typical order
- document `SemanticModel.PrintBinderTree()` debugging utility

## Testing
- `dotnet format Raven.sln --include docs/compiler/architecture/semantic-binding.md --no-restore -v diag`


------
https://chatgpt.com/codex/tasks/task_e_68ada2786a58832fa9e80f931de6ced0