### PR TITLE
test: show diagnostic spans in verifier output

### DIFF
--- a/src/Raven.CodeAnalysis.Testing/AnalyzerVerifier.cs
+++ b/src/Raven.CodeAnalysis.Testing/AnalyzerVerifier.cs
@@ -100,7 +100,9 @@ public class AnalyzerVerifier<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, n
                 var lineSpan = diag.Location.GetLineSpan();
                 var line = lineSpan.StartLinePosition.Line + 1;
                 var column = lineSpan.StartLinePosition.Character + 1;
-                message.AppendLine($"  ({line},{column}): {diag.Descriptor.Id} - {diag.GetDescription()}");
+                var endLine = lineSpan.EndLinePosition.Line + 1;
+                var endColumn = lineSpan.EndLinePosition.Character + 1;
+                message.AppendLine($"  ({line},{column} - {endLine},{endColumn}): {diag.Descriptor.Id} - {diag.GetDescription()}");
             }
         }
 
@@ -115,8 +117,12 @@ public class AnalyzerVerifier<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, n
                     : string.Format(descriptor.MessageFormat, expected.Arguments);
 
                 var start = expected.Location.Span.StartLinePosition;
+                var end = expected.Location.Span.EndLinePosition;
+                var loc = expected.Location.Options.HasFlag(DiagnosticLocationOptions.IgnoreLocation)
+                    ? "?:? - ?:?"
+                    : $"{start.Line + 1},{start.Character + 1} - {end.Line + 1},{end.Character + 1}";
 
-                message.AppendLine($"  ({start.Line + 1},{start.Character + 1}): {expected.Id} - {m}");
+                message.AppendLine($"  ({loc}): {expected.Id} - {m}");
             }
         }
 

--- a/src/Raven.CodeAnalysis.Testing/AnalyzerVerifierTest.cs
+++ b/src/Raven.CodeAnalysis.Testing/AnalyzerVerifierTest.cs
@@ -1,0 +1,28 @@
+using Raven.CodeAnalysis.Diagnostics;
+using Shouldly;
+
+namespace Raven.CodeAnalysis.Testing;
+
+public class AnalyzerVerifierTest
+{
+    [Fact]
+    public void Verify_ThrowsException_WhenMissingDiagnostic()
+    {
+        const string code = "class C { }";
+
+        var verifier = new AnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>
+        {
+            Test = new Test
+            {
+                TestCode = code,
+                ExpectedDiagnostics =
+                [
+                    new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId).WithSpan(1, 1, 1, 1)
+                ]
+            }
+        };
+
+        var exception = Assert.Throws<DiagnosticVerificationException>(() => verifier.Verify());
+        exception.Message.ShouldContain("(1,1 - 1,1)");
+    }
+}

--- a/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
@@ -149,9 +149,10 @@ public class DiagnosticVerifier
                 var m = string.Format(descriptor!.MessageFormat, expected.Arguments);
 
                 var start = expected.Location.Span.StartLinePosition;
+                var end = expected.Location.Span.EndLinePosition;
                 var loc = expected.Location.Options.HasFlag(DiagnosticLocationOptions.IgnoreLocation)
-                    ? "?:?"
-                    : $"{start.Line + 1},{start.Character + 1}";
+                    ? "?:? - ?:?"
+                    : $"{start.Line + 1},{start.Character + 1} - {end.Line + 1},{end.Character + 1}";
 
                 message.AppendLine($"  ({loc}): {expected.Id} - {m}");
             }

--- a/src/Raven.CodeAnalysis.Testing/DiagnosticVerifierTest.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticVerifierTest.cs
@@ -49,6 +49,7 @@ public class DiagnosticVerifierTest
         result.MatchedDiagnostics.Count.ShouldBe(0);
         result.MissingDiagnostics.Count.ShouldBe(1);
         result.UnexpectedDiagnostics.Count.ShouldBe(0);
+        exception.Message.ShouldContain("(1,47 - 1,48)");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- include start and end positions when diagnostic verifiers report spans
- cover span formatting in verifier exception messages with unit tests

## Testing
- `dotnet format src/Raven.CodeAnalysis.Testing/Raven.CodeAnalysis.Testing.csproj --no-restore --include AnalyzerVerifier.cs,DiagnosticVerifier.cs,DiagnosticVerifierTest.cs,AnalyzerVerifierTest.cs`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run`
- `dotnet test --filter FullyQualifiedName=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: Assert.Equal() Failure - Exit code 134)*

------
https://chatgpt.com/codex/tasks/task_e_68af9bc94c94832f80af76498bfc49a0