### PR TITLE
feat: extend CLI options

### DIFF
--- a/src/Raven.CodeAnalysis/Text/AnsiExtensions.cs
+++ b/src/Raven.CodeAnalysis/Text/AnsiExtensions.cs
@@ -1,0 +1,12 @@
+using System.Text.RegularExpressions;
+
+namespace Raven.CodeAnalysis.Text;
+
+public static partial class AnsiExtensions
+{
+    private static readonly Regex s_ansiRegex = new("\u001B\\[[0-9;]*m", RegexOptions.Compiled);
+
+    public static string StripAnsiCodes(this string text)
+        => s_ansiRegex.Replace(text, string.Empty);
+}
+

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -13,51 +13,98 @@ using static Raven.ConsoleEx;
 
 var stopwatch = Stopwatch.StartNew();
 
-// ravc test.rav [-o test.exe]
-// dotnet run -- test.rav [-o test.exe]
-
 // Options:
-// -s - display the syntax tree
+// -s - display the syntax tree (single file only)
 // -d - dump syntax (highlighted)
 // -r - print the source
 // -b - print binder tree
+// --ref <path> - additional metadata reference
+// --moniker <tfm> - target framework moniker
+// -o <path> - output assembly path
 
-var filePath = args.Length > 0 ? args[0] : $"../../../samples/main{RavenFileExtensions.Raven}";
-var outputPath = args.Contains("-o") ? args[Array.IndexOf(args, "-o") + 1] : "test.dll"; //: null;
+var sourceFiles = new List<string>();
+var additionalRefs = new List<string>();
+string? moniker = null;
+string? outputPath = null;
 
-var debug = DebugFileExists();
+var shouldPrintSyntaxTree = false;
+var shouldDumpSyntax = false;
+var shouldDumpRawSyntax = false;
+var shouldDumpBinders = false;
 
-var shouldPrintSyntaxTree = debug || args.Contains("-s");
-var shouldDumpSyntax = debug || args.Contains("-d");
-var shouldDumpRawSyntax = debug || args.Contains("-r");
-var shouldDumpBinders = debug || args.Contains("-b");
-
-filePath = Path.GetFullPath(filePath);
-
-if (!File.Exists(filePath))
+for (int i = 0; i < args.Length; i++)
 {
-    AnsiConsole.MarkupLine($"[red]Input file '{filePath}' doesn't exist.[/]");
-    return;
+    switch (args[i])
+    {
+        case "-o":
+            if (i + 1 < args.Length)
+                outputPath = args[++i];
+            break;
+        case "-s":
+            shouldPrintSyntaxTree = true;
+            break;
+        case "-d":
+            shouldDumpSyntax = true;
+            break;
+        case "-r":
+            shouldDumpRawSyntax = true;
+            break;
+        case "-b":
+            shouldDumpBinders = true;
+            break;
+        case "--ref":
+            if (i + 1 < args.Length)
+                additionalRefs.Add(args[++i]);
+            break;
+        case "--moniker":
+            if (i + 1 < args.Length)
+                moniker = args[++i];
+            break;
+        default:
+            if (!args[i].StartsWith('-'))
+                sourceFiles.Add(args[i]);
+            break;
+    }
 }
 
-using var file = File.OpenRead(filePath);
-var sourceText = SourceText.From(file);
+var debug = DebugFileExists();
+shouldPrintSyntaxTree |= debug;
+shouldDumpSyntax |= debug;
+shouldDumpRawSyntax |= debug;
+shouldDumpBinders |= debug;
 
-var assemblyName = Path.GetFileNameWithoutExtension(filePath);
+if (sourceFiles.Count == 0)
+    sourceFiles.Add($"../../../samples/main{RavenFileExtensions.Raven}");
 
-var targetFramework = "net9.0";
+for (int i = 0; i < sourceFiles.Count; i++)
+{
+    sourceFiles[i] = Path.GetFullPath(sourceFiles[i]);
+    if (!File.Exists(sourceFiles[i]))
+    {
+        AnsiConsole.MarkupLine($"[red]Input file '{sourceFiles[i]}' doesn't exist.[/]");
+        return;
+    }
+}
+
+var assemblyName = Path.GetFileNameWithoutExtension(sourceFiles[0]);
+
+var targetFramework = moniker ?? TargetFrameworkUtil.GetLatestFramework();
+var version = TargetFrameworkResolver.ResolveVersion(targetFramework);
+var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
 
 var options = new CompilationOptions(OutputKind.ConsoleApplication);
-var version = TargetFrameworkResolver.ResolveLatestInstalledVersion();
-var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version /* version.Moniker.Version.ToString() + ".*" */);
-
 var workspace = RavenWorkspace.Create(targetFramework: targetFramework);
 var projectId = workspace.AddProject(assemblyName, compilationOptions: options);
