### PR TITLE
Avoid emitting unit value for discarded invocation results

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -45,28 +45,12 @@ internal class StatementGenerator : Generator
     private void EmitExpressionStatement(BoundExpressionStatement expressionStatement)
     {
         var expression = expressionStatement.Expression;
-        // If the expression is the unit literal and its value is discarded,
-        // there's nothing to emit.
-        if (expression is BoundUnitExpression)
-            return;
+        new ExpressionGenerator(this, expression).Emit(false);
 
-        if (expression is BoundInvocationExpression bie && bie.Type is UnitTypeSymbol)
-            return;
-
-        new ExpressionGenerator(this, expression).Emit();
-
-        ISymbol? symbol = expressionStatement.Symbol;
-
-        if (expression is BoundInvocationExpression invocationExpression)
-        {
-            symbol = ((IMethodSymbol)expressionStatement.Symbol).ReturnType;
-        }
-
-        // TODO: Handle the case that Pop is required. If not Void, and not assigned anywhere.
-
-        var type = symbol?.UnwrapType();
+        var type = expression.Type?.UnwrapType();
         if (type is not null &&
-            type.SpecialType is not SpecialType.System_Void)
+            type.SpecialType is not SpecialType.System_Void &&
+            type is not UnitTypeSymbol)
         {
             // The value is not used, pop it from the stack.
             ILGenerator.Emit(OpCodes.Pop);

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -48,7 +48,8 @@ internal class StatementGenerator : Generator
         new ExpressionGenerator(this, expression).Emit(false);
 
         var type = expression.Type?.UnwrapType();
-        if (type is not null &&
+        if (expression is not BoundAssignmentExpression &&
+            type is not null &&
             type.SpecialType is not SpecialType.System_Void &&
             type is not UnitTypeSymbol)
         {

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/BlockExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/BlockExpressionTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class BlockExpressionTests
+{
+    [Fact]
+    public void BlockExpression_AsAssignmentRightHandSide_DoesNotEmitPop()
+    {
+        var code = """
+class Foo {
+    Test() -> void {
+        var i = 0;
+        i = { i + 1; };
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, TestMetadataReferences.Default);
+        var method = loaded.Assembly.GetType("Foo")!.GetMethod("Test")!;
+        var il = method.GetMethodBody()!.GetILAsByteArray();
+
+        Assert.DoesNotContain(il, b => b == OpCodes.Pop.Value);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/ExpressionStatementTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/ExpressionStatementTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class ExpressionStatementTests
+{
+    [Fact]
+    public void Assignment_AsExpressionStatement_DoesNotEmitPop()
+    {
+        var code = """
+class Foo {
+    Test() -> void {
+        var x = 0;
+        x = 1;
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, TestMetadataReferences.Default);
+        var method = loaded.Assembly.GetType("Foo")!.GetMethod("Test")!;
+        var il = method.GetMethodBody()!.GetILAsByteArray();
+
+        Assert.DoesNotContain(il, b => b == OpCodes.Pop.Value);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UnitExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UnitExpressionTests.cs
@@ -65,4 +65,34 @@ class Foo {
         Assert.DoesNotContain(il, b => b == OpCodes.Ldsfld.Value);
         Assert.DoesNotContain(il, b => b == OpCodes.Pop.Value);
     }
+
+    [Fact]
+    public void UnitReturningCall_AsArgument_EmitsValue()
+    {
+        var code = """
+class Foo {
+    Bar() -> unit { }
+    Baz(x: unit) -> void { }
+    Test() -> void {
+        Baz(Bar());
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, TestMetadataReferences.Default);
+        var method = loaded.Assembly.GetType("Foo")!.GetMethod("Test")!;
+        var il = method.GetMethodBody()!.GetILAsByteArray();
+
+        Assert.Contains(il, b => b == OpCodes.Ldsfld.Value);
+        Assert.DoesNotContain(il, b => b == OpCodes.Pop.Value);
+    }
 }


### PR DESCRIPTION
## Summary
- allow expression generator to know whether a result is used
- avoid loading Unit.Value for discarded invocation results and handle implicit receivers
- skip popping Unit results in expression statements
- test that calling a unit-returning method as a statement emits no value

## Testing
- `dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --include CodeGen/Generators/ExpressionGenerator.cs,CodeGen/Generators/StatementGenerator.cs`
- `dotnet format test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --include CodeGen/UnitExpressionTests.cs`
- `dotnet build`
- `dotnet test --filter UnitReturningCall_AsExpressionStatement_DoesNotEmitValue`
- `dotnet test` *(fails: FieldInitializationTests.InstanceAndStaticFieldInitializers_AreEmitted, ForExpressionTests.ForEach_OverArray_UsesTypedElement, IndexerTests.Indexer_EmitsItemPropertyWithBodies, SampleProgramsTests.Sample_should_compile_and_run and others)*

------
https://chatgpt.com/codex/tasks/task_e_68aeac94cb68832fbc4b3af2c32e756c