### PR TITLE
docs: revise unit type proposal

### DIFF
--- a/docs/lang/proposals/unit-type.md
+++ b/docs/lang/proposals/unit-type.md
@@ -1,15 +1,24 @@
 # Proposal: Unit type
 
-⚠️ This proposal has **NOT** been implemented
+✅ This proposal has been implemented
 
-The `unit` type represents a value in absence of a value. It can be seen as `void` but the difference is that it is a real type with exactly one value.
+> The current implementation exists but is being reworked from a clean slate. The design notes below capture the expected behavior for the renewed implementation.
+
+The `unit` type represents a value in absence of a value. It can be seen as `void` but the difference is that it is a real type with exactly one value. Once the feature is reintroduced, `unit` will wholly replace the language's `void` concept so that every callable returns a concrete type.
 
 The keyword `unit` maps to the type `System.Unit` (see definition below).
 
 ## Purpose
 
+- Replace `void` with a first-class `unit` value so all functions have a real return type.
 - Enable type flow where `void` cannot be used (generics, tuples, unions).
 - Provide a concrete value for "empty", distinct from `null` or `void`.
+ 
+## Rationale
+
+Raven treats the absence of a result as a first-class value so that every expression has a type. A dedicated `unit` type avoids
+special cases around `void`, letting side-effect-only functions compose with generics, tuples, and unions. This mirrors
+functional languages where even "do nothing" computations produce a value and encourages explicit handling of effects.
 
 ## Syntax
 
@@ -17,41 +26,46 @@ The keyword `unit` maps to the type `System.Unit` (see definition below).
 let v = Foo()   // v : unit
 
 func Foo() -> unit {
-    unit // return unit
+    () // return unit
 }
-````
+```
 
 * `unit` is a valid type specifier.
 * Functions without explicit return type default to `unit`.
-* The literal `unit` refers to the single value of this type.
+* The literal `()` refers to the single value of this type.
 
 ## Semantics
 
 * `unit` is a builtin type with one value.
 * Control-flow and block expressions return `unit` when no other type is inferred.
 * `unit` may appear in unions and tuples.
+* Declaring parameters of type `unit` is discouraged and may be disallowed; fields and properties cannot be solely `unit`, though they may use unions that include it.
+* The `unit` type typically arises from control flow and type inference rather than explicit user annotations.
+* The `()` literal may only appear as an explicit `return ()` or as the implicit result of a block; standalone expressions such as `[()]` or `(1, ())` are invalid.
+* Because `unit` is a concrete value, `return` statements must supply an expression; `return;` is invalid. Use `return ()` for an explicit unit or fall through to return it implicitly.
+* `unit` participates in pattern matching like any other value. A dedicated `match` expression is a separate proposal; existing `if`-expression pattern syntax (`if x is () { ... }`) already works.
 
 ```raven
 func Foo(ok: bool) -> int | unit {
     if ok {
         return 42
     }
-    return unit
+    return ()
 }
 ```
 
-> In the future we might enforce the handling of `unit`. Either b7 use or discard `_ = Console.WriteLine("")`. This enforces functional programming patterns.
+> In the future we might enforce the handling of `unit`, either by using the returned value or by explicitly discarding it (e.g. `_ = Console.WriteLine("")`). This enforces functional programming patterns.
 
 ### Control flow
 
-> **Note:** Type unions is not explained in this proposal. Just remember that `unit` is a type like any other..
+> **Note:** Type unions are not explained in this proposal. Just remember that `unit` is a type like any other.
 
-```csharp
-let x = if true {.42 } // x : int | unit
+```raven
+let x = if true { 42 } // x : int | unit
 ```
 
-```csharp
-let x = if true {.42 } else { Console.WriteLine("Test2") } //  x : int | unit
+```raven
+let x = if true { 42 } else { Console.WriteLine("Test2") } //  x : int | unit
 ```
 
 ### Aliasing
@@ -62,9 +76,103 @@ Just like other built in types, `unit` can be aliased.
 alias MyUnit = unit
 ```
 
+### Additional examples
+
+#### Generics and tuples
+
+A `unit` value must originate from control flow; bare literals like `[()]` or `(1, ())` are invalid.
+
+```raven
+func ping() { }
+
+let u = ping()
+let list: List<unit> = [u]
+let pair: (int, unit) = (1, u)
+```
+
+C#:
+
+```csharp
+void Ping() { }
+
+Ping();
+var u = Unit.Value;
+var list = new List<Unit> { u };
+var pair = (1, u);
+```
+
+#### Pattern matching
+
+Pattern matching with a `match` expression will be introduced in a separate proposal. Until then, `unit` works with the existing pattern syntax in `if` expressions.
+
+```raven
+let u = ping()
+if u is () {
+    Console.WriteLine("ok")
+}
+```
+
+C#:
+
+```csharp
+Ping();
+var u = Unit.Value;
+if (u == Unit.Value)
+{
+    Console.WriteLine("ok");
+}
+```
+
+#### Explicit discarding
+
+```raven
+_ = Console.WriteLine("logged")
+```
+
+C#:
+
+```csharp
+_ = Console.WriteLine("logged");
+```
+
+#### Implicit `unit` return
+
+```raven
+func Outer() {
+    func Inner() { }
+}
+```
+
+C#:
+
+```csharp
+void Outer() {
+    void Inner() { }
+}
+```
+
 ### Implementation details
 
 * `UnitTypeSymbol` is its own symbol.
