### PR TITLE
fix: resolve base constructor from source types

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/BaseConstructorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/BaseConstructorTests.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class BaseConstructorTests
+{
+    [Fact]
+    public void ParameterlessBaseConstructor_IsCalled()
+    {
+        var code = """
+open class Base {
+    var initialized: bool = false
+    public init() { initialized = true }
+    public IsInitialized: bool { get => initialized }
+}
+
+class Derived : Base {
+    public init() {}
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var version = TargetFrameworkResolver.ResolveVersion("net9.0");
+        MetadataReference[] references = [
+            .. TargetFrameworkResolver.GetReferenceAssemblies(version)
+                .Select(path => MetadataReference.CreateFromFile(path))
+        ];
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var runtimeAssembly = loaded.Assembly;
+        var type = runtimeAssembly.GetType("Derived", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var prop = type.GetProperty("IsInitialized", BindingFlags.Public | BindingFlags.Instance)!;
+        Assert.True((bool)prop.GetValue(instance)!);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid TypeBuilder.GetConstructor before type creation
- add regression test for base constructor invocation

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs,test/Raven.CodeAnalysis.Tests/CodeGen/BaseConstructorTests.cs`
- `dotnet build`
- `dotnet test` *(failed: process terminated)*
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter BaseConstructorTests --no-build` *(failed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b02a3b9660832fbc63a3684e4ea0be