### PR TITLE
feat: add analyzer verifier and restrict type analyzer to returns

### DIFF
--- a/src/Raven.CodeAnalysis.Testing/AnalyzerTestBase.cs
+++ b/src/Raven.CodeAnalysis.Testing/AnalyzerTestBase.cs
@@ -1,0 +1,20 @@
+using Raven.CodeAnalysis.Diagnostics;
+
+namespace Raven.CodeAnalysis.Testing;
+
+public abstract class AnalyzerTestBase
+{
+    protected AnalyzerVerifier<TAnalyzer> CreateAnalyzerVerifier<TAnalyzer>(string testCode, IEnumerable<DiagnosticResult>? expectedDiagnostics = null, IEnumerable<string>? disabledDiagnostics = null)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        return new AnalyzerVerifier<TAnalyzer>
+        {
+            Test = new Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = expectedDiagnostics?.ToList() ?? [],
+                DisabledDiagnostics = disabledDiagnostics?.ToList() ?? []
+            }
+        };
+    }
+}

--- a/src/Raven.CodeAnalysis.Testing/AnalyzerVerifier.cs
+++ b/src/Raven.CodeAnalysis.Testing/AnalyzerVerifier.cs
@@ -1,0 +1,125 @@
+using System.Linq;
+using System.Text;
+
+using Raven.CodeAnalysis.Diagnostics;
+using Raven.CodeAnalysis.Text;
+
+namespace Raven.CodeAnalysis.Testing;
+
+public class AnalyzerVerifier<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    public Test Test { get; set; } = new();
+
+    public DiagnosticVerifierResult GetResult()
+    {
+        var workspace = RavenWorkspace.Create(targetFramework: TestTargetFramework.Default);
+        var projectId = workspace.AddProject("Test");
+        var docId = DocumentId.CreateNew(projectId);
+        var solution = workspace.CurrentSolution.AddDocument(docId, "test.rav", SourceText.From(Test.TestCode));
+        workspace.TryApplyChanges(solution);
+
+        var project = workspace.CurrentSolution.GetProject(projectId)!;
+        project = project.AddAnalyzerReference(new AnalyzerReference(new TAnalyzer()));
+        foreach (var reference in ReferenceAssemblies.Default)
+            project = project.AddMetadataReference(reference);
+        workspace.TryApplyChanges(project.Solution);
+
+        var compilation = workspace.GetCompilation(projectId);
+        var actualDiagnostics = workspace.GetDiagnostics(projectId);
+        var expectedDiagnostics = Test.ExpectedDiagnostics;
+        var disabledDiagnostics = Test.DisabledDiagnostics.ToHashSet();
+
+        var unexpectedDiagnostics = new List<Diagnostic>();
+        var missingDiagnostics = new List<DiagnosticResult>();
+        var matchedDiagnostics = new List<Diagnostic>();
+
+        foreach (var diagnostic in actualDiagnostics)
+        {
+            var lineSpan = diagnostic.Location.GetLineSpan();
+
+            if (disabledDiagnostics.Contains(diagnostic.Descriptor.Id))
+                continue;
+
+            var isExpected = expectedDiagnostics.Any(expected =>
+                expected.Id == diagnostic.Descriptor.Id &&
+                expected.Arguments.Select(x => x.ToString()).SequenceEqual(diagnostic.GetMessageArgs().Select(x => x.ToString())) &&
+                expected.Location.Span.StartLinePosition == lineSpan.StartLinePosition);
+
+            if (isExpected)
+                matchedDiagnostics.Add(diagnostic);
+            else
+                unexpectedDiagnostics.Add(diagnostic);
+        }
+
+        foreach (var expected in expectedDiagnostics)
+        {
+            var isFound = actualDiagnostics.Any(actual =>
+            {
+                var expectedSpan = expected.Location.Span;
+                return actual.Descriptor.Id == expected.Id &&
+                       actual.GetMessageArgs().Select(x => x.ToString()).SequenceEqual(expected.Arguments.Select(x => x.ToString())) &&
+                       actual.Location.GetLineSpan().StartLinePosition == expectedSpan.StartLinePosition;
+            });
+
+            if (!isFound)
+                missingDiagnostics.Add(expected);
+        }
+
+        var result = new DiagnosticVerifierResult
+        {
+            Compilation = compilation,
+            MatchedDiagnostics = matchedDiagnostics,
+            UnexpectedDiagnostics = unexpectedDiagnostics,
+            MissingDiagnostics = missingDiagnostics
+        };
+
+        return result;
+    }
+
+    public void Verify()
+    {
+        var result = GetResult();
+
+        if (result.UnexpectedDiagnostics.Any() || result.MissingDiagnostics.Any())
+        {
+            var errorMessage = BuildErrorMessage(result.UnexpectedDiagnostics, result.MissingDiagnostics);
+            throw new DiagnosticVerificationException(errorMessage, result);
+        }
+    }
+
+    private static string BuildErrorMessage(List<Diagnostic> unexpected, List<DiagnosticResult> missing)
+    {
+        var message = new StringBuilder();
+        message.AppendLine("Mismatch between expected and actual diagnostics:");
+
+        if (unexpected.Any())
+        {
+            message.AppendLine("\nUnexpected Diagnostics:");
+            foreach (var diag in unexpected)
+            {
+                var lineSpan = diag.Location.GetLineSpan();
+                var line = lineSpan.StartLinePosition.Line + 1;
+                var column = lineSpan.StartLinePosition.Character + 1;
+                message.AppendLine($"  ({line},{column}): {diag.Descriptor.Id} - {diag.GetDescription()}");
+            }
+        }
+
+        if (missing.Any())
+        {
+            message.AppendLine("\nMissing Expected Diagnostics:");
+            foreach (var expected in missing)
+            {
+                var descriptor = CompilerDiagnostics.GetDescriptor(expected.Id);
+                var m = descriptor is null
+                    ? string.Join(",", expected.Arguments.Select(a => a?.ToString()))
+                    : string.Format(descriptor.MessageFormat, expected.Arguments);
+
+                var start = expected.Location.Span.StartLinePosition;
+
+                message.AppendLine($"  ({start.Line + 1},{start.Character + 1}): {expected.Id} - {m}");
+            }
+        }
+
+        return message.ToString();
+    }
+}

