### PR TITLE
docs: clarify union type semantics

### DIFF
--- a/docs/compiler/development/analyzers.md
+++ b/docs/compiler/development/analyzers.md
@@ -4,14 +4,18 @@ Raven ships with Roslyn-style source code analyzers that inspect syntax and sema
 report diagnostics. Analyzers run as part of compilation and can surface suggestions or
 warnings for code that compiles but might benefit from additional annotations or fixes.
 
-Currently available analyzers:
+Raven currently provides analyzers for two different contexts:
 
-- **MissingReturnTypeAnnotationAnalyzer** – reports a diagnostic when a function omits an
-  explicit return type. By surfacing the inferred type, the analyzer nudges developers to
-  weigh the clarity of explicit annotations often favored in object-oriented code against
-  the brevity and flexibility of functional style. Teams can then deliberately pick the
-  approach that best fits their codebase. When the inferred type is `Unit` (the language's
-  `void`), the analyzer suppresses the suggestion.
+- **MissingReturnTypeAnnotationAnalyzer** (Raven) – reports a diagnostic when a Raven
+  function omits an explicit return type. The implementation is intentionally simple and
+  serves as a reference for building analyzers that operate on Raven syntax and semantics.
+  When the inferred type is `Unit` (the language's `void`), the analyzer suppresses the
+  suggestion.
+- **TypeUnionAnalyzer** (C#) – enforces the semantics of `[TypeUnion]` attributes in C#
+  code. Members annotated with `TypeUnionAttribute` must use `object` or `dynamic` as
+  their CLR type, and any value assigned, returned, or matched against them must implicitly
+  convert to at least one of the declared union members. The analyzer also validates
+  pattern and switch cases and only permits `null` when `null` is included in the union.
 
 The `Raven.Compiler` CLI uses `RavenWorkspace` to attach analyzers during compilation. Any
 analyzer diagnostics appear alongside regular compilation errors and warnings.

--- a/src/TypeUnionAnalyzer/README.md
+++ b/src/TypeUnionAnalyzer/README.md
@@ -1,14 +1,28 @@
 # Type Union Analyzer for C#
 
-The purpose of this analyzer is to enable the `TypeUnionAttribute` for C#, and to allow for basic type checking. 
+This Roslyn analyzer runs inside C# projects to validate usages of Raven's
+`[TypeUnion]` attribute and provide basic type checking. It helps interop
+with type unions declared in Raven.
 
-It will help interop with Raven's type unions.
+Unlike `MissingReturnTypeAnnotationAnalyzer`, which targets the Raven language
+and serves as a reference implementation for Raven analyzers, `TypeUnionAnalyzer`
+focuses solely on C# code that consumes Raven-generated unions.
 
 For every usage of an attribute with signature `[TypeUnionAttribute(params Type[] types)]`, diagnostics will be reported so to discover them more easily.
 
 Since type unions are built on `object`, similar to type `dynamic`, it is not possible to overload on parameter representing type unions.
 
 If you want to, you can use `dynamic`, because it is basically `object`.
+
+## Union semantics
+
+`TypeUnionAttribute` lists the set of concrete types that a value may take. Any parameter,
+field, property, or return annotated with `[TypeUnion]` must have a CLR type of `object` or
+`dynamic`. At each usage site the analyzer verifies that the value assigned, returned, or
+matched against the member implicitly converts to at least one of the allowed types. Pattern
+matching and switch sections are checked in the same way. `null` is only permitted when
+`typeof(void)` (representing the `null` type) is explicitly included in the attribute's type
+list.
 
 ## Samples
 
@@ -66,7 +80,7 @@ class Test
 ### Field
 
 ```csharp
-class Test 
+class Test
 {
     [TypeUnion(typeof(string), typeof(int))]
     public static object Field = 1;


### PR DESCRIPTION
## Summary
- document `[TypeUnion]` semantics for analyzer consumers
- expand TypeUnionAnalyzer README with union usage rules
- distinguish Raven and C# analyzer responsibilities

## Testing
- `dotnet format Raven.sln --include docs/compiler/development/analyzers.md,src/TypeUnionAnalyzer/README.md` *(restore operation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b01268cfc0832f834b3ce5f826d4ee