### PR TITLE
feat: support dot-prefixed decimal literals

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
@@ -119,7 +119,7 @@ internal class Lexer : ILexer
         {
             if (_stringBuilder.Length > 0) _stringBuilder.Clear();
 
-            if (char.IsLetterOrDigit(ch))
+            if (char.IsLetter(ch) || char.IsDigit(ch) || (ch == '.' && PeekChar(out ch2) && char.IsDigit(ch2)))
             {
 
                 _stringBuilder.Append(ch);
@@ -150,24 +150,36 @@ internal class Lexer : ILexer
 
                     return new Token(syntaxKind, GetStringBuilderValue(), diagnostics: diagnostics);
                 }
-                else if (char.IsDigit(ch))
+                else if (char.IsDigit(ch) || ch == '.')
                 {
                     bool isFloat = false;
-                    bool hasDecimal = false;
+                    bool hasDecimal = ch == '.';
                     bool hasExponent = false;
 
-                    // Integer part
-                    while (PeekChar(out ch) && char.IsDigit(ch))
+                    if (ch != '.')
                     {
-                        ReadChar();
-                        _stringBuilder.Append(ch);
-                    }
+                        // Integer part
+                        while (PeekChar(out ch) && char.IsDigit(ch))
+                        {
+                            ReadChar();
+                            _stringBuilder.Append(ch);
+                        }
 
-                    // Decimal point
-                    if (PeekChar(out ch) && ch == '.')
+                        // Decimal point
+                        if (PeekChar(out ch) && ch == '.')
+                        {
+                            hasDecimal = true;
+                            ReadChar(); _stringBuilder.Append('.');
+                            while (PeekChar(out ch) && char.IsDigit(ch))
+                            {
+                                ReadChar();
+                                _stringBuilder.Append(ch);
+                            }
+                        }
+                    }
+                    else
                     {
-                        hasDecimal = true;
-                        ReadChar(); _stringBuilder.Append('.');
+                        // Leading decimal point without integer part
                         while (PeekChar(out ch) && char.IsDigit(ch))
                         {
                             ReadChar();

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class LexerTests
+{
+    [Fact]
+    public void DotPrefixedDecimal_IsParsedAsNumericLiteral()
+    {
+        var lexer = new Lexer(new StringReader(".12"));
+        var token = lexer.ReadToken();
+
+        Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind);
+        Assert.Equal(".12", token.Text);
+        var value = Assert.IsType<double>(token.Value);
+        Assert.Equal(0.12d, value);
+    }
+}


### PR DESCRIPTION
## Summary
- allow numbers starting with `.` to be lexed as numeric literals
- test lexer behavior for `.12`

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs,test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs`
- `dotnet build`
- `dotnet test`
- `dotnet test --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68b0072e54dc832fb482055233caa02d