### PR TITLE
fix: box value types returned in unions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,33 +3,6 @@
 ## Semantic analysis
 
 ## Code generator
-
-### Bug: Box values in type unions when directly returning from a method
-
-Value types in a union should be boxed when returning since they are passed as `object`.
-
-```raven
-func test(flag: bool) -> int | () {
-    if flag {
-        return 42
-    } else {
-        return ()
-    }
-}
-```
-
-This works as intended when assigning a variable:
-
-```
-let x = if true {
-        42
-    } else {
-        ()
-    }
-```
-
-The 42 gets boxed.
-
 ### Bug: Issue with implicit vs explicit return
 
 This fails.

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -36,6 +36,14 @@ internal class StatementGenerator : Generator
         if (returnStatement.Expression is not null)
         {
             new ExpressionGenerator(this, returnStatement.Expression).Emit();
+
+            var expressionType = returnStatement.Expression.Type;
+            var returnType = MethodSymbol.ReturnType;
+
+            if (expressionType.IsValueType && (returnType.SpecialType is SpecialType.System_Object || returnType is IUnionTypeSymbol))
+            {
+                ILGenerator.Emit(OpCodes.Box, ResolveClrType(expressionType));
+            }
         }
 
         ILGenerator.Emit(OpCodes.Ret);

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class UnionReturnTests
+{
+    [Fact]
+    public void ValueTypesInUnionAreBoxedWhenReturning()
+    {
+        var code = """
+class Foo {
+    Test(flag: bool) -> int | () {
+        if flag {
+            return 42
+        } else {
+            return ()
+        }
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Foo", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Test")!;
+        var value = method.Invoke(instance, new object[] { true });
+
+        Assert.Equal(42, (int)value!);
+    }
+}


### PR DESCRIPTION
## Summary
- box value types when returning from methods with union or object return types
- cover union boxing with a new codegen test
- clean up TODO entry for resolved bug

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs,test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs,TODO.md`
- `cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f && cd ../../..`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run`
- `dotnet test --filter Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: 6 failed, 4 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68af19dbf7dc832fa0a8640ca27337a6