### PR TITLE
feat: add diagnostic severity remapping

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -305,7 +305,7 @@ public class Compilation
         }
     }
 
-    public ImmutableArray<Diagnostic> GetDiagnostics(CancellationToken cancellationToken = default)
+    public ImmutableArray<Diagnostic> GetDiagnostics(CompilationWithAnalyzersOptions? analyzerOptions = null, CancellationToken cancellationToken = default)
     {
         var diagnostics = new List<Diagnostic>();
 
@@ -323,18 +323,18 @@ public class Compilation
 
         void Add(Diagnostic diagnostic)
         {
-            var mapped = ApplyCompilationOptions(diagnostic);
+            var mapped = ApplyCompilationOptions(diagnostic, analyzerOptions?.ReportSuppressedDiagnostics ?? false);
             if (mapped is not null)
                 diagnostics.Add(mapped);
         }
     }
 
-    internal Diagnostic? ApplyCompilationOptions(Diagnostic diagnostic)
+    internal Diagnostic? ApplyCompilationOptions(Diagnostic diagnostic, bool reportSuppressedDiagnostics = false)
     {
         if (Options.SpecificDiagnosticOptions.TryGetValue(diagnostic.Descriptor.Id, out var report))
         {
             if (report == ReportDiagnostic.Suppress)
-                return null;
+                return reportSuppressedDiagnostics ? diagnostic.WithSuppression(true) : null;
 
             if (report != ReportDiagnostic.Default)
             {

--- a/src/Raven.CodeAnalysis/CompilationOptions.cs
+++ b/src/Raven.CodeAnalysis/CompilationOptions.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
 namespace Raven.CodeAnalysis;
 
 public class CompilationOptions
@@ -7,10 +10,28 @@ public class CompilationOptions
     {
     }
 
-    public CompilationOptions(OutputKind outputKind)
+    public CompilationOptions(
+        OutputKind outputKind,
+        ImmutableDictionary<string, ReportDiagnostic>? specificDiagnosticOptions = null,
+        bool runAnalyzers = true)
     {
         OutputKind = outputKind;
+        SpecificDiagnosticOptions = specificDiagnosticOptions ?? ImmutableDictionary<string, ReportDiagnostic>.Empty;
+        RunAnalyzers = runAnalyzers;
     }
 
     public OutputKind OutputKind { get; }
+
+    public ImmutableDictionary<string, ReportDiagnostic> SpecificDiagnosticOptions { get; }
+
+    public bool RunAnalyzers { get; }
+
+    public CompilationOptions WithSpecificDiagnosticOptions(IDictionary<string, ReportDiagnostic> options)
+        => new(OutputKind, SpecificDiagnosticOptions.SetItems(options), RunAnalyzers);
+
+    public CompilationOptions WithSpecificDiagnosticOption(string diagnosticId, ReportDiagnostic option)
+        => new(OutputKind, SpecificDiagnosticOptions.SetItem(diagnosticId, option), RunAnalyzers);
+
+    public CompilationOptions WithRunAnalyzers(bool runAnalyzers)
+        => new(OutputKind, SpecificDiagnosticOptions, runAnalyzers);
 }

--- a/src/Raven.CodeAnalysis/CompilationWithAnalyzersOptions.cs
+++ b/src/Raven.CodeAnalysis/CompilationWithAnalyzersOptions.cs
@@ -1,0 +1,29 @@
+namespace Raven.CodeAnalysis;
+
+public class CompilationWithAnalyzersOptions
+{
+    public CompilationWithAnalyzersOptions(
+        bool reportSuppressedDiagnostics = false,
+        bool logAnalyzerExecutionTime = false,
+        bool concurrentAnalysis = true)
+    {
+        ReportSuppressedDiagnostics = reportSuppressedDiagnostics;
+        LogAnalyzerExecutionTime = logAnalyzerExecutionTime;
+        ConcurrentAnalysis = concurrentAnalysis;
+    }
+
+    public bool ReportSuppressedDiagnostics { get; }
+
+    public bool LogAnalyzerExecutionTime { get; }
+
+    public bool ConcurrentAnalysis { get; }
+
+    public CompilationWithAnalyzersOptions WithReportSuppressedDiagnostics(bool value)
+        => new(value, LogAnalyzerExecutionTime, ConcurrentAnalysis);
+
+    public CompilationWithAnalyzersOptions WithLogAnalyzerExecutionTime(bool value)
+        => new(ReportSuppressedDiagnostics, value, ConcurrentAnalysis);
+
+    public CompilationWithAnalyzersOptions WithConcurrentAnalysis(bool value)
+        => new(ReportSuppressedDiagnostics, LogAnalyzerExecutionTime, value);
+}

--- a/src/Raven.CodeAnalysis/Diagnostic.cs
+++ b/src/Raven.CodeAnalysis/Diagnostic.cs
@@ -10,14 +10,22 @@ public class Diagnostic : IEquatable<Diagnostic>
 
     public DiagnosticSeverity Severity { get; }
 
+    public bool IsSuppressed { get; }
+
     public object[] GetMessageArgs() => _messageArgs ?? [];
 
-    public Diagnostic(DiagnosticDescriptor descriptor, Location location, object[]? messageArgs, DiagnosticSeverity? severity = null)
+    public Diagnostic(
+        DiagnosticDescriptor descriptor,
+        Location location,
+        object[]? messageArgs,
+        DiagnosticSeverity? severity = null,
+        bool isSuppressed = false)
     {
         Descriptor = descriptor;
         Location = location;
         _messageArgs = messageArgs;
         Severity = severity ?? descriptor.DefaultSeverity;
+        IsSuppressed = isSuppressed;
     }
 
     public override string ToString() => GetDescription();
@@ -73,6 +81,9 @@ public class Diagnostic : IEquatable<Diagnostic>
         if (Severity != other.Severity)
             return false;
 
+        if (IsSuppressed != other.IsSuppressed)
+            return false;
+
         // Compare the fully formatted message (args normalized via ProcessArgs)
         return string.Equals(GetMessage(), other.GetMessage(), StringComparison.Ordinal);
     }
@@ -85,6 +96,7 @@ public class Diagnostic : IEquatable<Diagnostic>
         hash.Add(Descriptor);
         hash.Add(Location);
         hash.Add(Severity);
+        hash.Add(IsSuppressed);
         // Hash by final formatted message to align with Equals
         hash.Add(GetMessage(), StringComparer.Ordinal);
         return hash.ToHashCode();
@@ -94,5 +106,8 @@ public class Diagnostic : IEquatable<Diagnostic>
     public static bool operator !=(Diagnostic? left, Diagnostic? right) => !Equals(left, right);
 
     internal Diagnostic WithSeverity(DiagnosticSeverity severity)
-        => new Diagnostic(Descriptor, Location, GetMessageArgs(), severity);
+        => new Diagnostic(Descriptor, Location, GetMessageArgs(), severity, IsSuppressed);
+
+    internal Diagnostic WithSuppression(bool isSuppressed)
+        => new Diagnostic(Descriptor, Location, GetMessageArgs(), Severity, isSuppressed);
 }

