### PR TITLE
feat: extend CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,18 @@ dotnet run --project src/Raven.Compiler -- <path-to-file> -o <output-file-path>
 
 Options:
 
+- `-s` &ndash; display the syntax tree (single file only)
+- `-d` &ndash; dump syntax with highlighting (single file only)
+- `-r` &ndash; print the raw source (single file only)
+- `-b` &ndash; print the binder tree (single file only)
+- `--ref <path>` &ndash; additional metadata reference
+- `--framework <tfm>` &ndash; target framework
+- `-o <path>` &ndash; output assembly path
 
-> ⚠️ **When the arguments are omitted**, there is a hardcoded input file, and and hardcoded output file path (`test.dll`).
+Debug flags write their output to a `debug/` directory when multiple files are
+compiled or a `.debug` marker file is present.
+
+> ⚠️ **When the arguments are omitted**, there is a hardcoded input file, and a hardcoded output file path (`test.dll`).
 
 ---
 

--- a/docs/compiler/index.md
+++ b/docs/compiler/index.md
@@ -1,1 +1,5 @@
 # Compiler
+
+The compiler consists of several components including the command-line driver,
+[Raven.Compiler](raven-compiler.md), which can compile `.rav` files and emit
+debug information for inspection.

--- a/docs/compiler/raven-compiler.md
+++ b/docs/compiler/raven-compiler.md
@@ -1,0 +1,30 @@
+# Raven.Compiler CLI
+
+`Raven.Compiler` is the command-line entry point for the Raven language.
+It compiles one or more `.rav` source files into a .NET assembly and exposes a
+few switches for inspecting the compiler's output.
+
+## Usage
+
+```bash
+dotnet run --project src/Raven.Compiler -- [options] <source-files>
+```
+
+## Options
+
+- `-s` &ndash; display the syntax tree (single file only)
+- `-d` &ndash; dump syntax with highlighting (single file only)
+- `-r` &ndash; print the raw source (single file only)
+- `-b` &ndash; print the binder tree (single file only)
+- `--ref <path>` &ndash; additional metadata reference
+- `--framework <tfm>` &ndash; target framework (e.g. `net8.0`)
+- `-o <path>` &ndash; output assembly path
+
+If any of the debug flags above are provided while compiling multiple files or
+a `.debug` marker file exists, the output is written into a `debug/` directory
+alongside the build. Each input file produces its own syntax tree, highlighted
+syntax, raw source and binder tree dump. These files make it easier to debug
+the compiler or share reproduction cases.
+
+When no framework is specified the compiler defaults to the newest installed
+framework.

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -1,5 +1,7 @@
 - name: Overview
   href: index.md
+- name: Raven.Compiler CLI
+  href: raven-compiler.md
 - name: Architecture
   items:
     - name: Overview

--- a/src/Raven.CodeAnalysis/Text/AnsiExtensions.cs
+++ b/src/Raven.CodeAnalysis/Text/AnsiExtensions.cs
@@ -1,0 +1,12 @@
+using System.Text.RegularExpressions;
+
+namespace Raven.CodeAnalysis.Text;
+
+public static partial class AnsiExtensions
+{
+    private static readonly Regex s_ansiRegex = new("\u001B\\[[0-9;]*m", RegexOptions.Compiled);
+
+    public static string StripAnsiCodes(this string text)
+        => s_ansiRegex.Replace(text, string.Empty);
+}
+

--- a/test/Raven.CodeAnalysis.Tests/Text/AnsiExtensionsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Text/AnsiExtensionsTests.cs
@@ -1,0 +1,15 @@
+using Raven.CodeAnalysis.Text;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Text.Tests;
+
+public class AnsiExtensionsTests
+{
+    [Fact]
+    public void StripAnsiCodes_RemovesEscapeSequences()
+    {
+        var text = "\u001b[31mhello\u001b[0m";
+        var result = text.StripAnsiCodes();
+        Assert.Equal("hello", result);
+    }
+}


### PR DESCRIPTION
## Summary
- rename moniker option to `--framework` and resolve TestDep path
- document Raven.Compiler usage and debug dumps

## Testing
- `dotnet format Raven.sln --include src/Raven.Compiler/Program.cs`
- `dotnet build`
- `dotnet test` *(fails: Assert.Equal() Failure)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b041aacf44832f93db67174fceb6fd