### PR TITLE
feat: highlight diagnostics in console highlighter

### DIFF
--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -125,7 +125,7 @@ if (shouldDumpSyntax)
 {
     ConsoleSyntaxHighlighter.ColorScheme = ColorScheme.Light;
 
-    Console.WriteLine(root.WriteNodeToText(compilation));
+    Console.WriteLine(root.WriteNodeToText(compilation, includeDiagnostics: true));
 
     Console.WriteLine();
 }

--- a/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
@@ -1,0 +1,27 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Text;
+using Raven.CodeAnalysis.Tests;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Text.Tests;
+
+public class ConsoleSyntaxHighlighterTests
+{
+    [Fact]
+    public void UnderlinesDiagnosticSpans_WhenEnabled()
+    {
+        var source = """
+import System.*
+Console.WriteLine(Console.WriteLine());
+""";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var root = tree.GetRoot();
+
+        var text = root.WriteNodeToText(compilation, includeDiagnostics: true);
+
+        Assert.Contains("\u001b[91m", text);
+        Assert.Contains("~", text);
+    }
+}


### PR DESCRIPTION
## Summary
- underline diagnostic spans in console highlighter
- color-code underlines by severity and add tests

## Testing
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68af8a680cb0832fb951666b49c5d1fa