### PR TITLE
Fix namespace path colorization in ConsoleSyntaxHighlighter

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticClassifier.cs
+++ b/src/Raven.CodeAnalysis/SemanticClassifier.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Raven.CodeAnalysis.Syntax;
 
 namespace Raven.CodeAnalysis;
@@ -38,6 +39,8 @@ public static class SemanticClassifier
 
                     if (symbol != null)
                         tokenMap[descendant] = ClassifySymbol(symbol);
+                    else if (descendant.Parent.AncestorsAndSelf().OfType<ImportDirectiveSyntax>().Any())
+                        tokenMap[descendant] = SemanticClassification.Namespace;
                     else
                         tokenMap[descendant] = SemanticClassification.Default;
                 }
@@ -80,7 +83,7 @@ public static class SemanticClassifier
         {
             if (node.Parent is MemberAccessExpressionSyntax ma && ma.Name == node)
                 node = ma;
-            else if (node.Parent is QualifiedNameSyntax qn && qn.Right == node)
+            else if (node.Parent is QualifiedNameSyntax qn && (qn.Left == node || qn.Right == node))
                 node = qn;
             else if (node.Parent is InvocationExpressionSyntax inv && inv.Expression == node)
                 node = inv;

--- a/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
@@ -43,5 +44,19 @@ class Test {
 
         Assert.Contains('$', text);
         Assert.Contains('"', text);
+    }
+
+    [Fact]
+    public void FullyQualifiedNamespace_IsColorized()
+    {
+        var source = "import System.Collections.Generic.*";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var root = tree.GetRoot();
+
+        var text = root.WriteNodeToText(compilation);
+
+        var matches = Regex.Matches(text, "\u001b\\[9[56]m");
+        Assert.Equal(3, matches.Count);
     }
 }


### PR DESCRIPTION
## Summary
- ensure semantic classifier colors identifiers from import directives and climbs entire qualified names
- test ConsoleSyntaxHighlighter highlights every segment of a namespace path

## Testing
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/SemanticClassifier.cs,test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'`
- `dotnet test --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68b0105d6f04832f85fe820c996c37f8