### PR TITLE
fix: handle pattern locals in if condition

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/PatternVariableTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/PatternVariableTests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class PatternVariableTests
+{
+    [Fact]
+    public void PatternVariableInIfCondition_EmitsSuccessfully()
+    {
+        var code = """
+import System.*
+
+let v = if true { 1; } else { true; }
+if v is int a {
+    Console.WriteLine(a)
+}
+""";
+
+        var tree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(references);
+
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success);
+    }
+}


### PR DESCRIPTION
## Summary
- preserve pattern variables from `if` condition by scoping condition and then branch together
- guard against missing local builders
- add regression test for pattern variable scoping

## Testing
- `dotnet build`
- `dotnet test --filter FullyQualifiedName\!~Sample_should_compile_and_run`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Assert.Equal() Failure Expected: 0 Actual: 134)*

------
https://chatgpt.com/codex/tasks/task_e_68af9ea30314832f99f4daf4390ec860