### PR TITLE
test: use WithSpan for diagnostics

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs
@@ -24,8 +24,8 @@ class Foo {
 
         var verifier = CreateVerifier(code,
             expectedDiagnostics: [
-                new DiagnosticResult("RAV1900").WithLocation(4, 13),
-                new DiagnosticResult("RAV1900").WithLocation(6, 13)
+                new DiagnosticResult("RAV1900").WithSpan(4, 13, 4, 13),
+                new DiagnosticResult("RAV1900").WithSpan(6, 13, 6, 13)
             ]);
 
         var result = verifier.GetResult();
@@ -53,8 +53,8 @@ let x = if true {
 
         var verifier = CreateVerifier(code,
             expectedDiagnostics: [
-                new DiagnosticResult("RAV1900").WithLocation(2, 5),
-                new DiagnosticResult("RAV1900").WithLocation(4, 5)
+                new DiagnosticResult("RAV1900").WithSpan(2, 5, 2, 5),
+                new DiagnosticResult("RAV1900").WithSpan(4, 5, 4, 5)
             ]);
 
         var result = verifier.GetResult();

--- a/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
@@ -19,7 +19,7 @@ class C {
         var verifier = CreateAnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>(code,
             expectedDiagnostics: [
                 new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
-                    .WithLocation(2, 5)
+                    .WithSpan(2, 5, 2, 9)
                     .WithArguments("Test", "Unit")
             ],
             disabledDiagnostics: ["RAV1503"]);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -219,7 +219,7 @@ public class AliasResolutionTest : DiagnosticTestBase
 
         var verifier = CreateVerifier(
             testCode,
-            expectedDiagnostics: [new DiagnosticResult("RAV2020").WithSeverity(DiagnosticSeverity.Error).WithLocation(1, 13)],
+            expectedDiagnostics: [new DiagnosticResult("RAV2020").WithSeverity(DiagnosticSeverity.Error).WithSpan(1, 13, 1, 21)],
             disabledDiagnostics: ["RAV0103"]);
 
         verifier.Verify();

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs
@@ -17,7 +17,7 @@ public class ExpressionSemanticTest : DiagnosticTestBase
         var verifier = CreateVerifier(
                     testCode,
                     [
-                         new DiagnosticResult("RAV1501").WithLocation(3, 1).WithArguments("WriteLine", "1")
+                         new DiagnosticResult("RAV1501").WithSpan(3, 1, 3, 39).WithArguments("WriteLine", "1")
                     ]);
 
         verifier.Verify();

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -15,7 +15,7 @@ public class ImportResolutionTest : DiagnosticTestBase
         var verifier = CreateVerifier(
                     testCode,
                     [
-                         new DiagnosticResult("RAV0103").WithLocation(1, 1).WithArguments("String")
+                         new DiagnosticResult("RAV0103").WithSpan(1, 1, 1, 7).WithArguments("String")
                     ]);
 
         verifier.Verify();
@@ -49,7 +49,7 @@ public class ImportResolutionTest : DiagnosticTestBase
         var verifier = CreateVerifier(
             testCode,
             [
-                new DiagnosticResult("RAV0103").WithLocation(2, 16).WithArguments("String")
+                new DiagnosticResult("RAV0103").WithSpan(2, 16, 2, 22).WithArguments("String")
             ]);
 
         verifier.Verify();
@@ -111,7 +111,7 @@ public class ImportResolutionTest : DiagnosticTestBase
         var verifier = CreateVerifier(
             testCode,
             [
-                new DiagnosticResult("RAV0305").WithLocation(3, 8).WithArguments("List", 1)
+                new DiagnosticResult("RAV0305").WithSpan(3, 8, 3, 12).WithArguments("List", 1)
             ]);
 
         verifier.Verify();
@@ -160,8 +160,8 @@ public class ImportResolutionTest : DiagnosticTestBase
         var verifier = CreateVerifier(
             testCode,
             [
-                new DiagnosticResult("RAV0235").WithLocation(1, 8),
-                new DiagnosticResult("RAV0103").WithLocation(3, 1).WithArguments("String"),
+                new DiagnosticResult("RAV0235").WithSpan(1, 8, 1, 14),
+                new DiagnosticResult("RAV0103").WithSpan(3, 1, 3, 7).WithArguments("String"),
             ]);
 
         verifier.Verify();

--- a/test/Raven.CodeAnalysis.Tests/Semantics/NamespaceResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/NamespaceResolutionTest.cs
@@ -29,7 +29,7 @@ public class NamespaceResolutionTest : DiagnosticTestBase
         var verifier = CreateVerifier(
                testCode,
                [
-                    new DiagnosticResult("RAV0234").WithLocation(1, 8).WithArguments("Foo", "System"),
+                    new DiagnosticResult("RAV0234").WithSpan(1, 8, 1, 11).WithArguments("Foo", "System"),
                ]);
 
         verifier.Verify();
@@ -59,7 +59,7 @@ public class NamespaceResolutionTest : DiagnosticTestBase
         var verifier = CreateVerifier(
                     testCode,
                     [
-                         new DiagnosticResult("RAV0117").WithLocation(1, 1).WithArguments("Console", "WriteLine2"),
+                         new DiagnosticResult("RAV0117").WithSpan(1, 1, 1, 26).WithArguments("Console", "WriteLine2"),
                     ]);
 
         verifier.Verify();
@@ -76,7 +76,7 @@ public class NamespaceResolutionTest : DiagnosticTestBase
         var verifier = CreateVerifier(
                     testCode,
                     [
-                         new DiagnosticResult("RAV0103").WithLocation(1, 1).WithArguments("Console"),
+                         new DiagnosticResult("RAV0103").WithSpan(1, 1, 1, 8).WithArguments("Console"),
                     ]);
 
         verifier.Verify();

--- a/test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs
@@ -18,7 +18,7 @@ public class PropertyBindingTests : DiagnosticTestBase
             """;
 
         var verifier = CreateVerifier(testCode,
-            [new DiagnosticResult("RAV0117").WithLocation(6, 5).WithArguments("Foo", "Bar")]);
+            [new DiagnosticResult("RAV0117").WithSpan(6, 5, 6, 8).WithArguments("Foo", "Bar")]);
 
         verifier.Verify();
     }
@@ -38,7 +38,7 @@ public class PropertyBindingTests : DiagnosticTestBase
             """;
 
         var verifier = CreateVerifier(testCode,
-            [new DiagnosticResult("RAV0103").WithLocation(7, 3).WithArguments("Bar")]);
+            [new DiagnosticResult("RAV0103").WithSpan(7, 3, 7, 6).WithArguments("Bar")]);
 
         verifier.Verify();
     }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs
@@ -17,7 +17,7 @@ public class SymbolQueryTests : DiagnosticTestBase
             """;
 
         var verifier = CreateVerifier(testCode,
-            [new DiagnosticResult("RAV0117").WithLocation(5, 1).WithArguments("Foo", "M")]);
+            [new DiagnosticResult("RAV0117").WithSpan(5, 1, 5, 6).WithArguments("Foo", "M")]);
 
         verifier.Verify();
     }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
@@ -46,8 +46,8 @@ class Baz {
 """;
 
         var verifier = CreateVerifier(code, [
-            new DiagnosticResult("RAV1503").WithLocation(6, 9).WithArguments("Foo | Bar", "Foo"),
-            new DiagnosticResult("RAV1503").WithLocation(9, 20).WithArguments("Bar", "Foo"),
+            new DiagnosticResult("RAV1503").WithSpan(6, 9, 6, 9).WithArguments("Foo | Bar", "Foo"),
+            new DiagnosticResult("RAV1503").WithSpan(9, 20, 9, 25).WithArguments("Bar", "Foo"),
         ]);
         verifier.Verify();
     }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/StringLiteralTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/StringLiteralTests.cs
@@ -28,7 +28,7 @@ public class StringLiteralTests : DiagnosticTestBase
         var verifier = CreateVerifier(
                testCode,
                [
-                    new DiagnosticResult("RAV1010").WithLocation(1, 1)
+                    new DiagnosticResult("RAV1010").WithSpan(1, 1, 1, 1)
                ]);
 
         verifier.Verify();


### PR DESCRIPTION
## Summary
- verify diagnostics with WithSpan across tests

## Testing
- `dotnet format test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --include test/Raven.CodeAnalysis.Tests/Bugs/ExplicitReturnInIfExpressionTests.cs,test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs,test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs,test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs,test/Raven.CodeAnalysis.Tests/Semantics/NamespaceResolutionTest.cs,test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs,test/Raven.CodeAnalysis.Tests/Syntax/StringLiteralTests.cs` *(fails: The server disconnected unexpectedly.)*
- `dotnet build`
- `dotnet test` *(fails: Return statements are not valid in expressions; sample programs exit with code 134)*

------
https://chatgpt.com/codex/tasks/task_e_68af8910ce80832fb5323597449aa357