### PR TITLE
feat: allow aliases for tuples and unions

### DIFF
--- a/docs/lang/proposals/aliases.md
+++ b/docs/lang/proposals/aliases.md
@@ -3,7 +3,7 @@
 > ⚠️ 🧩 This proposal has been partly implemented
 
 This document outlines aliases - which allow you to define alternative names for
-namespaces, types (including closed generic types), and static members.
+namespaces, types (including closed generic types, tuples, and type unions), and static members.
 
 ## Syntax
 
@@ -24,12 +24,15 @@ The name `IO` will be an alias for the `System.IO` namespace.
 alias SB = System.StringBuilder
 
 alias IntList = System.Collections.Generic.List<int>
+alias Pair = (int, string)
+alias Number = int | string
 ```
 
 The name `SB` will be an alias for `System.StringBuilder`.
 
 The type aliased is required to be specified in fully qualified form
-(`System.StringBuilder`). This is to resolve ambiguities.
+(`System.StringBuilder`) unless it is a type expression such as a tuple or
+type union. This is to resolve ambiguities.
 
 ### Member alias
 

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -6,7 +6,7 @@
 CompilationUnit          ::= {ImportDirective | AliasDirective | Declaration | Statement} EOF ;
 
 ImportDirective          ::= 'import' QualifiedName ('.' '*')? ; (* Namespace imports require '.*'; applying '.*' to a type imports its static members and nested types *)
-AliasDirective           ::= 'alias' Identifier '=' QualifiedName ;
+AliasDirective           ::= 'alias' Identifier '=' Type ;
 
 (* ---------- Modifiers ---------- *)
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -238,12 +238,15 @@ let pi = PI
 ### Alias directive
 
 The `alias` directive assigns an alternative name to a fully qualified
-**namespace**, type, or static member.
+**namespace**, type, static member, or to any type expression such as tuples
+and type unions.
 
 ```raven
 alias IO = System.IO
 alias SB = System.Text.StringBuilder
 alias PrintLine = System.Console.WriteLine
+alias Pair = (x: int, y: int)
+alias Number = int | string
 
 let sb = SB()
 PrintLine("Hi")
@@ -254,8 +257,9 @@ Aliasing a method binds a specific overload. Multiple directives using the
 same alias name may appear to alias additional overloads, forming an overload
 set.
 
-Aliases require fully qualified names to avoid ambiguity and may appear at the
-top of a file or inside a namespace alongside import directives.
+Aliases require fully qualified names for namespaces, types, and members to
+avoid ambiguity; type expressions are written directly. Alias directives may
+appear at the top of a file or inside a namespace alongside import directives.
 
 ### Scoped namespaces
 

