### PR TITLE
fix: handle null expressions in rewriter

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -23,37 +23,23 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             yield return (T)VisitSymbol(symbol)!;
     }
 
-    public virtual BoundExpression VisitExpression(BoundExpression node)
+    public virtual BoundExpression? VisitExpression(BoundExpression? node)
     {
-        switch (node)
-        {
-            case BoundLiteralExpression lit:
-                VisitLiteralExpression(lit);
-                break;
-            case BoundLocalAccess local:
-                VisitLocalAccess(local);
-                break;
-            case BoundParameterAccess par:
-                VisitParameterAccess(par);
-                break;
-            case BoundBinaryExpression bin:
-                VisitBinaryExpression(bin);
-                break;
-            case BoundInvocationExpression call:
-                VisitInvocationExpression(call);
-                break;
-            case BoundObjectCreationExpression objectCreation:
-                VisitObjectCreationExpression(objectCreation);
-                break;
-            case BoundLambdaExpression lambda:
-                VisitLambdaExpression(lambda);
-                break;
-            case BoundBlockExpression block:
-                VisitBlockExpression(block);
-                break;
-        }
+        if (node is null)
+            return null;
 
-        throw new NotImplementedException($"Unhandled expression: {node.GetType().Name}");
+        return node switch
+        {
+            BoundLiteralExpression lit => (BoundExpression)VisitLiteralExpression(lit)!,
+            BoundLocalAccess local => (BoundExpression)VisitLocalAccess(local)!,
+            BoundParameterAccess par => (BoundExpression)VisitParameterAccess(par)!,
+            BoundBinaryExpression bin => (BoundExpression)VisitBinaryExpression(bin)!,
+            BoundInvocationExpression call => (BoundExpression)VisitInvocationExpression(call)!,
+            BoundObjectCreationExpression objectCreation => (BoundExpression)VisitObjectCreationExpression(objectCreation)!,
+            BoundLambdaExpression lambda => (BoundExpression)VisitLambdaExpression(lambda)!,
+            BoundBlockExpression block => (BoundExpression)VisitBlockExpression(block)!,
+            _ => throw new NotImplementedException($"Unhandled expression: {node.GetType().Name}"),
+        };
     }
 
     public virtual INamespaceSymbol VisitNamespace(INamespaceSymbol @namespace)

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs
@@ -11,7 +11,11 @@ class Scope : Generator
 
     }
 
-    public override void AddLocal(ILocalSymbol localSymbol, LocalBuilder builder) => _localBuilders.Add(localSymbol, builder);
+    public override void AddLocal(ILocalSymbol localSymbol, LocalBuilder builder)
+    {
+        if (!_localBuilders.ContainsKey(localSymbol))
+            _localBuilders.Add(localSymbol, builder);
+    }
 
     public override LocalBuilder? GetLocal(ILocalSymbol localSymbol)
     {

--- a/src/Raven.Compiler/samples/type-unions.rav
+++ b/src/Raven.Compiler/samples/type-unions.rav
@@ -47,7 +47,7 @@ func test2 (input : int | null) -> () {
     
 }
 
-func test3 () {
+func test3 () -> int | null {
     return null
 }
 

--- a/test/Raven.CodeAnalysis.Tests/Bugs/UninitializedLocalTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/UninitializedLocalTests.cs
@@ -1,0 +1,21 @@
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class UninitializedLocalTests : DiagnosticTestBase
+{
+    [Fact]
+    public void LocalDeclarationWithoutInitializer_NoDiagnostics()
+    {
+        const string code = """
+        class Foo {
+            Test() -> unit {
+                var x: int;
+            }
+        }
+        """;
+
+        var verifier = CreateVerifier(code);
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- prevent bound tree rewriter from crashing on null expressions
- avoid duplicate local registration in scope generator
- add regression test for uninitialized locals
- clarify return type in type-unions sample

## Testing
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run`
- `dotnet test --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68afb83ec674832f9756fb119200631c