### PR TITLE
feat(testing): support span-based diagnostic checks

### DIFF
--- a/docs/compiler/development/testing/verifying-diagnostics.md
+++ b/docs/compiler/development/testing/verifying-diagnostics.md
@@ -27,7 +27,8 @@ public class DiagnosticVerifierTest
         var verifier = CreateVerifier(
             testCode,
             expectedDiagnostics: [
-                new DiagnosticResult("RAV1010").WithLocation(1, 36)
+                // Validate the full span of the diagnostic
+                new DiagnosticResult("RAV1010").WithSpan(1, 36, 1, 46)
             ],
             disabledDiagnostics: [ "RAV1002" ]);
 
@@ -52,3 +53,7 @@ public class DiagnosticVerifierTest
     }
 }
 ```
+
+`WithSpan` verifies both the start and end of the diagnostic. Use `WithLocation` to
+check only the start position, or `WithAnySpan()` (or omit a location entirely)
+to match a diagnostic regardless of its span.

--- a/src/Raven.CodeAnalysis.Testing/DiagnosticVerifierTest.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticVerifierTest.cs
@@ -94,6 +94,48 @@ public class DiagnosticVerifierTest
         Assert.Empty(result.UnexpectedDiagnostics);
     }
 
+    [Fact]
+    public void GetResult_WithSpan()
+    {
+        string testCode =
+            """
+            String
+            """;
+
+        var verifier = CreateVerifier(
+            testCode,
+            [
+                new DiagnosticResult("RAV0103").WithSpan(1, 1, 1, 7).WithArguments("String")
+            ]);
+
+        var result = verifier.GetResult();
+
+        result.MatchedDiagnostics.Count.ShouldBe(1);
+        Assert.Empty(result.MissingDiagnostics);
+        Assert.Empty(result.UnexpectedDiagnostics);
+    }
+
+    [Fact]
+    public void GetResult_WithAnySpan()
+    {
+        string testCode =
+            """
+            String
+            """;
+
+        var verifier = CreateVerifier(
+            testCode,
+            [
+                new DiagnosticResult("RAV0103").WithAnySpan().WithArguments("String")
+            ]);
+
+        var result = verifier.GetResult();
+
+        result.MatchedDiagnostics.Count.ShouldBe(1);
+        Assert.Empty(result.MissingDiagnostics);
+        Assert.Empty(result.UnexpectedDiagnostics);
+    }
+
     private DiagnosticVerifier CreateVerifier(string testCode, IList<DiagnosticResult>? expectedDiagnostics = null, IList<string>? disabledDiagnostics = null)
     {
         return new DiagnosticVerifier


### PR DESCRIPTION
## Summary
- expand `DiagnosticVerifier` to validate full spans, start-only locations, or any span
- add `WithSpan` and `WithAnySpan` helpers for diagnostics
- document span-aware verification and cover with tests

## Testing
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'`


------
https://chatgpt.com/codex/tasks/task_e_68af7c457300832f810397f03d746e5f