### PR TITLE
fix: allow return without value in unit methods

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
@@ -48,6 +48,14 @@ class MethodBodyBinder : BlockBinder
         return bound;
     }
 
+    public override BoundNode GetOrBind(SyntaxNode node)
+    {
+        if (node is BlockSyntax block)
+            return BindBlock(block, allowReturn: true);
+
+        return base.GetOrBind(node);
+    }
+
     private sealed class NamedConstructorRewriter : BoundTreeRewriter
     {
         private readonly IMethodSymbol _methodSymbol;

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -109,7 +109,10 @@ internal class StatementSyntaxParser : SyntaxParser
 
         SetTreatNewlinesAsTokens(false);
 
-        var expression = new ExpressionSyntaxParser(this).ParseExpressionOrNull();
+        ExpressionSyntax? expression = null;
+        var next = PeekToken();
+        if (next.Kind is not (SyntaxKind.SemicolonToken or SyntaxKind.CloseBraceToken or SyntaxKind.EndOfFileToken))
+            expression = new ExpressionSyntaxParser(this).ParseExpression();
 
         SetTreatNewlinesAsTokens(true);
 

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ReturnStatementUnitTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ReturnStatementUnitTests.cs
@@ -1,0 +1,20 @@
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class ReturnStatementUnitTests : DiagnosticTestBase
+{
+    [Fact]
+    public void UnitMethod_ExplicitReturn_NoDiagnostics()
+    {
+        var code = """
+class Foo {
+    Test() -> unit {
+        return;
+    }
+}
+""";
+        var verifier = CreateVerifier(code);
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- allow return statements without a value when the next token is a terminator
- ensure method bodies bind blocks with return support
- add regression test for explicit return in unit methods

## Testing
- `dotnet build`
- `dotnet test` *(fails: UnionConversionTests.UnionNotConvertibleToExplicitType_ProducesDiagnostic, StringInterpolationTests.InterpolatedString_FormatsCorrectly, ForExpressionTests.ForEach_OverArray_UsesTypedElement, MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType, NullableAttributeEmissionTests.NullableReferenceTypes_EmitNullableAttribute, NullableAttributeEmissionTests.UnionContainingNull_EmitsNullableAttribute, NullableAttributeEmissionTests.NonNullableReferenceTypes_DoNotEmitNullableAttribute, ReturnStatementUnitTests.UnitMethod_ExplicitReturn_NoDiagnostics, CodeGeneratorTests.Emit_ShouldGenerateClass, SampleProgramsTests.Sample_should_compile_and_run)*
- `dotnet test --filter ReturnStatementUnitTests.UnitMethod_ExplicitReturn_NoDiagnostics`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run(fileName: "type-unions.rav"), SampleProgramsTests.Sample_should_compile_and_run(fileName: "classes.rav"))*


------
https://chatgpt.com/codex/tasks/task_e_68af72623b64832fb5d768bf4d181b99