### PR TITLE
test: verify diagnostics with spans

### DIFF
--- a/src/Raven.CodeAnalysis.Testing/DiagnosticVerifierTest.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticVerifierTest.cs
@@ -38,7 +38,7 @@ public class DiagnosticVerifierTest
             var verifier = CreateVerifier(
                  testCode,
                  [
-                    new DiagnosticResult("RAV1002").WithLocation(1, 47)
+                    new DiagnosticResult("RAV1002").WithSpan(1, 47, 1, 48)
                  ]);
 
             verifier.Verify();
@@ -62,7 +62,7 @@ public class DiagnosticVerifierTest
         var verifier = CreateVerifier(
             testCode,
             [
-                new DiagnosticResult("RAV1010").WithLocation(1, 36),
+                new DiagnosticResult("RAV1010").WithSpan(1, 36, 1, 36),
             ]);
 
         var result = verifier.GetResult();
@@ -83,7 +83,7 @@ public class DiagnosticVerifierTest
         var verifier = CreateVerifier(
             testCode,
             [
-                new DiagnosticResult("RAV1010").WithLocation(1, 36)
+                new DiagnosticResult("RAV1010").WithSpan(1, 36, 1, 36)
             ],
             ["RAV1002"]);
 


### PR DESCRIPTION
## Summary
- verify diagnostic locations using WithSpan in DiagnosticVerifier tests

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis.Testing/DiagnosticVerifierTest.cs -v diag`
- `dotnet build`
- `dotnet test src/Raven.CodeAnalysis.Testing/Raven.CodeAnalysis.Testing.csproj`
- `dotnet test` *(fails: SampleProgramsTests.Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e46197c832f826233620a2d7b6d