### PR TITLE
feat: infer return type for missing annotations

### DIFF
--- a/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
+++ b/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
@@ -30,25 +31,79 @@ public sealed class MissingReturnTypeAnnotationAnalyzer : DiagnosticAnalyzer
         var semanticModel = context.Compilation.GetSemanticModel(context.SyntaxTree);
         var root = context.SyntaxTree.GetRoot();
 
-        void AnalyzeNode(SyntaxNode node, SyntaxToken identifier, SyntaxNode? returnType)
+        void AnalyzeNode(SyntaxNode node, SyntaxToken identifier, SyntaxNode? returnType, SyntaxNode? body)
         {
-            if (returnType is not null)
+            if (returnType is not null || body is null)
                 return;
 
             var symbol = semanticModel.GetDeclaredSymbol(node) as IMethodSymbol;
             if (symbol is null)
                 return;
 
-            var typeDisplay = symbol.ReturnType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            var boundBody = semanticModel.GetBoundNode(body);
+            var inferred = ReturnTypeCollector.Infer(boundBody);
+
+            if (inferred is null || inferred.SpecialType == SpecialType.System_Unit)
+                return;
+
+            if (inferred is IUnionTypeSymbol union && union.Types.All(t => t.SpecialType != SpecialType.System_Unit))
+            {
+                var commonBase = FindCommonBase(union.Types);
+                if (commonBase is not null &&
+                    commonBase.SpecialType is not SpecialType.System_Object and not SpecialType.System_ValueType)
+                {
+                    inferred = commonBase;
+                }
+            }
+
+            var typeDisplay = FormatType(inferred);
             var location = identifier.GetLocation();
             var diagnostic = Diagnostic.Create(Descriptor, location, symbol.Name, typeDisplay);
             context.ReportDiagnostic(diagnostic);
         }
 
         foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
-            AnalyzeNode(method, method.Identifier, method.ReturnType);
+            AnalyzeNode(method, method.Identifier, method.ReturnType, method.Body);
 
         foreach (var function in root.DescendantNodes().OfType<FunctionStatementSyntax>())
-            AnalyzeNode(function, function.Identifier, function.ReturnType);
+            AnalyzeNode(function, function.Identifier, function.ReturnType, function.Body);
+    }
+
+    private static string FormatType(ITypeSymbol type)
+    {
+        if (type is IUnionTypeSymbol union)
+        {
+            var parts = union.Types
+                .Select(t => t.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat))
+                .OrderBy(x => x);
+            return string.Join(" | ", parts);
+        }
+
+        return type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat);
+    }
+
+    private static ITypeSymbol? FindCommonBase(IEnumerable<ITypeSymbol> types)
+    {
+        HashSet<INamedTypeSymbol>? intersection = null;
+
+        foreach (var type in types)
+        {
+            if (type is not INamedTypeSymbol named)
+                return null;
+
+            var bases = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            for (INamedTypeSymbol? current = named; current is not null; current = current.BaseType)
+                bases.Add(current);
+
+            if (intersection is null)
+                intersection = bases;
+            else
+                intersection.IntersectWith(bases);
+
+            if (intersection.Count == 0)
+                return null;
+        }
+
+        return intersection?.FirstOrDefault();
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
@@ -20,7 +20,7 @@ class C {
             expectedDiagnostics: [
                 new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
                     .WithSpan(2, 5, 2, 9)
-                    .WithArguments("Test", "Unit")
+                    .WithArguments("Test", "int")
             ],
             disabledDiagnostics: ["RAV1503"]);
 
@@ -40,8 +40,52 @@ func Test() {
             expectedDiagnostics: [
                 new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
                     .WithSpan(1, 6, 1, 10)
-                    .WithArguments("Test", "Unit")
+                    .WithArguments("Test", "int")
             ],
+            disabledDiagnostics: ["RAV1503"]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion()
+    {
+        const string code = """
+class C {
+    Test(flag: bool) {
+        if flag {
+            return 1
+        } else {
+            return true
+        }
+    }
+}
+""";
+
+        var verifier = CreateAnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>(code,
+            expectedDiagnostics: [
+                new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
+                    .WithSpan(2, 5, 2, 9)
+                    .WithArguments("Test", "bool | int")
+            ],
+            disabledDiagnostics: ["RAV1503"]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MethodReturningUnitWithoutAnnotation_NoDiagnostic()
+    {
+        const string code = """
+class C {
+    Test() {
+        return ()
+    }
+}
+""";
+
+        var verifier = CreateAnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>(code,
+            expectedDiagnostics: [],
             disabledDiagnostics: ["RAV1503"]);
 
         verifier.Verify();


### PR DESCRIPTION
## Summary
- infer return types when methods and functions lack annotations
- handle union return types and suggest common bases where appropriate
- test missing return type analyzer including unions and unit cases

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs,test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs` *(failed: Restore operation failed)*
- `dotnet build` *(failed: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(failed: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test --filter Sample_should_compile_and_run` *(failed: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68afa8d3986c832fbf812a05150393cd