### PR TITLE
fix: box Unit when returned in union types

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -42,8 +42,8 @@ Raven has no `void` type. The absence of a meaningful value is represented by th
 spelled `unit` or `()`. Functions without an explicit return type implicitly
 return `unit`. When interacting with .NET, methods that return `void` are
 projected as returning `unit`, and Raven's `unit` emits as `void` unless the
-value is observed. Because `unit` is a real type, it participates in generics,
-tuples, and unions like any other type.
+value is observed. The `unit` type is a value type (struct). Because `unit` is a
+real type, it participates in generics, tuples, and unions like any other type.
 
 ## Statements
 

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -1,6 +1,6 @@
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Linq;
 
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
@@ -219,15 +219,15 @@ internal class MethodBodyGenerator
 
     private void EmitBoundBlock(BoundBlockExpression block, bool withReturn = true)
     {
-        for (var i = 0; i < block.Statements.Length; i++)
+        for (var i = 0; i < block.Statements.Count(); i++)
         {
-            var statement = block.Statements[i];
+            var statement = block.Statements.ElementAt(i);
 
             // If this is the last statement in the block and the method expects a
             // value, treat a bare expression statement as an implicit return. This
             // allows functions to omit an explicit `return` for the final
             // expression, while still emitting any required boxing.
-            var isLast = i == block.Statements.Length - 1;
+            var isLast = i == block.Statements.Count() - 1;
             if (withReturn && isLast &&
                 MethodSymbol.ReturnType.SpecialType is not SpecialType.System_Void &&
                 statement is BoundExpressionStatement exprStmt)
@@ -237,7 +237,8 @@ internal class MethodBodyGenerator
                 var expressionType = exprStmt.Expression.Type;
                 var returnType = MethodSymbol.ReturnType;
 
-                if (expressionType.IsValueType &&
+                if (expressionType is not null &&
+                    expressionType.IsValueType &&
                     (returnType.SpecialType is SpecialType.System_Object ||
                      returnType is IUnionTypeSymbol))
                 {

--- a/src/Raven.CodeAnalysis/Symbols/UnitTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/UnitTypeSymbol.cs
@@ -25,6 +25,8 @@ internal sealed class UnitTypeSymbol : SourceSymbol, INamedTypeSymbol
 
     public TypeKind TypeKind { get; }
 
+    public bool IsValueType => true;
+
     public ITypeSymbol? OriginalDefinition => this;
 
     public ImmutableArray<ISymbol> GetMembers() => [];

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs
@@ -39,8 +39,12 @@ class Foo {
         var type = assembly.GetType("Foo", true)!;
         var instance = Activator.CreateInstance(type)!;
         var method = type.GetMethod("Test")!;
-        var value = method.Invoke(instance, new object[] { true });
+        var intResult = method.Invoke(instance, new object[] { true });
+        Assert.Equal(42, (int)intResult!);
 
-        Assert.Equal(42, (int)value!);
+        var unitResult = method.Invoke(instance, new object[] { false });
+        Assert.NotNull(unitResult);
+        Assert.Equal("Unit", unitResult!.GetType().Name);
+        Assert.Equal("()", unitResult.ToString());
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs
@@ -47,4 +47,43 @@ class Foo {
         Assert.Equal("Unit", unitResult!.GetType().Name);
         Assert.Equal("()", unitResult.ToString());
     }
+    [Fact]
+    public void FinalExpressionUnitIsBoxed()
+    {
+        var code = """
+class Foo {
+    Test(flag: bool) -> int | () {
+        if flag {
+            return 42
+        }
+        ()
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Foo", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Test")!;
+        var intResult = method.Invoke(instance, new object[] { true });
+        Assert.Equal(42, (int)intResult!);
+
+        var unitResult = method.Invoke(instance, new object[] { false });
+        Assert.NotNull(unitResult);
+        Assert.Equal("Unit", unitResult!.GetType().Name);
+        Assert.Equal("()", unitResult.ToString());
+    }
+
 }


### PR DESCRIPTION
## Summary
- ensure Unit type is treated as a value type
- test boxing of Unit when returned as part of a union

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Symbols/UnitTypeSymbol.cs,test/Raven.CodeAnalysis.Tests/CodeGen/UnionReturnTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'`

------
https://chatgpt.com/codex/tasks/task_e_68af1f263398832fae67d2ddd5f5c94e