### PR TITLE
feat: infer return type for missing annotations

### DIFF
--- a/docs/compiler/development/analyzers.md
+++ b/docs/compiler/development/analyzers.md
@@ -7,8 +7,11 @@ warnings for code that compiles but might benefit from additional annotations or
 Currently available analyzers:
 
 - **MissingReturnTypeAnnotationAnalyzer** – reports a diagnostic when a function omits an
-  explicit return type. The analyzer computes the inferred type and suggests annotating the
-  method for clarity.
+  explicit return type. By surfacing the inferred type, the analyzer nudges developers to
+  weigh the clarity of explicit annotations often favored in object-oriented code against
+  the brevity and flexibility of functional style. Teams can then deliberately pick the
+  approach that best fits their codebase. When the inferred type is `Unit` (the language's
+  `void`), the analyzer suppresses the suggestion.
 
 The `Raven.Compiler` CLI uses `RavenWorkspace` to attach analyzers during compilation. Any
 analyzer diagnostics appear alongside regular compilation errors and warnings.

--- a/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
+++ b/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
@@ -7,6 +8,10 @@ namespace Raven.CodeAnalysis.Diagnostics;
 /// <summary>
 /// Reports methods without explicit return type annotations and suggests the inferred type.
 /// </summary>
+/// <remarks>
+/// Making return types explicit helps teams balance the expressiveness of functional-style
+/// inference with the clarity and intent often emphasized in object-oriented code.
+/// </remarks>
 public sealed class MissingReturnTypeAnnotationAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "RAV9001";
@@ -30,25 +35,83 @@ public sealed class MissingReturnTypeAnnotationAnalyzer : DiagnosticAnalyzer
         var semanticModel = context.Compilation.GetSemanticModel(context.SyntaxTree);
         var root = context.SyntaxTree.GetRoot();
 
-        void AnalyzeNode(SyntaxNode node, SyntaxToken identifier, SyntaxNode? returnType)
+        void AnalyzeNode(SyntaxNode node, SyntaxToken identifier, SyntaxNode? returnType, SyntaxNode? body)
         {
-            if (returnType is not null)
+            if (returnType is not null || body is null)
                 return;
 
             var symbol = semanticModel.GetDeclaredSymbol(node) as IMethodSymbol;
             if (symbol is null)
                 return;
 
-            var typeDisplay = symbol.ReturnType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            var boundBody = semanticModel.GetBoundNode(body);
+            var inferred = ReturnTypeCollector.Infer(boundBody);
+
+            if (inferred is null ||
+                inferred.SpecialType is SpecialType.System_Unit or SpecialType.System_Void)
+                return;
+
+            if (inferred is IUnionTypeSymbol union &&
+                union.Types.All(t => t.SpecialType != SpecialType.System_Unit && t.SpecialType != SpecialType.System_Void))
+            {
+                var commonBase = FindCommonBase(union.Types);
+                if (commonBase is not null &&
+                    commonBase.SpecialType != SpecialType.None &&
+                    commonBase.SpecialType != SpecialType.System_Object &&
+                    commonBase.SpecialType != SpecialType.System_ValueType)
+                {
+                    inferred = commonBase;
+                }
+            }
+
+            var typeDisplay = FormatType(inferred);
             var location = identifier.GetLocation();
             var diagnostic = Diagnostic.Create(Descriptor, location, symbol.Name, typeDisplay);
             context.ReportDiagnostic(diagnostic);
         }
 
         foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
-            AnalyzeNode(method, method.Identifier, method.ReturnType);
+            AnalyzeNode(method, method.Identifier, method.ReturnType, method.Body);
 
         foreach (var function in root.DescendantNodes().OfType<FunctionStatementSyntax>())
-            AnalyzeNode(function, function.Identifier, function.ReturnType);
+            AnalyzeNode(function, function.Identifier, function.ReturnType, function.Body);
+    }
+
+    private static string FormatType(ITypeSymbol type)
+    {
+        if (type is IUnionTypeSymbol union)
+        {
+            var parts = union.Types
+                .Select(t => t.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat))
+                .OrderBy(x => x);
+            return string.Join(" | ", parts);
+        }
+
+        return type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat);
+    }
+
+    private static ITypeSymbol? FindCommonBase(IEnumerable<ITypeSymbol> types)
+    {
+        HashSet<INamedTypeSymbol>? intersection = null;
+
+        foreach (var type in types)
+        {
+            if (type is not INamedTypeSymbol named)
+                return null;
+
+            var bases = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            for (INamedTypeSymbol? current = named; current is not null; current = current.BaseType)
+                bases.Add(current);
+
+            if (intersection is null)
+                intersection = bases;
+            else
+                intersection.IntersectWith(bases);
+
+            if (intersection.Count == 0)
+                return null;
+        }
+
+        return intersection?.FirstOrDefault();
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs
@@ -20,7 +20,7 @@ class C {
             expectedDiagnostics: [
                 new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
                     .WithSpan(2, 5, 2, 9)
-                    .WithArguments("Test", "Unit")
+                    .WithArguments("Test", "int")
             ],
             disabledDiagnostics: ["RAV1503"]);
 
@@ -40,8 +40,74 @@ func Test() {
             expectedDiagnostics: [
                 new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
                     .WithSpan(1, 6, 1, 10)
-                    .WithArguments("Test", "Unit")
+                    .WithArguments("Test", "int")
             ],
+            disabledDiagnostics: ["RAV1503"]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion()
+    {
+        const string code = """
+class C {
+    Test(flag: bool) {
+        if flag {
+            return 1
+        } else {
+            return true
+        }
+    }
+}
+""";
+
+        var verifier = CreateAnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>(code,
+            expectedDiagnostics: [
+                new DiagnosticResult(MissingReturnTypeAnnotationAnalyzer.DiagnosticId)
+                    .WithSpan(2, 5, 2, 9)
+                    .WithArguments("Test", "bool | int")
+            ],
+            disabledDiagnostics: ["RAV1503"]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MethodReturningUnitWithoutAnnotation_NoDiagnostic()
+    {
+        const string code = """
+class C {
+    Test() {
+        return ()
+    }
+}
+""";
+
+        var verifier = CreateAnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>(code,
+            expectedDiagnostics: [],
+            disabledDiagnostics: ["RAV1503"]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MethodWithBranchesReturningVoid_NoDiagnostic()
+    {
+        const string code = """
+class C {
+    Test(input: int | bool) {
+        if input is int a {
+            System.Console.WriteLine(a)
+        } else if input is bool b {
+            System.Console.WriteLine(b)
+        }
+    }
+}
+""";
+
+        var verifier = CreateAnalyzerVerifier<MissingReturnTypeAnnotationAnalyzer>(code,
+            expectedDiagnostics: [],
             disabledDiagnostics: ["RAV1503"]);
 
         verifier.Verify();


### PR DESCRIPTION
## Summary
- skip return type suggestions when the inferred type is Unit/void
- avoid collapsing unions to generic bases like ValueType or Object
- document and test non-diagnostic behavior for methods that only return Unit

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs,test/Raven.CodeAnalysis.Tests/Diagnostics/MissingReturnTypeAnnotationAnalyzerTests.cs,docs/compiler/development/analyzers.md` *(warnings: Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.)*
- `dotnet build` *(succeeded with warnings)*
- `dotnet test` *(failed: Sample_should_compile_and_run(fileName: "classes.rav", args: []) – Assert.Equal() Failure)*
- `dotnet test --filter Sample_should_compile_and_run` *(failed: Sample_should_compile_and_run(fileName: "classes.rav", args: []) – Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68afa8d3986c832fbf812a05150393cd