### PR TITLE
feat: show symbol names in binder tree

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BinderTreePrinter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BinderTreePrinter.cs
@@ -10,10 +10,14 @@ public static class BinderTreePrinter
     public static void PrintBinderTree(this SemanticModel model)
     {
         var cache = GetBinderCache(model);
-        var allBinders = cache.Values.Distinct().ToHashSet();
+        var binderNodes = cache
+            .GroupBy(kv => kv.Value)
+            .ToDictionary(g => g.Key, g => g.Select(kv => kv.Key).ToList());
+
+        var allBinders = binderNodes.Keys.Distinct().ToHashSet();
 
         // Discover all reachable parents (even if not in the cache)
-        foreach (var binder in cache.Values)
+        foreach (var binder in binderNodes.Keys)
         {
             var current = binder.ParentBinder;
             while (current is not null && allBinders.Add(current))
@@ -25,11 +29,11 @@ public static class BinderTreePrinter
         // Get true root(s)
         var roots = allBinders
             .Where(b => b.ParentBinder is null)
-            .OrderBy(DescribeBinder)
+            .OrderBy(b => DescribeBinder(b, binderNodes, parentToChildren))
             .ToList();
 
         foreach (var root in roots)
-            PrintRecursive(root, parentToChildren, "", isLast: true);
+            PrintRecursive(root, parentToChildren, binderNodes, "", isLast: true);
     }
 
     private static Dictionary<Binder, List<Binder>> BuildParentChildMap(IEnumerable<Binder> allBinders)
@@ -50,22 +54,63 @@ public static class BinderTreePrinter
         return map;
     }
 
-    private static void PrintRecursive(Binder binder, Dictionary<Binder, List<Binder>> parentToChildren, string indent, bool isLast)
+    private static void PrintRecursive(
+        Binder binder,
+        Dictionary<Binder, List<Binder>> parentToChildren,
+        Dictionary<Binder, List<SyntaxNode>> binderNodes,
+        string indent,
+        bool isLast)
     {
         var marker = isLast ? "└── " : "├── ";
-        Console.WriteLine($"{indent}{marker}{DescribeBinder(binder)}");
+        Console.WriteLine($"{indent}{marker}{DescribeBinder(binder, binderNodes, parentToChildren)}");
 
         indent += isLast ? "    " : "│   ";
 
         if (parentToChildren.TryGetValue(binder, out var children))
         {
             for (int i = 0; i < children.Count; i++)
-                PrintRecursive(children[i], parentToChildren, indent, i == children.Count - 1);
+                PrintRecursive(children[i], parentToChildren, binderNodes, indent, i == children.Count - 1);
         }
     }
 
-    private static string DescribeBinder(Binder binder)
+    private static string DescribeBinder(
+        Binder binder,
+        Dictionary<Binder, List<SyntaxNode>> binderNodes,
+        Dictionary<Binder, List<Binder>> parentToChildren)
     {
+        static string DescribeSymbol(
+            Binder binder,
+            Dictionary<Binder, List<SyntaxNode>> nodesMap,
+            Dictionary<Binder, List<Binder>> parentToChildren)
+        {
+            if (nodesMap.TryGetValue(binder, out var nodes) && nodes.Count > 0)
+            {
+                foreach (var node in nodes)
+                {
+                    var symbol = binder.BindDeclaredSymbol(node);
+                    if (symbol is not null)
+                        return $" ({symbol.Name})";
+                }
+            }
+            else if (parentToChildren.TryGetValue(binder, out var children))
+            {
+                foreach (var child in children)
+                {
+                    if (nodesMap.TryGetValue(child, out var childNodes))
+                    {
+                        foreach (var node in childNodes)
+                        {
+                            var symbol = binder.BindDeclaredSymbol(node);
+                            if (symbol is not null)
+                                return $" ({symbol.Name})";
+                        }
+                    }
+                }
+            }
+
+            return string.Empty;
+        }
+
         return binder switch
         {
             GlobalBinder => "GlobalBinder",
@@ -74,10 +119,11 @@ public static class BinderTreePrinter
             TopLevelBinder => "TopLevelBinder (synthesized Main)",
             TypeDeclarationBinder td => $"TypeDeclarationBinder ({td.ContainingSymbol?.Name ?? "?"})",
             MethodBinder m => $"MethodBinder ({m.GetMethodSymbol()?.Name ?? "?"})",
+            TypeMemberBinder => $"TypeMemberBinder{DescribeSymbol(binder, binderNodes, parentToChildren)}",
             MethodBodyBinder => "MethodBodyBinder",
             BlockBinder => "BlockBinder",
             LocalScopeBinder => "LocalScopeBinder",
-            LocalFunctionBinder => "LocalFunctionBinder",
+            LocalFunctionBinder => $"LocalFunctionBinder{DescribeSymbol(binder, binderNodes, parentToChildren)}",
             _ => binder.GetType().Name
         };
     }


### PR DESCRIPTION
## Summary
- extend binder tree printer to label type and local members with their symbol names

## Testing
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(fails: Raven.CodeAnalysis.Tests.VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal)*
- `(cd src/Raven.Compiler && dotnet run -- samples/classes.rav)`

------
https://chatgpt.com/codex/tasks/task_e_68adc1d5b758832f8bdd2a587647b370