--- a/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
+++ b/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Reports methods without explicit return type annotations and suggests the inferred type.
+/// </summary>
+public sealed class MissingReturnTypeAnnotationAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "RAV9001";
+
+    private static readonly DiagnosticDescriptor Descriptor = DiagnosticDescriptor.Create(
+        id: DiagnosticId,
+        title: "Return type annotation missing",
+        description: null,
+        helpLinkUri: string.Empty,
+        messageFormat: "Method '{0}' has no return type annotation; consider '{1}'",
+        category: "Typing",
+        defaultSeverity: DiagnosticSeverity.Info);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterSyntaxTreeAction(AnalyzeTree);
+    }
+
+    private static void AnalyzeTree(SyntaxTreeAnalysisContext context)
+    {
+        var semanticModel = context.Compilation.GetSemanticModel(context.SyntaxTree);
+        var root = context.SyntaxTree.GetRoot();
+
+        foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            if (method.ReturnType is not null)
+                continue;
+
+            var symbol = semanticModel.GetDeclaredSymbol(method) as IMethodSymbol;
+            if (symbol is null)
+                continue;
+
+            var typeDisplay = symbol.ReturnType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            var location = method.Identifier.GetLocation();
+            var diagnostic = Diagnostic.Create(Descriptor, location, symbol.Name, typeDisplay);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
@@ -1,0 +1,29 @@
+using Raven.CodeAnalysis.Diagnostics;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Diagnostics;
+
+public class MissingReturnTypeAnnotationAnalyzerTests : AnalyzerTestBase
+{
+    [Fact]
+    public void MethodWithoutAnnotation_SuggestsInferredReturnType()
+    {
+        const string code = """
+class C {
+    Test() {
+        return 1
+    }
+}
+""";
+
+        var verifier = CreateAnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>(code,
+            expectedDiagnostics: [
+                new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
+                    .WithLocation(2, 5)
+                    .WithArguments("Test", "Unit")
+            ],
+            disabledDiagnostics: ["RAV1503"]);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- add `AnalyzerVerifier` and test base for workspace-driven analyzer tests
- specialize `MissingReturnTypeAnnotationAnalyzer` to report only missing method return types
- cover return-type analyzer with new verifier

## Testing
- `cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet format Raven.sln --no-restore --include src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs,src/Raven.Compiler/Program.cs,src/Raven.CodeAnalysis.Testing/AnalyzerVerifier.cs,src/Raven.CodeAnalysis.Testing/AnalyzerTestBase.cs,test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!="Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run"`


------
https://chatgpt.com/codex/tasks/task_e_68af46ff3f44832f8fd604babf8f7368