### PR TITLE
feat: track interpolated string delimiters

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -838,8 +838,11 @@ internal class ExpressionSyntaxParser : SyntaxParser
                 {
                     var segment = sb.ToString();
                     sb.Clear();
-                    contents.Add(InterpolatedStringText(new Raven.CodeAnalysis.Syntax.InternalSyntax.SyntaxToken(SyntaxKind.StringLiteralToken, segment, segment, segment.Length)));
+                    contents.Add(InterpolatedStringText(new SyntaxToken(SyntaxKind.StringLiteralToken, segment, segment, segment.Length)));
                 }
+
+                var dollarToken = new SyntaxToken(SyntaxKind.DollarToken, "$");
+                var openBraceToken = new SyntaxToken(SyntaxKind.OpenBraceToken, "{");
 
                 i += 2; // skip ${
                 int depth = 1;
@@ -853,7 +856,8 @@ internal class ExpressionSyntaxParser : SyntaxParser
                 int end = i - 1;
                 var exprText = text.Substring(start, end - start);
                 var exprSyntax = ParseExpressionFromText(exprText);
-                contents.Add(Interpolation(new Raven.CodeAnalysis.Syntax.InternalSyntax.SyntaxToken(SyntaxKind.OpenBraceToken, "{"), exprSyntax, new Raven.CodeAnalysis.Syntax.InternalSyntax.SyntaxToken(SyntaxKind.CloseBraceToken, "}")));
+                var closeBraceToken = new SyntaxToken(SyntaxKind.CloseBraceToken, "}");
+                contents.Add(Interpolation(dollarToken, openBraceToken, exprSyntax, closeBraceToken));
             }
             else
             {
@@ -865,10 +869,12 @@ internal class ExpressionSyntaxParser : SyntaxParser
         if (sb.Length > 0)
         {
             var segment = sb.ToString();
-            contents.Add(InterpolatedStringText(new Raven.CodeAnalysis.Syntax.InternalSyntax.SyntaxToken(SyntaxKind.StringLiteralToken, segment, segment, segment.Length)));
+            contents.Add(InterpolatedStringText(new SyntaxToken(SyntaxKind.StringLiteralToken, segment, segment, segment.Length)));
         }
 
-        return InterpolatedStringExpression(List(contents));
+        var startToken = new SyntaxToken(SyntaxKind.StringStartToken, "\"");
+        var endToken = new SyntaxToken(SyntaxKind.StringEndToken, "\"");
+        return InterpolatedStringExpression(startToken, List(contents), endToken);
     }
 
     private static ExpressionSyntax ParseExpressionFromText(string text)

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -155,13 +155,16 @@
     <Slot Name="CloseParenToken" Type="Token" />
   </Node>
   <Node Name="InterpolatedStringExpression" Inherits="Expression">
+    <Slot Name="StringStartToken" Type="Token" />
     <Slot Name="Contents" Type="List" ElementType="InterpolatedStringContent" />
+    <Slot Name="StringEndToken" Type="Token" />
   </Node>
   <Node Name="InterpolatedStringContent" Inherits="Node" IsAbstract="true" />
   <Node Name="InterpolatedStringText" Inherits="InterpolatedStringContent">
     <Slot Name="Token" Type="Token" />
   </Node>
   <Node Name="Interpolation" Inherits="InterpolatedStringContent">
+    <Slot Name="DollarToken" Type="Token" />
     <Slot Name="OpenBraceToken" Type="Token" />
     <Slot Name="Expression" Type="Expression" />
     <Slot Name="CloseBraceToken" Type="Token" />

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -75,6 +75,9 @@
   <TokenKind Name="CloseBraceToken" Text="}" />
   <TokenKind Name="OpenBracketToken" Text="[" />
   <TokenKind Name="CloseBracketToken" Text="]" />
+  <TokenKind Name="DollarToken" Text="$" />
+  <TokenKind Name="StringStartToken" Text="&quot;" />
+  <TokenKind Name="StringEndToken" Text="&quot;" />
 
   <!-- Trivia and specials -->
   <TokenKind Name="WhitespaceTrivia" Text=" " IsTrivia="true" />

--- a/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
@@ -24,4 +24,24 @@ Console.WriteLine(Console.WriteLine());
         Assert.Contains("\u001b[91m", text);
         Assert.Contains("~", text);
     }
+
+    [Fact]
+    public void InterpolatedString_WritesDelimiters()
+    {
+        var source = """
+class Test {
+    GetInfo(name: string) -> string {
+        return "Hello ${name}";
+    }
+}
+""";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var root = tree.GetRoot();
+
+        var text = root.WriteNodeToText(compilation);
+
+        Assert.Contains('$', text);
+        Assert.Contains('"', text);
+    }
 }


### PR DESCRIPTION
## Summary
- add explicit tokens for `$`, start, and end delimiters in interpolated strings
- parse and expose new tokens for interpolation delimiters
- verify console highlighter prints `$` and quotes

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet test --filter Sample_should_compile_and_run` *(no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b003e7047c832fa40dd7e7a9e22529