### PR TITLE
docs: note generator responsibility for visitors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Major components:
 - `src/Raven.CodeAnalysis` — core compiler (syntax tree, binder, semantic model, code generation).
 - `src/Raven.Compiler` — CLI entry point and sample programs.
 - `test/Raven.CodeAnalysis.Tests` — unit tests.
-- `tools/NodeGenerator` / `tools/Generator` — code‑generation utilities for syntax nodes and Roslyn-based generators.
+- `tools/NodeGenerator` / `tools/Generator` — code‑generation utilities for syntax nodes and Roslyn-based generators. `tools/Generator` is responsible for the visitors for Symbols and Bound Nodes.
 - `docs/` — language design notes and specification.
 
 ## Build & Test


### PR DESCRIPTION
## Summary
- mention that `tools/Generator` is responsible for visitors for Symbols and Bound Nodes in AGENTS.md

## Testing
- `dotnet format --no-restore --include AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_68af9efa7c18832fb783d7eeec314b08