### PR TITLE
fix(parser): preserve trivia for interpolated strings

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -567,7 +567,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
                 ReadToken();
                 var str = token.GetValueText() ?? string.Empty;
                 expr = str.Contains("${")
-                    ? ParseInterpolatedStringExpression(str)
+                    ? ParseInterpolatedStringExpression(token, str)
                     : LiteralExpression(SyntaxKind.StringLiteralExpression, token);
                 break;
 
@@ -826,7 +826,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
         return ArrowExpressionClause(arrowToken, expression);
     }
 
-    private InterpolatedStringExpressionSyntax ParseInterpolatedStringExpression(string text)
+    private InterpolatedStringExpressionSyntax ParseInterpolatedStringExpression(SyntaxToken token, string text)
     {
         var contents = new List<InterpolatedStringContentSyntax>();
         var sb = new StringBuilder();
@@ -872,8 +872,18 @@ internal class ExpressionSyntaxParser : SyntaxParser
             contents.Add(InterpolatedStringText(new SyntaxToken(SyntaxKind.StringLiteralToken, segment, segment, segment.Length)));
         }
 
-        var startToken = new SyntaxToken(SyntaxKind.StringStartToken, "\"");
-        var endToken = new SyntaxToken(SyntaxKind.StringEndToken, "\"");
+        var startToken = new SyntaxToken(
+            SyntaxKind.StringStartToken,
+            "\"",
+            token.LeadingTrivia,
+            SyntaxTriviaList.Empty);
+
+        var endToken = new SyntaxToken(
+            SyntaxKind.StringEndToken,
+            "\"",
+            SyntaxTriviaList.Empty,
+            token.TrailingTrivia);
+
         return InterpolatedStringExpression(startToken, List(contents), endToken);
     }
 

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTriviaTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTriviaTest.cs
@@ -1,0 +1,35 @@
+using IS = Raven.CodeAnalysis.Syntax.InternalSyntax;
+using Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+using System.Reflection;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class InterpolatedStringTriviaTest
+{
+    [Fact]
+    public void InterpolatedString_PreservesLeadingAndTrailingTrivia()
+    {
+        var leadingTrivia = IS.SyntaxTriviaList.Create(new[] { IS.SyntaxFactory.Whitespace("  ") });
+        var trailingTrivia = IS.SyntaxTriviaList.Create(new[] { IS.SyntaxFactory.Whitespace("  ") });
+        var token = new IS.SyntaxToken(SyntaxKind.StringLiteralToken, "$\"foo{bar}\"", leadingTrivia, trailingTrivia);
+
+        var parser = new ExpressionSyntaxParser(new BaseParseContext(new Lexer(new StringReader(string.Empty))));
+        var method = typeof(ExpressionSyntaxParser).GetMethod("ParseInterpolatedStringExpression", BindingFlags.Instance | BindingFlags.NonPublic);
+        var green = (IS.InterpolatedStringExpressionSyntax)method!.Invoke(parser, new object[] { token, "foo{bar}" })!;
+        var interpolated = (InterpolatedStringExpressionSyntax)green.CreateRed()!;
+
+        var startTrivia = interpolated.StringStartToken.LeadingTrivia;
+        startTrivia.Count.ShouldBe(1);
+        var leading = startTrivia.Single();
+        leading.Kind.ShouldBe(SyntaxKind.WhitespaceTrivia);
+        leading.ToString().ShouldBe("  ");
+        interpolated.StringStartToken.TrailingTrivia.ShouldBeEmpty();
+
+        var endTrivia = interpolated.StringEndToken.TrailingTrivia;
+        endTrivia.Count.ShouldBe(1);
+        var trailing = endTrivia.Single();
+        trailing.Kind.ShouldBe(SyntaxKind.WhitespaceTrivia);
+        trailing.ToString().ShouldBe("  ");
+        interpolated.StringEndToken.LeadingTrivia.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- preserve leading/trailing trivia when parsing interpolated strings
- test trivia handling on interpolated string start/end tokens

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b00aa3fe80832fa5b3a72ddc836408