+* Functions and local functions without an explicit return type are bound to return `unit`.
+* `unit` is a keyword token for the type; the literal value is spelled `()`.
+* The parser treats a standalone `()` in expression position as a `UnitLiteralExpression`; parenthesized expressions must contain an inner expression, and `()` following an expression denotes an empty argument list.
+* Control-flow statements without an explicit value produce `unit`.
+* Methods returning `unit` emit IL `ret` without pushing a value; callers that require a `unit` result must load `Unit.Value` after the call.
+
+### Reimplementation considerations
+
+When reintroducing the feature:
+
+* Reserve the `unit` keyword in the lexer and parser.
+* Ensure binder defaults missing return types to `unit` for top-level and local functions.
+* Introduce a built-in `UnitTypeSymbol` and a `UnitLiteralExpression` syntax node.
+* Contextually parse `()` as the unit literal when it appears on its own rather than as an argument list or grouped expression.
+* Remove the `return` statement form without an expression.
+* Map `unit` to a `System.Unit` struct during lowering and code generation.
+* Avoid emitting the `Unit.Value` field unless the value is consumed.
+* Add tests covering generics, tuples, interop with `void`, and default return types.
+* Use `()` as the unit literal, matching functional-language conventions and the `Unit.ToString()` output.
 
 ## Interop
 
@@ -77,7 +185,8 @@ alias MyUnit = unit
 
 ### Methods return `void` instead of `unit`
 
-Method returning `unit` will have actual type `void`.
+Methods declared with a `unit` return type are emitted as `void`. If a call site needs the resulting value (for example, to pass
+into a generic method or to store in a variable), the compiler inserts a load of `Unit.Value` after the call.
 
 ```raven
 class Test {
@@ -91,10 +200,10 @@ class Test {
 }
 ```
 
-C#
+C#:
 
-```raven
-class Test 
+```csharp
+class Test
 {
     void Foo() { }
     void Foo2() { }
@@ -103,7 +212,7 @@ class Test
 
 ### Emit `unit` only when used
 
-Codegen will not emit any `unit` value for constructs, such as expressions and statements in block, unless consumed by another construct.
+Codegen will not emit any `unit` value for constructs, such as expressions and statements in block, unless the surrounding code consumes the result.
 
 #### Method declarations
 
@@ -134,15 +243,17 @@ class Test
 
 Other example:
 
-```csharp
-let x = Console.WriteLine("Test") // x: unit = unit
-
-Console.WriteLine(Console.WriteLine("Test")) // Emit unit for inner WriteLine. Prints: "()" for unit
+```raven
+let x = Console.WriteLine("Test") // x: unit = ()
+Console.WriteLine(Console.WriteLine("Test")) // prints "()"
 ```
 
 The representation in C#:
 
 ```csharp
+Console.WriteLine("Test");
+var x = Unit.Value;
+
 Console.WriteLine("Test");
 Console.WriteLine(Unit.Value);
 ```
@@ -161,11 +272,11 @@ The representation in C#:
 ```csharp
 bool check = true;
 object x = default; // Semantically: Union between unit and 42
-if(check) 
+if(check)
 {
-    x = Unit.value;
+    x = Unit.Value;
 }
-else 
+else
 {
     x = 42;
 }
@@ -186,7 +297,7 @@ public readonly struct Unit : IEquatable<Unit>
 }
 ```
 
-The literal `unit` maps to `Unit.Value`.
+The literal `()` maps to `Unit.Value`.
 
 > Initially this type will be embedded in Raven assemblies, later moved to a shared core library.
 


### PR DESCRIPTION
## Summary
- adopt `()` as the unit literal and clarify it only arises from control flow
- note that dedicated `match` syntax is a separate proposal and show `if`-expression matching
- specify parser context for `()` and require `return` to always include an expression
- describe code generation for unit: methods emit `void` and callers load `Unit.Value` only when the result is used

## Testing
- `dotnet format --include docs/lang/proposals/unit-type.md --no-restore --verify-no-changes --verbosity diagnostic`


------
https://chatgpt.com/codex/tasks/task_e_68aed08709a0832f8e89240c8e034e77