### PR TITLE
fix: handle local declarations in named constructors

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ObjectCreationTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ObjectCreationTests.cs
@@ -88,6 +88,31 @@ public class ObjectCreationTests : DiagnosticTestBase
     }
 
     [Fact]
+    public void NamedConstructorWithLocalDeclarationCreatesObject()
+    {
+        string testCode =
+            """
+            class Person {
+                var name: string;
+
+                public init WithName(name: string) {
+                    let temp = name;
+                    self.name = temp;
+                }
+
+                public GetName() -> string => name;
+            }
+
+            let p = Person.WithName("John");
+            let n = p.GetName();
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void DefaultConstructorSynthesizedWhenMissing()
     {
         string testCode =


### PR DESCRIPTION
## Summary
- adjust NamedConstructorRewriter to update all implicit `self` assignments
- add regression test for named constructor containing local variable declarations

## Testing
- `dotnet format Raven.sln --verify-no-changes --include src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/ObjectCreationTests.cs`
- `dotnet build Raven.sln`
- `dotnet test Raven.sln --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run`
- `dotnet test Raven.sln --filter FullyQualifiedName=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68afa1bf6734832f9e1909e179b976d0