### PR TITLE
fix: handle early returns in variable initializers

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -87,14 +87,20 @@ internal class StatementGenerator : Generator
             new ExpressionGenerator(this, declarator.Initializer).Emit();
 
             var localBuilder = GetLocal(declarator.Local);
-
-            var s = declarator.Initializer.Type;
-
+            var expressionType = declarator.Initializer.Type;
             var localSymbol = declarator.Local;
 
-            if (s.IsValueType && (localSymbol.Type.SpecialType is SpecialType.System_Object || localSymbol.Type is IUnionTypeSymbol))
+            // If the local wasn't declared (e.g., the initializer returns early),
+            // there's nothing to store.
+            if (localBuilder is null)
+                return;
+
+            if (expressionType is not null &&
+                localSymbol.Type is not null &&
+                expressionType.IsValueType &&
+                (localSymbol.Type.SpecialType is SpecialType.System_Object || localSymbol.Type is IUnionTypeSymbol))
             {
-                ILGenerator.Emit(OpCodes.Box, ResolveClrType(s));
+                ILGenerator.Emit(OpCodes.Box, ResolveClrType(expressionType));
             }
 
             ILGenerator.Emit(OpCodes.Stloc, localBuilder);

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -65,6 +65,8 @@ internal class MethodBodyGenerator
                     foreach (var localDeclarator in localDeclStmt.Declaration.Declarators)
                     {
                         var localSymbol = GetDeclaredSymbol<ILocalSymbol>(localDeclarator);
+                        if (localSymbol?.Type is null)
+                            continue;
 
                         var clrType = ResolveClrType(localSymbol.Type);
                         var builder = ILGenerator.DeclareLocal(clrType);
@@ -210,6 +212,11 @@ internal class MethodBodyGenerator
 
         foreach (var localSymbol in collector.Locals)
         {
+            // Skip locals without a type. This can occur when the initializer
+            // contains an early return, making the declaration unreachable.
+            if (localSymbol.Type is null)
+                continue;
+
             var clrType = ResolveClrType(localSymbol.Type);
             var builder = ILGenerator.DeclareLocal(clrType);
             builder.SetLocalSymInfo(localSymbol.Name);

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class ExplicitReturnInIfExpressionTests
+{
+    [Fact]
+    public void ExplicitReturnInIfExpressionInitializerCompiles()
+    {
+        var code = """
+class Foo {
+    Test(flag: bool) -> int | () {
+        let x = if flag {
+            return 42
+        } else {
+            return ()
+        }
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Foo", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Test")!;
+        var intResult = method.Invoke(instance, new object[] { true });
+        Assert.Equal(42, (int)intResult!);
+
+        var unitResult = method.Invoke(instance, new object[] { false });
+        Assert.NotNull(unitResult);
+        Assert.Equal("Unit", unitResult!.GetType().Name);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid emitting locals without a resolved type during codegen
- skip storing to locals when an initializer returns early
- test explicit return in `if` expression initializer

## Testing
- `dotnet build --no-restore`
- `dotnet test --filter FullyQualifiedName!~Sample_should_compile_and_run`
- `dotnet test --filter FullyQualifiedName~SampleProgramsTests.Sample_should_compile_and_run` *(fails: Process must exit before requested information can be determined)*

------
https://chatgpt.com/codex/tasks/task_e_68af26d63340832fb6b98fa51c2c109e