### PR TITLE
fix: report diagnostic for duplicate local functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,19 +2,6 @@
 
 ## Semantic analysis
 
-### Bug: Allows for multiple local functions with same signature, and crashes
-
-You should not be able to define another local function in global scope using the same signature as an existing one.
-
-Right now, the compiler crashes at code generation:
-
-```raven
-func test () {}
-func test () {}
-```
-
-There should be a diagnostic for the second one telling that there already is a function with the same signature.
-
 ## Code generator
 
 ### Bug: Box values in type unions when directly returning from a method

--- a/src/Raven.CodeAnalysis/Binder/TopLevelBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TopLevelBinder.cs
@@ -25,7 +25,13 @@ class TopLevelBinder : BlockBinder
             {
                 var binder = SemanticModel.GetBinder(localFunc, this);
                 if (binder is LocalFunctionBinder lfBinder)
-                    DeclareLocalFunction(lfBinder.GetMethodSymbol());
+                {
+                    var symbol = lfBinder.GetMethodSymbol();
+                    if (_localFunctions.TryGetValue(symbol.Name, out var existing) && HaveSameSignature(existing, symbol))
+                        _diagnostics.ReportLocalFunctionAlreadyDefined(symbol.Name, localFunc.Identifier.GetLocation());
+                    else
+                        DeclareLocalFunction(symbol);
+                }
             }
         }
 

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
@@ -40,6 +40,7 @@ internal class CompilerDiagnostics
     private static DiagnosticDescriptor? _typeRequiresTypeArguments;
     private static DiagnosticDescriptor? _nullableTypeInUnion;
     private static DiagnosticDescriptor? _typeAlreadyDefinesMember;
+    private static DiagnosticDescriptor? _localFunctionAlreadyDefined;
 
     /// <summary>
     /// RAV1001: Identifier; expected
@@ -505,6 +506,19 @@ internal class CompilerDiagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// RAV0112: Local function '{0}' already defined with the same parameter types
+    /// </summary>
+    public static DiagnosticDescriptor LocalFunctionAlreadyDefined => _localFunctionAlreadyDefined ??= DiagnosticDescriptor.Create(
+        id: "RAV0112",
+        title: "Local function already defined",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "A local function named '{0}' is already defined with the same parameter types",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public static DiagnosticDescriptor[] AllDescriptors => _allDescriptors ??=
     [
         IdentifierExpected,
@@ -541,7 +555,8 @@ internal class CompilerDiagnostics
         InvalidAliasType,
         MemberAccessRequiresTargetType,
         NullableTypeInUnion,
-        TypeAlreadyDefinesMember
+        TypeAlreadyDefinesMember,
+        LocalFunctionAlreadyDefined
     ];
 
     public static DiagnosticDescriptor? GetDescriptor(string diagnosticId)
@@ -583,6 +598,7 @@ internal class CompilerDiagnostics
             "RAV0305" => TypeRequiresTypeArguments,
             "RAV0400" => NullableTypeInUnion,
             "RAV0111" => TypeAlreadyDefinesMember,
+            "RAV0112" => LocalFunctionAlreadyDefined,
             _ => null // Return null if the diagnostic ID is not recognized
         };
     }

--- a/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
@@ -118,4 +118,7 @@ public static class DiagnosticBagExtensions
 
     public static void ReportTypeAlreadyDefinesMember(this DiagnosticBag diagnostics, string typeName, string memberName, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TypeAlreadyDefinesMember, location, typeName, memberName));
+
+    public static void ReportLocalFunctionAlreadyDefined(this DiagnosticBag diagnostics, string name, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.LocalFunctionAlreadyDefined, location, name));
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LocalFunctionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LocalFunctionTests.cs
@@ -24,4 +24,21 @@ func outer() {
         var symbol = (IMethodSymbol)model.GetDeclaredSymbol(inner)!;
         Assert.Equal(SpecialType.System_Unit, symbol.ReturnType.SpecialType);
     }
+
+    [Fact]
+    public void DuplicateLocalFunction_DiagnosticReported()
+    {
+        var source = """
+func test() {}
+func test() {}
+""";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var model = compilation.GetSemanticModel(tree);
+        var funcs = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().ToArray();
+        _ = model.GetDeclaredSymbol(funcs[0]);
+        _ = model.GetDeclaredSymbol(funcs[1]);
+        var diagnostic = Assert.Single(compilation.GetDiagnostics());
+        Assert.Equal(CompilerDiagnostics.LocalFunctionAlreadyDefined, diagnostic.Descriptor);
+    }
 }


### PR DESCRIPTION
## Summary
- add RAV0112 to flag duplicate local functions
- ensure binders check and report duplicates
- cover duplicate local functions with a new unit test

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompilerDiagnostics.cs,src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs,src/Raven.CodeAnalysis/Binder/TopLevelBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/LocalFunctionTests.cs,TODO.md --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'`


------
https://chatgpt.com/codex/tasks/task_e_68af15f5f4e0832fbeaa07266accb77b