--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -103,7 +103,19 @@ class BinderFactory
 
         foreach (var aliasDirective in nsSyntax.Aliases)
         {
-            var symbols = ResolveAlias(nsSymbol!, aliasDirective.Name);
+            IReadOnlyList<ISymbol> symbols;
+            if (aliasDirective.Target is NameSyntax name)
+            {
+                symbols = ResolveAlias(nsSymbol!, name);
+            }
+            else
+            {
+                var typeSymbol = provisionalImportBinder.ResolveType(aliasDirective.Target);
+                symbols = typeSymbol == _compilation.ErrorTypeSymbol
+                    ? Array.Empty<ISymbol>()
+                    : new ISymbol[] { typeSymbol };
+            }
+
             if (symbols.Count > 0)
             {
                 var aliasSymbols = symbols

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -264,7 +264,19 @@ public partial class SemanticModel
 
         foreach (var alias in cu.Aliases)
         {
-            var symbols = ResolveAlias(targetNamespace, alias.Name);
+            IReadOnlyList<ISymbol> symbols;
+            if (alias.Target is NameSyntax name)
+            {
+                symbols = ResolveAlias(targetNamespace, name);
+            }
+            else
+            {
+                var typeSymbol = provisionalImportBinder.ResolveType(alias.Target);
+                symbols = typeSymbol == Compilation.ErrorTypeSymbol
+                    ? Array.Empty<ISymbol>()
+                    : new ISymbol[] { typeSymbol };
+            }
+
             if (symbols.Count > 0)
             {
                 var aliasSymbols = symbols

--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Raven.CodeAnalysis.Symbols;
@@ -144,6 +145,43 @@ internal sealed class AliasNamedTypeSymbol : AliasSymbol, INamedTypeSymbol
     public ITypeSymbol Construct(params ITypeSymbol[] typeArguments) => _type.Construct(typeArguments);
 }
 
+internal sealed class AliasUnionTypeSymbol : AliasSymbol, IUnionTypeSymbol
+{
+    private readonly IUnionTypeSymbol _type;
+
+    public AliasUnionTypeSymbol(string name, IUnionTypeSymbol underlying)
+        : base(name, underlying)
+    {
+        _type = underlying;
+    }
+
+    public bool IsNamespace => _type.IsNamespace;
+
+    public bool IsType => _type.IsType;
+
+    public ImmutableArray<ISymbol> GetMembers() => _type.GetMembers();
+
+    public ImmutableArray<ISymbol> GetMembers(string name) => _type.GetMembers(name);
+
+    public ITypeSymbol? LookupType(string name) => _type.LookupType(name);
+
+    public bool IsMemberDefined(string name, out ISymbol? symbol) => _type.IsMemberDefined(name, out symbol);
+
+    public INamedTypeSymbol? BaseType => _type.BaseType;
+
+    public ITypeSymbol? OriginalDefinition => _type.OriginalDefinition;
+
+    public SpecialType SpecialType => _type.SpecialType;
+
+    public TypeKind TypeKind => _type.TypeKind;
+
+    public bool IsReferenceType => _type.IsReferenceType;
+
+    public bool IsValueType => _type.IsValueType;
+
+    public IEnumerable<ITypeSymbol> Types => _type.Types;
+}
+
 internal sealed class AliasMethodSymbol : AliasSymbol, IMethodSymbol
 {
     private readonly IMethodSymbol _method;
@@ -226,6 +264,7 @@ internal static class AliasSymbolFactory
     public static IAliasSymbol Create(string name, ISymbol underlying) => underlying switch
     {
         INamespaceSymbol n => new AliasNamespaceSymbol(name, n),
+        IUnionTypeSymbol u => new AliasUnionTypeSymbol(name, u),
         INamedTypeSymbol t => new AliasNamedTypeSymbol(name, t),
         IMethodSymbol m => new AliasMethodSymbol(name, m),
         IPropertySymbol p => new AliasPropertySymbol(name, p),

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/AliasDirectiveSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/AliasDirectiveSyntaxParser.cs
@@ -14,7 +14,7 @@ internal class AliasDirectiveSyntaxParser : SyntaxParser
         var identifier = ReadToken();
         var equalsToken = ReadToken();
 
-        NameSyntax nameSyntax;
+        TypeSyntax target;
         if (PeekToken().Kind == SyntaxKind.SemicolonToken)
         {
             var missing = MissingToken(SyntaxKind.IdentifierToken);
@@ -22,11 +22,11 @@ internal class AliasDirectiveSyntaxParser : SyntaxParser
                 DiagnosticInfo.Create(
                     CompilerDiagnostics.IdentifierExpected,
                     GetEndOfLastToken()));
-            nameSyntax = IdentifierName(missing);
+            target = IdentifierName(missing);
         }
         else
         {
-            nameSyntax = new NameSyntaxParser(this).ParseName();
+            target = new NameSyntaxParser(this).ParseTypeName();
         }
 
         SetTreatNewlinesAsTokens(true);
@@ -35,6 +35,6 @@ internal class AliasDirectiveSyntaxParser : SyntaxParser
 
         SetTreatNewlinesAsTokens(false);
 
-        return AliasDirective(aliasKeyword, identifier, equalsToken, nameSyntax, terminatorToken);
+        return AliasDirective(aliasKeyword, identifier, equalsToken, target, terminatorToken);
     }
 }

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -268,7 +268,7 @@
     <Slot Name="AliasKeyword" Type="Token" />
     <Slot Name="Identifier" Type="Token" />
     <Slot Name="EqualsToken" Type="Token" />
-    <Slot Name="Name" Type="Name" />
+    <Slot Name="Target" Type="Type" />
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="ElseClause" Inherits="Node">

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -175,13 +175,13 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
         var aliasKeyword = node.AliasKeyword.WithTrailingTrivia(SyntaxFactory.Space);
         var identifier = node.Identifier.WithTrailingTrivia(SyntaxFactory.Space);
         var equalsToken = node.EqualsToken.WithTrailingTrivia(SyntaxFactory.Space);
-        var nameSyntax = (NameSyntax)VisitName(node.Name)!;
+        var target = (TypeSyntax)VisitType(node.Target)!;
         var terminatorToken = node.TerminatorToken
             .WithTrailingTrivia(
                 SyntaxFactory.CarriageReturnLineFeed,
                 SyntaxFactory.CarriageReturnLineFeed);
 
-        return node.Update(aliasKeyword, identifier, equalsToken, nameSyntax, terminatorToken);
+        return node.Update(aliasKeyword, identifier, equalsToken, target, terminatorToken);
     }
 
     public override SyntaxNode? VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -64,6 +64,50 @@ public class AliasResolutionTest : DiagnosticTestBase
     }
 
     [Fact]
+    public void AliasDirective_UsesAlias_Tuple()
+    {
+        string testCode =
+            """
+            alias Pair = (x: int, y: int)
+
+            let p: Pair
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        var result = verifier.GetResult();
+        verifier.Verify();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().First(id => id.Identifier.Text == "Pair");
+        var symbol = model.GetSymbolInfo(identifier).Symbol;
+        Assert.NotNull(symbol);
+        Assert.True(symbol!.IsAlias);
+    }
+
+    [Fact]
+    public void AliasDirective_UsesAlias_Union()
+    {
+        string testCode =
+            """
+            alias Number = int | string
+
+            let n: Number
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        var result = verifier.GetResult();
+        verifier.Verify();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().First(id => id.Identifier.Text == "Number");
+        var symbol = model.GetSymbolInfo(identifier).Symbol;
+        Assert.NotNull(symbol);
+        Assert.True(symbol!.IsAlias);
+    }
+
+    [Fact]
     public void AliasDirective_UsesMemberAlias_Method()
     {
         string testCode =


### PR DESCRIPTION
## Summary
- allow alias directives to target tuple and union types
- handle new alias targets during binding and semantic analysis
- document aliasing of complex type expressions

## Testing
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: Could not observe local increment within the same tick)*
- `dotnet test --filter VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal` *(fails: Could not observe local increment within the same tick)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: several sample programs did not compile/run)*

------
https://chatgpt.com/codex/tasks/task_e_68add9df5454832f9cc9ac6486490dfa