### PR TITLE
docs: add NodeGenerator documentation

### DIFF
--- a/docs/compiler/development/node-generator.md
+++ b/docs/compiler/development/node-generator.md
@@ -1,0 +1,23 @@
+# Node generator
+
+`NodeGenerator` builds most of the syntax tree infrastructure from XML descriptions.
+It reads the `Model.xml`, `Tokens.xml`, and `NodeKinds.xml` files in
+`src/Raven.CodeAnalysis/Syntax` and emits code for both the public
+"red" nodes and the internal "green" nodes along with visitors,
+rewriters, and factory helpers.
+
+See the [generator specification](../architecture/generator-specification.md)
+for a detailed description of the produced members and algorithms. The
+structure of the XML files is described in the
+[XML format specification](../../../tools/NodeGenerator/README.md).
+
+## Running the generator
+
+Regenerate syntax nodes whenever the XML model or generator code changes:
+
+```bash
+cd src/Raven.CodeAnalysis/Syntax
+# add `-f` to force regeneration
+dotnet run --project ../../../tools/NodeGenerator -- -f
+```
+

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -38,6 +38,8 @@
       href: development/debugging.md
     - name: Source generation
       href: development/source-generation.md
+    - name: Node generator
+      href: development/node-generator.md
     - name: Analyzers
       href: development/analyzers.md
     - name: CIL


### PR DESCRIPTION
## Summary
- document the NodeGenerator tool and link to existing specification
- add Node generator to the compiler docs table of contents

## Testing
- `dotnet format Raven.sln --include docs/compiler/development/node-generator.md docs/compiler/toc.yml`

------
https://chatgpt.com/codex/tasks/task_e_68af9bb6ad4c832f8e748b97da36d8e5