### PR TITLE
fix: skip emitting unused unit literal

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -45,12 +45,16 @@ internal class StatementGenerator : Generator
     private void EmitExpressionStatement(BoundExpressionStatement expressionStatement)
     {
         var expression = expressionStatement.Expression;
+        // If the expression is the unit literal and its value is discarded,
+        // there's nothing to emit.
+        if (expression is BoundUnitExpression)
+            return;
 
         new ExpressionGenerator(this, expression).Emit();
 
         ISymbol? symbol = expressionStatement.Symbol;
 
-        if (expressionStatement.Expression is BoundInvocationExpression invocationExpression)
+        if (expression is BoundInvocationExpression invocationExpression)
         {
             symbol = ((IMethodSymbol)expressionStatement.Symbol).ReturnType;
         }

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UnitExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UnitExpressionTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class UnitExpressionTests
+{
+    [Fact]
+    public void UnitLiteral_AsExpressionStatement_DoesNotEmitValue()
+    {
+        var code = """
+class Foo {
+    Test() -> void {
+        unit;
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, TestMetadataReferences.Default);
+        var method = loaded.Assembly.GetType("Foo")!.GetMethod("Test")!;
+        var il = method.GetMethodBody()!.GetILAsByteArray();
+
+        Assert.DoesNotContain(il, b => b == OpCodes.Ldsfld.Value);
+        Assert.DoesNotContain(il, b => b == OpCodes.Pop.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid pushing and popping `Unit.Value` when a unit literal is used as a stand-alone expression
- add regression test checking unit literal emits no stack operations

## Testing
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Process must exit before requested information can be determined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae17bbe294832fab21d2a8675ac402