### PR TITLE
feat: enforce directive order

### DIFF
--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
@@ -9,6 +9,8 @@ internal class CompilerDiagnostics
     private static DiagnosticDescriptor? _semicolonExpected;
     private static DiagnosticDescriptor? _characterExpected;
     private static DiagnosticDescriptor? _duplicateModifier;
+    private static DiagnosticDescriptor? _importDirectiveOutOfOrder;
+    private static DiagnosticDescriptor? _aliasDirectiveOutOfOrder;
     private static DiagnosticDescriptor? _unrecognizedEscapeSequence;
     private static DiagnosticDescriptor? _newlineInConstant;
     private static DiagnosticDescriptor? _methodNameExpected;
@@ -92,6 +94,32 @@ internal class CompilerDiagnostics
         description: "",
         helpLinkUri: "",
         messageFormat: "Duplicate '{0}' modifier",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// RAV1005: Import directive out of order
+    /// </summary>
+    public static DiagnosticDescriptor ImportDirectiveOutOfOrder => _importDirectiveOutOfOrder ??= DiagnosticDescriptor.Create(
+        id: "RAV1005",
+        title: "Import directive out of order",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Import directives must appear before alias directives and member declarations",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// RAV1006: Alias directive out of order
+    /// </summary>
+    public static DiagnosticDescriptor AliasDirectiveOutOfOrder => _aliasDirectiveOutOfOrder ??= DiagnosticDescriptor.Create(
+        id: "RAV1006",
+        title: "Alias directive out of order",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Alias directives must appear before member declarations",
         category: "compiler",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -553,6 +581,8 @@ internal class CompilerDiagnostics
         SemicolonExpected,
         CharacterExpected,
         DuplicateModifier,
+        ImportDirectiveOutOfOrder,
+        AliasDirectiveOutOfOrder,
         UnrecognizedEscapeSequence,
         NewlineInConstant,
         MethodNameExpected,
@@ -596,6 +626,8 @@ internal class CompilerDiagnostics
             "RAV1002" => SemicolonExpected,
             "RAV1003" => CharacterExpected,
             "RAV1004" => DuplicateModifier,
+            "RAV1005" => ImportDirectiveOutOfOrder,
+            "RAV1006" => AliasDirectiveOutOfOrder,
             "RAV1009" => UnrecognizedEscapeSequence,
             "RAV1010" => NewlineInConstant,
             "RAV0149" => MethodNameExpected,

--- a/src/Raven.CodeAnalysis/Syntax/CompilationUnitSyntax.cs
+++ b/src/Raven.CodeAnalysis/Syntax/CompilationUnitSyntax.cs
@@ -2,13 +2,18 @@ namespace Raven.CodeAnalysis.Syntax;
 
 public partial class CompilationUnitSyntax : SyntaxNode
 {
-public CompilationUnitSyntax(SyntaxTree syntaxTree, SyntaxList<ImportDirectiveSyntax> imports, SyntaxList<AliasDirectiveSyntax> aliases, SyntaxList<MemberDeclarationSyntax> members, SyntaxToken endOfFileToken)
-    : base(new InternalSyntax.CompilationUnitSyntax(imports.Green, aliases.Green, members.Green, endOfFileToken.Green), syntaxTree)
-{
-}
+    public CompilationUnitSyntax(SyntaxTree syntaxTree, SyntaxList<ImportDirectiveSyntax> imports, SyntaxList<AliasDirectiveSyntax> aliases, SyntaxList<MemberDeclarationSyntax> members, SyntaxToken endOfFileToken)
+        : base(new InternalSyntax.CompilationUnitSyntax(imports.Green, aliases.Green, members.Green, endOfFileToken.Green), syntaxTree)
+    {
+    }
+
+    private CompilationUnitSyntax(SyntaxTree syntaxTree, InternalSyntax.CompilationUnitSyntax green)
+        : base(green, syntaxTree)
+    {
+    }
 
     internal CompilationUnitSyntax WithSyntaxTree(SyntaxTree syntaxTree)
     {
-    return new CompilationUnitSyntax(syntaxTree, Imports, Aliases, Members, EndOfFileToken);
-}
+        return new CompilationUnitSyntax(syntaxTree, (InternalSyntax.CompilationUnitSyntax)Green);
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/DirectiveOrderTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/DirectiveOrderTests.cs
@@ -1,0 +1,36 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class DirectiveOrderTests
+{
+    [Fact]
+    public void CompilationUnit_ImportAfterMember_ProducesDiagnostic()
+    {
+        var code = """
+        struct S {}
+        import Foo;
+        """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var diagnostic = Assert.Single(tree.GetDiagnostics());
+        Assert.Equal(CompilerDiagnostics.ImportDirectiveOutOfOrder, diagnostic.Descriptor);
+    }
+
+    [Fact]
+    public void Namespace_AliasAfterMember_ProducesDiagnostic()
+    {
+        var code = """
+        namespace NS {
+            struct S {}
+            alias A = B;
+        };
+        """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var diagnostic = Assert.Single(tree.GetDiagnostics());
+        Assert.Equal(CompilerDiagnostics.AliasDirectiveOutOfOrder, diagnostic.Descriptor);
+    }
+}


### PR DESCRIPTION
## Summary
- validate import/alias/member ordering at the compilation unit and namespace level
- add diagnostics for misplaced import and alias directives
- test directive order parsing

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompilerDiagnostics.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs,src/Raven.CodeAnalysis/Syntax/CompilationUnitSyntax.cs,test/Raven.CodeAnalysis.Tests/Syntax/Parser/DirectiveOrderTests.cs`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Assert.Equal() Failure Expected: 0 Actual: 134)*

------
https://chatgpt.com/codex/tasks/task_e_68b02c584b70832faaf3e08aed6161e6