### PR TITLE
fix: distinguish constructors with different containing types

### DIFF
--- a/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
+++ b/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
@@ -11,11 +11,24 @@ public class SymbolEqualityComparer : IEqualityComparer<ISymbol>
         // Compare kinds
         if (x.Kind != y.Kind) return false;
 
+        // Special handling for parameters to avoid recursive containment checks
+        if (x is IParameterSymbol px && y is IParameterSymbol py)
+        {
+            if (px.RefKind != py.RefKind)
+                return false;
+
+            return px.Type.Equals(py.Type, Default);
+        }
+
         // Compare names
         if (x.Name != y.Name) return false;
 
         // Compare containing namespaces
         if (!Equals(x.ContainingNamespace?.ToDisplayString(), y.ContainingNamespace?.ToDisplayString()))
+            return false;
+
+        // Compare containing symbols (e.g., enclosing types)
+        if (!Equals(x.ContainingSymbol, y.ContainingSymbol))
             return false;
 
         // Compare parameters (for methods)
@@ -45,6 +58,7 @@ public class SymbolEqualityComparer : IEqualityComparer<ISymbol>
         int hash = obj.Kind.GetHashCode();
         hash = (hash * 31) + (obj.Name?.GetHashCode() ?? 0);
         hash = (hash * 31) + (obj.ContainingNamespace?.ToDisplayString().GetHashCode() ?? 0);
+        hash = (hash * 31) + (obj.ContainingSymbol?.GetHashCode() ?? 0);
         return hash;
     }
 }


### PR DESCRIPTION
## Summary
- ensure SymbolEqualityComparer accounts for containing symbols to avoid constructor collisions
- add regression test covering implicit base constructor invocation

## Testing
- `dotnet build`
- `dotnet test` *(fails: GenericTypeInvocationCreatesObject, TupleTypeSyntax_BindsToTupleTypeSymbol_WithNames, TupleExpression_TargetTypedMismatch_ReportsDiagnostic, TupleExpression_TargetTyped_UsesDeclaredType_IgnoringNames, Sample_should_compile_and_run(main.rav), Sample_should_compile_and_run(tuples.rav), Sample_should_compile_and_run(io.rav), Sample_should_load_into_compilation(main.rav), Sample_should_load_into_compilation(tuples.rav), Sample_should_load_into_compilation(io.rav))*
- `dotnet run -- samples/classes.rav -o test.dll`
- `dotnet test.dll`

------
https://chatgpt.com/codex/tasks/task_e_68b04f485f3c832f8fec184779d75310