### PR TITLE
Improve NodeGenerator stamp handling and reporting

### DIFF
--- a/src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj
+++ b/src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -27,7 +27,9 @@
   </ItemGroup>
 
   <Target Name="RunNodeGenerator"
-    BeforeTargets="CoreCompile">
+    BeforeTargets="CoreCompile"
+    Inputs="Syntax/Model.xml;Syntax/Tokens.xml;Syntax/NodeKinds.xml;../../tools/NodeGenerator/**/*.cs;../../tools/NodeGenerator/NodeGenerator.csproj;../../tools/NodesShared/**/*.cs;../../tools/NodesShared/NodesShared.csproj"
+    Outputs="Syntax/generated/.stamp">
     <Exec Command="dotnet run --project ../../../tools/NodeGenerator"
       WorkingDirectory="Syntax" />
   </Target>


### PR DESCRIPTION
## Summary
- ensure NodeGenerator hash includes generator assembly and store stamp using absolute path
- add detailed generation statistics and counts for produced artifacts
- run NodeGenerator target incrementally by tracking inputs and .stamp output

## Testing
- `dotnet format Raven.sln --include tools/NodeGenerator/Program.cs,src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter "FullyQualifiedName~Raven.CodeAnalysis.Tests&FullyQualifiedName!~Sample_should_compile_and_run&FullyQualifiedName!~VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal"`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: sample program tests)*


------
https://chatgpt.com/codex/tasks/task_e_68ade4ddf0bc832f936ce8ece743e672