### PR TITLE
feat: disallow explicit returns in expressions

### DIFF
--- a/docs/lang/proposals/unit-type.md
+++ b/docs/lang/proposals/unit-type.md
@@ -37,8 +37,8 @@ func Foo() -> unit {
 * `unit` may appear in unions and tuples.
 * Declaring parameters of type `unit` is discouraged and may be disallowed; fields and properties cannot be solely `unit`, though they may use unions that include it.
 * The `unit` type typically arises from control flow and type inference rather than explicit user annotations.
-* The `()` literal may only appear as an explicit `return ()` or as the implicit result of a block; standalone expressions such as `[()]` or `(1, ())` are invalid.
-* Because `unit` is a concrete value, `return` statements must supply an expression; `return;` is invalid. Use `return ()` for an explicit unit or fall through to return it implicitly.
+* The `()` literal may appear as an explicit `return ()` or as the implicit result of a block; standalone expressions such as `[()]` or `(1, ())` are invalid.
+* Although `unit` has a concrete value, `return` may omit an expression when a function returns `unit` or .NET `void`, in which case `()` is returned implicitly.
 * `unit` participates in pattern matching like any other value. A dedicated `match` expression is a separate proposal; existing `if`-expression pattern syntax (`if x is () { ... }`) already works.
 
 ```raven

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -93,6 +93,24 @@ Any expression can appear as a statement.
 > **Note:** Control flow such as `if`, `while`, and `for` are **expressions**. When used
 > on their own line, they form an `ExpressionStatement`.
 
+### Return statements
+
+The `return` keyword exits a function, lambda, or property accessor. Because control-flow constructs are expressions, using `return` inside an expression that itself produces a value is not allowed. Explicit `return` statements may appear only in statement positions, such as within a function body or as their own expression statement. When a `return` occurs in a value context—for example, within an `if` expression assigned to a variable—the compiler reports diagnostic `RAV1900` and the block should rely on an implicit return instead.
+
+```raven
+func choose(flag: bool) -> int | () {
+    if flag {
+        42            // implicit return
+    } else {
+        ()             // implicit return
+    }
+}
+
+if flag {
+    return 42          // allowed: expression used as a statement
+}
+```
+
 ## Expressions
 
 ### Target typing

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -97,6 +97,8 @@ Any expression can appear as a statement.
 
 The `return` keyword exits a function, lambda, or property accessor. Because control-flow constructs are expressions, using `return` inside an expression that itself produces a value is not allowed. Explicit `return` statements may appear only in statement positions, such as within a function body or as their own expression statement. When a `return` occurs in a value context—for example, within an `if` expression assigned to a variable—the compiler reports diagnostic `RAV1900` and the block should rely on an implicit return instead.
 
+A `return` statement may omit its expression when the surrounding function or accessor returns `unit` (projected as `void` in IL). This is equivalent to returning the `()` value explicitly.
+
 ```raven
 func choose(flag: bool) -> int | () {
     if flag {
@@ -108,6 +110,11 @@ func choose(flag: bool) -> int | () {
 
 if flag {
     return 42          // allowed: expression used as a statement
+}
+
+func log(msg: string) {
+    Console.WriteLine(msg)
+    return            // equivalent to returning ()
 }
 ```
 

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -99,7 +99,12 @@ partial class BlockBinder : Binder
         var initializer = variableDeclarator.Initializer;
         if (initializer is not null)
         {
-            boundInitializer = BindExpression(initializer.Value);
+            // Initializers are always evaluated for their value; return statements
+            // are not permitted within them since they would escape the enclosing
+            // context. Bind the initializer with returns disallowed so explicit
+            // `return` keywords trigger diagnostics rather than method return
+            // validation.
+            boundInitializer = BindExpression(initializer.Value, allowReturn: false);
         }
 
         if (variableDeclarator.TypeAnnotation is null)

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -165,7 +165,8 @@ partial class BlockBinder : Binder
             ? BindExpression(returnStatement.Expression)
             : new BoundUnitExpression(Compilation.GetSpecialType(SpecialType.System_Unit));
 
-        if (_containingSymbol is IMethodSymbol method &&
+        if (_allowReturnsInExpression &&
+            _containingSymbol is IMethodSymbol method &&
             expr.Type is not null &&
             !IsAssignable(method.ReturnType, expr.Type))
         {

--- a/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
@@ -15,9 +15,9 @@ class MethodBodyBinder : BlockBinder
         _methodSymbol = methodSymbol;
     }
 
-    public override BoundBlockExpression BindBlock(BlockSyntax block)
+    public override BoundBlockExpression BindBlock(BlockSyntax block, bool allowReturn = true)
     {
-        var bound = base.BindBlock(block);
+        var bound = base.BindBlock(block, allowReturn);
 
         if (_methodSymbol.IsNamedConstructor)
         {

--- a/src/Raven.CodeAnalysis/BoundTree/BoundReturnStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundReturnStatement.cs
@@ -1,4 +1,4 @@
-using System.Linq.Expressions;
+using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis;
 
@@ -7,7 +7,10 @@ internal partial class BoundReturnStatement : BoundStatement
     public BoundReturnStatement(BoundExpression? expression)
     {
         Expression = expression;
+        Type = expression?.Type;
     }
 
     public BoundExpression? Expression { get; }
+
+    public override ITypeSymbol? Type { get; }
 }

--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -36,8 +36,7 @@ internal class CodeGenerator
     ConstructorInfo? _nullableCtor;
 
     bool _emitTypeUnionAttribute;
-    bool _emitNullType;
-    bool _emitUnitType = true;
+    readonly bool _emitUnitType = true;
 
     internal CustomAttributeBuilder? CreateNullableAttribute(ITypeSymbol type)
     {
@@ -119,8 +118,7 @@ internal class CodeGenerator
             CreateTypeUnionAttribute();
         if (_emitNullType)
             CreateNullStruct();
-        if (_emitUnitType)
-            CreateUnitStruct();
+        CreateUnitStruct();
 
         DefineTypeBuilders();
 
@@ -199,8 +197,6 @@ internal class CodeGenerator
                 {
                     if (t.TypeKind == TypeKind.Null)
                         _emitNullType = true;
-                    if (t.SpecialType == SpecialType.System_Unit)
-                        _emitUnitType = true;
                     CheckType(t);
                 }
                 return;
@@ -209,12 +205,6 @@ internal class CodeGenerator
             if (typeSymbol.TypeKind == TypeKind.Null)
             {
                 _emitNullType = true;
-                return;
-            }
-
-            if (typeSymbol.SpecialType == SpecialType.System_Unit)
-            {
-                _emitUnitType = true;
                 return;
             }
 

--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -36,7 +36,7 @@ internal class CodeGenerator
     ConstructorInfo? _nullableCtor;
 
     bool _emitTypeUnionAttribute;
-    readonly bool _emitUnitType = true;
+    bool _emitNullType;
 
     internal CustomAttributeBuilder? CreateNullableAttribute(ITypeSymbol type)
     {

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
@@ -41,6 +41,7 @@ internal class CompilerDiagnostics
     private static DiagnosticDescriptor? _nullableTypeInUnion;
     private static DiagnosticDescriptor? _typeAlreadyDefinesMember;
     private static DiagnosticDescriptor? _functionAlreadyDefined;
+    private static DiagnosticDescriptor? _returnStatementInExpression;
 
     /// <summary>
     /// RAV1001: Identifier; expected
@@ -519,6 +520,19 @@ internal class CompilerDiagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// RAV1900: Return statements are not valid in expressions
+    /// </summary>
+    public static DiagnosticDescriptor ReturnStatementInExpression => _returnStatementInExpression ??= DiagnosticDescriptor.Create(
+        id: "RAV1900",
+        title: "Return statement not allowed here",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Return statements are not valid in expressions; use an implicit return instead",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public static DiagnosticDescriptor[] AllDescriptors => _allDescriptors ??=
     [
         IdentifierExpected,
@@ -556,7 +570,8 @@ internal class CompilerDiagnostics
         MemberAccessRequiresTargetType,
         NullableTypeInUnion,
         TypeAlreadyDefinesMember,
-        FunctionAlreadyDefined
+        FunctionAlreadyDefined,
+        ReturnStatementInExpression
     ];
 
     public static DiagnosticDescriptor? GetDescriptor(string diagnosticId)
@@ -599,6 +614,7 @@ internal class CompilerDiagnostics
             "RAV0400" => NullableTypeInUnion,
             "RAV0111" => TypeAlreadyDefinesMember,
             "RAV0112" => FunctionAlreadyDefined,
+            "RAV1900" => ReturnStatementInExpression,
             _ => null // Return null if the diagnostic ID is not recognized
         };
     }

--- a/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
@@ -121,4 +121,7 @@ public static class DiagnosticBagExtensions
 
     public static void ReportFunctionAlreadyDefined(this DiagnosticBag diagnostics, string name, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.FunctionAlreadyDefined, location, name));
+
+    public static void ReportReturnNotAllowedInExpression(this DiagnosticBag diagnostics, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.ReturnStatementInExpression, location));
 }

--- a/src/Raven.Compiler/samples/classes.rav
+++ b/src/Raven.Compiler/samples/classes.rav
@@ -41,7 +41,7 @@ class Person {
     // Regular method
     public AddRole(role: string) -> Person {
         roles.Add(role)
-        return self
+        self
     }
 
     // public Test() -> int => 2
@@ -49,7 +49,7 @@ class Person {
     // Computed property
     public Name: string {
         get {
-            return name
+            name
         }
         set {
             name = value
@@ -64,7 +64,7 @@ class Person {
 
     // Invocation operator: e.g., person(2025)
     public self(year: int) -> string {
-        return "Name: ${name}, Age in ${year}: ${year - (System.DateTime.Now.Year - age)}"
+        "Name: ${name}, Age in ${year}: ${year - (System.DateTime.Now.Year - age)}"
     }
 
     public self(str: string) {

--- a/src/Raven.Compiler/samples/test3.rav
+++ b/src/Raven.Compiler/samples/test3.rav
@@ -1,11 +1,6 @@
-import System.*
-
-let x = test(false)
-Console.WriteLine(x);
-
-func test(flag: bool) -> int | () {
-    if flag {
-        return 42
+let a = 2
+let x = if a == 2 {
+        42
+    } else {
+        ()
     }
-    ()
-}

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
@@ -1,15 +1,14 @@
-using System;
-using System.IO;
-using System.Reflection;
+using System.Linq;
+using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Tests.Bugs;
 
-public class ExplicitReturnInIfExpressionTests
+public class ExplicitReturnInIfExpressionTests : DiagnosticTestBase
 {
     [Fact]
-    public void ExplicitReturnInIfExpressionInitializerCompiles()
+    public void ExplicitReturnInIfExpressionInitializerProducesDiagnostics()
     {
         var code = """
 class Foo {
@@ -23,27 +22,41 @@ class Foo {
 }
 """;
 
-        var syntaxTree = SyntaxTree.ParseText(code);
-        var references = TestMetadataReferences.Default;
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV1900").WithLocation(4, 13),
+                new DiagnosticResult("RAV1900").WithLocation(6, 13)
+            ]);
 
-        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddSyntaxTrees(syntaxTree)
-            .AddReferences(references);
+        var result = verifier.GetResult();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var variable = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(v => v.Identifier.Text == "x");
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(variable)!;
+        var union = Assert.IsAssignableFrom<IUnionTypeSymbol>(local.Type);
+        Assert.Contains(union.Types, t => t.SpecialType == SpecialType.System_Int32);
+        Assert.Contains(union.Types, t => t.SpecialType == SpecialType.System_Unit);
 
-        using var peStream = new MemoryStream();
-        var result = compilation.Emit(peStream);
-        Assert.True(result.Success);
+        verifier.Verify();
+    }
 
-        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
-        var assembly = loaded.Assembly;
-        var type = assembly.GetType("Foo", true)!;
-        var instance = Activator.CreateInstance(type)!;
-        var method = type.GetMethod("Test")!;
-        var intResult = method.Invoke(instance, new object[] { true });
-        Assert.Equal(42, (int)intResult!);
+    [Fact]
+    public void ExplicitReturnInIfExpressionStatementIsAllowed()
+    {
+        var code = """
+class Foo {
+    Test(flag: bool) -> int | () {
+        if flag {
+            return 42
+        } else {
+            return ()
+        }
+    }
+}
+""";
 
-        var unitResult = method.Invoke(instance, new object[] { false });
-        Assert.NotNull(unitResult);
-        Assert.Equal("Unit", unitResult!.GetType().Name);
+        var verifier = CreateVerifier(code);
+
+        verifier.Verify();
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
@@ -41,6 +41,35 @@ class Foo {
     }
 
     [Fact]
+    public void ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics()
+    {
+        var code = """
+let x = if true {
+    return 42
+} else {
+    return ()
+}
+""";
+
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV1900").WithLocation(2, 5),
+                new DiagnosticResult("RAV1900").WithLocation(4, 5)
+            ]);
+
+        var result = verifier.GetResult();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var variable = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(v => v.Identifier.Text == "x");
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(variable)!;
+        var union = Assert.IsAssignableFrom<IUnionTypeSymbol>(local.Type);
+        Assert.Contains(union.Types, t => t.SpecialType == SpecialType.System_Int32);
+        Assert.Contains(union.Types, t => t.SpecialType == SpecialType.System_Unit);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void ExplicitReturnInIfExpressionStatementIsAllowed()
     {
         var code = """


### PR DESCRIPTION
## Summary
- track expression context to allow `return` only in expression statements
- warn with RAV1900 suggesting implicit return in value contexts
- cover explicit return scenarios with regression tests

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,src/Raven.CodeAnalysis/CompilerDiagnostics.cs,test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs`
- `dotnet build`
- `dotnet test` *(fails: CodeGeneratorTests.Emit_ShouldGenerateClass, ForExpressionTests.ForEach_OverArray_UsesTypedElement, StringInterpolationTests.InterpolatedString_FormatsCorrectly, NullableAttributeEmissionTests, MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType, UnionConversionTests, ExplicitReturnInIfExpressionTests, SampleProgramsTests, etc.)*
- `dotnet test --filter ExplicitReturnInIfExpressionTests`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run(...))*

------
https://chatgpt.com/codex/tasks/task_e_68af5012d36c832f845e2dc3ef2d3b40