-var documentId = DocumentId.CreateNew(projectId);
-var solution = workspace.CurrentSolution.AddDocument(documentId, Path.GetFileName(filePath), sourceText, filePath);
-workspace.TryApplyChanges(solution);
-
 var project = workspace.CurrentSolution.GetProject(projectId)!;
+
+foreach (var filePath in sourceFiles)
+{
+    using var file = File.OpenRead(filePath);
+    var sourceText = SourceText.From(file);
+    var document = project.AddDocument(Path.GetFileName(filePath), sourceText, filePath);
+    project = document.Project;
+}
+
 foreach (var reference in new[]
 {
     MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
@@ -67,31 +114,18 @@ foreach (var reference in new[]
 })
     project = project.AddMetadataReference(reference);
 
+foreach (var r in additionalRefs)
+{
+    var full = Path.GetFullPath(r);
+    project = project.AddMetadataReference(MetadataReference.CreateFromFile(full));
+}
+
 project = project.AddAnalyzerReference(new AnalyzerReference(new MissingReturnTypeAnnotationAnalyzer()));
 workspace.TryApplyChanges(project.Solution);
-
-var document = project.Documents.Single();
-var syntaxTree = document.GetSyntaxTreeAsync().Result!;
-var root = syntaxTree.GetRoot();
+project = workspace.CurrentSolution.GetProject(projectId)!;
 
 var compilation = workspace.GetCompilation(projectId);
 var diagnostics = workspace.GetDiagnostics(projectId);
-
-//var semanticModel = compilation.GetSemanticModel(syntaxTree);
-
-//var methodSymbol = semanticModel.GetDeclaredSymbol(root) as IMethodSymbol;
-//var typeSymbol = methodSymbol?.ContainingType;
-
-//var local = semanticModel.GetDeclaredSymbol(root.DescendantNodes().OfType<VariableDeclaratorSyntax>().First()) as ILocalSymbol;
-
-/*
-var result1 = semanticModel.AnalyzeControlFlow(root.DescendantNodes().OfType<ExpressionStatementSyntax>().ElementAt(2));
-var result2 = semanticModel.AnalyzeDataFlow(root.DescendantNodes().OfType<BlockSyntax>().First());
-var result3 = semanticModel.AnalyzeDataFlow(root.DescendantNodes().OfType<AssignmentExpressionSyntax>().Last());
-*/
-
-//var service = new CompletionService();
-//var items = service.GetCompletions(compilation, syntaxTree, 28);
 
 outputPath = !string.IsNullOrEmpty(outputPath) ? outputPath : compilation.AssemblyName;
 outputPath = !Path.HasExtension(outputPath) ? $"{outputPath}.dll" : outputPath;
@@ -107,35 +141,95 @@ diagnostics = diagnostics.Concat(result!.Diagnostics).Distinct().ToImmutableArra
 
 stopwatch.Stop();
 
-if (shouldDumpRawSyntax)
-{
-    var str = root.ToFullString();
-    Console.WriteLine(str);
+var allowConsoleOutput = sourceFiles.Count == 1;
 
-    Console.WriteLine();
+if (shouldDumpRawSyntax || shouldPrintSyntaxTree || shouldDumpSyntax || shouldDumpBinders)
+{
+    var debugDir = Path.Combine(Environment.CurrentDirectory, "debug");
+    Directory.CreateDirectory(debugDir);
+
+    foreach (var document in project.Documents)
+    {
+        var syntaxTree = document.GetSyntaxTreeAsync().Result!;
+        var root = syntaxTree.GetRoot();
+        var name = Path.GetFileNameWithoutExtension(document.FilePath) ?? document.Name;
+
+        if (shouldDumpRawSyntax)
+        {
+            File.WriteAllText(Path.Combine(debugDir, $"{name}.raw.rav"), root.ToFullString());
+        }
+
+        if (shouldPrintSyntaxTree)
+        {
+            var treeText = root.GetSyntaxTreeRepresentation(new PrinterOptions
+            {
+                IncludeNames = true,
+                IncludeTokens = true,
+                IncludeTrivia = true,
+                IncludeSpans = true,
+                IncludeLocations = true,
+                Colorize = true,
+                ExpandListsAsProperties = true
+            }).StripAnsiCodes();
+
+            File.WriteAllText(Path.Combine(debugDir, $"{name}.syntax-tree.txt"), treeText);
+        }
+
+        if (shouldDumpSyntax)
+        {
+            ConsoleSyntaxHighlighter.ColorScheme = ColorScheme.Light;
+            var syntax = root.WriteNodeToText(compilation, includeDiagnostics: true).StripAnsiCodes();
+            File.WriteAllText(Path.Combine(debugDir, $"{name}.syntax.txt"), syntax);
+        }
+
+        if (shouldDumpBinders)
+        {
+            var semanticModel = compilation.GetSemanticModel(syntaxTree);
+            using var sw = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(sw);
+            semanticModel.PrintBinderTree();
+            Console.SetOut(original);
+            File.WriteAllText(Path.Combine(debugDir, $"{name}.binders.txt"), sw.ToString());
+        }
+    }
 }
 
-if (shouldPrintSyntaxTree)
+if (allowConsoleOutput)
 {
-    var includeLocations = true;
-    root.PrintSyntaxTree(new PrinterOptions { IncludeNames = true, IncludeTokens = true, IncludeTrivia = true, IncludeSpans = true, IncludeLocations = includeLocations, Colorize = true, ExpandListsAsProperties = true });
+    var document = project.Documents.Single();
+    var syntaxTree = document.GetSyntaxTreeAsync().Result!;
+    var root = syntaxTree.GetRoot();
+
+    if (shouldDumpRawSyntax)
+    {
+        Console.WriteLine(root.ToFullString());
+        Console.WriteLine();
+    }
+
+    if (shouldPrintSyntaxTree)
+    {
+        var includeLocations = true;
+        root.PrintSyntaxTree(new PrinterOptions { IncludeNames = true, IncludeTokens = true, IncludeTrivia = true, IncludeSpans = true, IncludeLocations = includeLocations, Colorize = true, ExpandListsAsProperties = true });
+    }
+
+    if (shouldDumpSyntax)
+    {
+        ConsoleSyntaxHighlighter.ColorScheme = ColorScheme.Light;
+        Console.WriteLine(root.WriteNodeToText(compilation, includeDiagnostics: true));
+        Console.WriteLine();
+    }
+
+    if (shouldDumpBinders)
+    {
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        semanticModel.PrintBinderTree();
+        Console.WriteLine();
+    }
 }
-
-if (shouldDumpSyntax)
+else if (shouldDumpRawSyntax || shouldPrintSyntaxTree || shouldDumpSyntax || shouldDumpBinders)
 {
-    ConsoleSyntaxHighlighter.ColorScheme = ColorScheme.Light;
-
-    Console.WriteLine(root.WriteNodeToText(compilation, includeDiagnostics: true));
-
-    Console.WriteLine();
-}
-
-if (shouldDumpBinders)
-{
-    var semanticModel = compilation.GetSemanticModel(syntaxTree);
-    semanticModel.PrintBinderTree();
-
-    Console.WriteLine();
+    AnsiConsole.MarkupLine("[yellow]Debug output written to 'debug' folder.[/]");
 }
 
 if (diagnostics.Length > 0)
@@ -146,30 +240,21 @@ if (diagnostics.Length > 0)
 
 if (result is not null)
 {
-    // Check the result
     if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
     {
         Failed(result);
     }
     else
     {
-        var warningsCount = diagnostics
-            .Count(x => x.Severity == DiagnosticSeverity.Warning);
-
+        var warningsCount = diagnostics.Count(x => x.Severity == DiagnosticSeverity.Warning);
         if (warningsCount > 0)
-        {
             SucceededWithWarnings(warningsCount, stopwatch.Elapsed);
-        }
         else
-        {
             Succeeded(stopwatch.Elapsed);
-        }
 
         CreateAppHost(compilation, outputPath, targetFramework);
     }
 }
-
-//Console.WriteLine(compilation.GlobalNamespace.ToSymbolHierarchyString());
 
 static bool IsProjectFolder(string path)
 {

--- a/test/Raven.CodeAnalysis.Tests/Text/AnsiExtensionsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Text/AnsiExtensionsTests.cs
@@ -1,0 +1,15 @@
+using Raven.CodeAnalysis.Text;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Text.Tests;
+
+public class AnsiExtensionsTests
+{
+    [Fact]
+    public void StripAnsiCodes_RemovesEscapeSequences()
+    {
+        var text = "\u001b[31mhello\u001b[0m";
+        var result = text.StripAnsiCodes();
+        Assert.Equal("hello", result);
+    }
+}


### PR DESCRIPTION
## Summary
- allow Raven.Compiler to compile multiple files and add references
- support target framework moniker option and debug file dumps
- strip ANSI codes utility with tests

## Testing
- `dotnet format Raven.sln --include src/Raven.Compiler/Program.cs,src/Raven.CodeAnalysis/Text/AnsiExtensions.cs,test/Raven.CodeAnalysis.Tests/Text/AnsiExtensionsTests.cs`
- `dotnet build`
- `dotnet test`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b041aacf44832f93db67174fceb6fd