--- a/src/Raven.CodeAnalysis/ReportDiagnostic.cs
+++ b/src/Raven.CodeAnalysis/ReportDiagnostic.cs
@@ -1,0 +1,11 @@
+namespace Raven.CodeAnalysis;
+
+public enum ReportDiagnostic
+{
+    Default,
+    Suppress,
+    Hidden,
+    Info,
+    Warn,
+    Error
+}

--- a/src/Raven.CodeAnalysis/Text/ConsoleSyntaxHighlighter.cs
+++ b/src/Raven.CodeAnalysis/Text/ConsoleSyntaxHighlighter.cs
@@ -102,7 +102,7 @@ public static class ConsoleSyntaxHighlighter
         foreach (var diagnostic in compilation.GetDiagnostics().Where(d => d.Location.SourceTree == tree))
         {
             var lineSpan = diagnostic.Location.GetLineSpan();
-            var severity = diagnostic.Descriptor.DefaultSeverity;
+            var severity = diagnostic.Severity;
 
             for (var line = lineSpan.StartLinePosition.Line; line <= lineSpan.EndLinePosition.Line; line++)
             {

--- a/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs
@@ -217,11 +217,19 @@ public class Workspace
         var compilation = GetCompilation(projectId);
         var diagnostics = compilation.GetDiagnostics(cancellationToken).ToHashSet();
 
-        foreach (var reference in project.AnalyzerReferences)
+        if (project.CompilationOptions?.RunAnalyzers != false)
         {
-            foreach (var analyzer in reference.GetAnalyzers())
+            foreach (var reference in project.AnalyzerReferences)
             {
-                diagnostics.AddRange(analyzer.Analyze(compilation, cancellationToken));
+                foreach (var analyzer in reference.GetAnalyzers())
+                {
+                    foreach (var diagnostic in analyzer.Analyze(compilation, cancellationToken))
+                    {
+                        var mapped = compilation.ApplyCompilationOptions(diagnostic);
+                        if (mapped is not null)
+                            diagnostics.Add(mapped);
+                    }
+                }
             }
         }
 

--- a/src/Raven.Compiler/ConsoleEx.cs
+++ b/src/Raven.Compiler/ConsoleEx.cs
@@ -43,14 +43,14 @@ static class ConsoleEx
 
             var fileLocation = $"({location.StartLinePosition.Line + 1},{location.StartLinePosition.Character + 1})";
 
-            var color = diagnostic.Descriptor.DefaultSeverity switch
+            var color = diagnostic.Severity switch
             {
                 DiagnosticSeverity.Warning => ConsoleColor.Green,
                 DiagnosticSeverity.Error => ConsoleColor.Red,
                 _ => ConsoleColor.Black
             };
 
-            AnsiConsole.MarkupLine($"{fileDirectory}[bold]{fileName}[/]{fileLocation}: [bold {color}]{descriptor.DefaultSeverity.ToString().ToLower()} {descriptor.Id}[/]: {Markup.Escape(diagnostic.GetMessage())}");
+            AnsiConsole.MarkupLine($"{fileDirectory}[bold]{fileName}[/]{fileLocation}: [bold {color}]{diagnostic.Severity.ToString().ToLower()} {descriptor.Id}[/]: {Markup.Escape(diagnostic.GetMessage())}");
         }
     }
 }

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -147,14 +147,14 @@ if (diagnostics.Length > 0)
 if (result is not null)
 {
     // Check the result
-    if (diagnostics.Any(d => d.Descriptor.DefaultSeverity == DiagnosticSeverity.Error))
+    if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
     {
         Failed(result);
     }
     else
     {
         var warningsCount = diagnostics
-            .Count(x => x.Descriptor.DefaultSeverity == DiagnosticSeverity.Warning);
+            .Count(x => x.Severity == DiagnosticSeverity.Warning);
 
         if (warningsCount > 0)
         {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs
@@ -125,6 +125,6 @@ class C {
         var tree = SyntaxTree.ParseText(source);
         var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
         var diagnostics = compilation.GetDiagnostics();
-        Assert.DoesNotContain(diagnostics, d => d.Descriptor.DefaultSeverity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Workspaces/DiagnosticOptionsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Workspaces/DiagnosticOptionsTests.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Diagnostics;
+using Raven.CodeAnalysis.Text;
+
+namespace Raven.CodeAnalysis.Tests.Workspaces;
+
+public class DiagnosticOptionsTests
+{
+    private sealed class TodoAnalyzer : DiagnosticAnalyzer
+    {
+        public static readonly DiagnosticDescriptor Descriptor = DiagnosticDescriptor.Create(
+            id: "AN0001",
+            title: "TODO found",
+            description: null,
+            helpLinkUri: string.Empty,
+            messageFormat: "TODO found",
+            category: "Testing",
+            defaultSeverity: DiagnosticSeverity.Info);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxTreeAction(ctx =>
+            {
+                var text = ctx.SyntaxTree.GetText()?.ToString();
+                if (text is not null && text.Contains("TODO"))
+                    ctx.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None));
+            });
+        }
+    }
+
+    [Fact]
+    public void SpecificDiagnosticOptions_RemapsAnalyzerSeverity()
+    {
+        var workspace = RavenWorkspace.Create(targetFramework: TestMetadataReferences.TargetFramework);
+        var options = new CompilationOptions(OutputKind.ConsoleApplication)
+            .WithSpecificDiagnosticOption(TodoAnalyzer.Descriptor.Id, ReportDiagnostic.Error);
+        var projectId = workspace.AddProject("Test", compilationOptions: options);
+        var docId = DocumentId.CreateNew(projectId);
+        workspace.TryApplyChanges(workspace.CurrentSolution.AddDocument(docId, "test.rav", SourceText.From("TODO")));
+
+        var project = workspace.CurrentSolution.GetProject(projectId)!;
+        project = project.AddAnalyzerReference(new AnalyzerReference(new TodoAnalyzer()));
+        foreach (var reference in TestMetadataReferences.Default)
+            project = project.AddMetadataReference(reference);
+        workspace.TryApplyChanges(project.Solution);
+
+        var diagnostics = workspace.GetDiagnostics(projectId);
+        var diagnostic = Assert.Single(diagnostics, d => d.Descriptor.Id == TodoAnalyzer.Descriptor.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void SpecificDiagnosticOptions_SuppressesCompilerDiagnostic()
+    {
+        var workspace = RavenWorkspace.Create(targetFramework: TestMetadataReferences.TargetFramework);
+        var options = new CompilationOptions(OutputKind.ConsoleApplication)
+            .WithSpecificDiagnosticOption("RAV1010", ReportDiagnostic.Suppress);
+        var projectId = workspace.AddProject("Test", compilationOptions: options);
+        var docId = DocumentId.CreateNew(projectId);
+        workspace.TryApplyChanges(workspace.CurrentSolution.AddDocument(docId, "test.rav", SourceText.From("\"unterminated")));
+
+        var project = workspace.CurrentSolution.GetProject(projectId)!;
+        foreach (var reference in TestMetadataReferences.Default)
+            project = project.AddMetadataReference(reference);
+        workspace.TryApplyChanges(project.Solution);
+
+        var diagnostics = workspace.GetDiagnostics(projectId);
+        Assert.DoesNotContain(diagnostics, d => d.Descriptor.Id == "RAV1010");
+    }
+
+    [Fact]
+    public void RunAnalyzers_False_DisablesAnalyzerDiagnostics()
+    {
+        var workspace = RavenWorkspace.Create(targetFramework: TestMetadataReferences.TargetFramework);
+        var options = new CompilationOptions(OutputKind.ConsoleApplication)
+            .WithRunAnalyzers(false);
+        var projectId = workspace.AddProject("Test", compilationOptions: options);
+        var docId = DocumentId.CreateNew(projectId);
+        workspace.TryApplyChanges(workspace.CurrentSolution.AddDocument(docId, "test.rav", SourceText.From("TODO \"unterminated")));
+
+        var project = workspace.CurrentSolution.GetProject(projectId)!;
+        project = project.AddAnalyzerReference(new AnalyzerReference(new TodoAnalyzer()));
+        foreach (var reference in TestMetadataReferences.Default)
+            project = project.AddMetadataReference(reference);
+        workspace.TryApplyChanges(project.Solution);
+
+        var diagnostics = workspace.GetDiagnostics(projectId);
+        Assert.Contains(diagnostics, d => d.Descriptor.Id == "RAV1010");
+        Assert.DoesNotContain(diagnostics, d => d.Descriptor.Id == TodoAnalyzer.Descriptor.Id);
+    }
+}


### PR DESCRIPTION
## Summary
- allow per-diagnostic severity overrides and analyzer suppression via `CompilationOptions`
- respect overrides when gathering diagnostics and optionally skip analyzer execution
- cover new behavior with workspace tests

## Testing
- `dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --include src/Raven.CodeAnalysis/CompilationOptions.cs,src/Raven.CodeAnalysis/ReportDiagnostic.cs,src/Raven.CodeAnalysis/Diagnostic.cs,src/Raven.CodeAnalysis/Compilation.cs,src/Raven.CodeAnalysis/Workspaces/Objects/Workspace.cs,src/Raven.CodeAnalysis/Text/ConsoleSyntaxHighlighter.cs --verbosity diagnostic`
- `dotnet format src/Raven.Compiler/Raven.Compiler.csproj --include src/Raven.Compiler/ConsoleEx.cs,src/Raven.Compiler/Program.cs --verbosity diagnostic`
- `dotnet format test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --include test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs,test/Raven.CodeAnalysis.Tests/Workspaces/DiagnosticOptionsTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!~SampleProgramsTests`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68afb099bc70832f81e8685b7f761b2a