### PR TITLE
docs: document type system

### DIFF
--- a/docs/lang/README.md
+++ b/docs/lang/README.md
@@ -3,6 +3,7 @@
 ### Sub sections
 
 * [Language specification](spec/language-specification.md)
+* [Type system](type-system.md)
 * [Proposals](proposals)
 
 ### Vision

--- a/docs/lang/type-system.md
+++ b/docs/lang/type-system.md
@@ -1,0 +1,50 @@
+# Raven type system
+
+Raven is a statically typed language whose types correspond directly to CLR types. The compiler uses .NET type symbols so that every Raven type has a concrete runtime representation.
+
+## Primitive types
+
+| Raven keyword | .NET type | Notes |
+| --- | --- | --- |
+| `int` | `System.Int32` | 32-bit signed integer |
+| `string` | `System.String` | UTF-16 sequence of characters |
+| `bool` | `System.Boolean` | logical true/false |
+| `char` | `System.Char` | UTF-16 code unit |
+| `unit` | `System.Unit` | single value `()` representing "no result" |
+| `null` | *(null literal)* | inhabits any nullable reference type |
+
+## Composite and derived types
+
+### Arrays
+
+`T[]` becomes `System.Array` with element type `T`.
+
+### Tuples
+
+`(T1, T2, ...)` map to `System.ValueTuple<T1, T2, ...>`.
+
+### Nullable values
+
+Appending `?` creates a nullable type. Value types are emitted as `System.Nullable<T>` while reference types use C#'s nullable metadata.
+
+### Union types
+
+`A | B` represents a value that may be either type. Each branch retains its own CLR representation and the union's base type is inferred from the operands.
+
+### Generics
+
+Generic parameters compile directly to .NET generics:
+
+```raven
+func identity<T>(value: T) -> T { value }
+```
+
+## Interoperability
+
+Because Raven reuses .NET types, existing libraries can be consumed seamlessly:
+
+```raven
+let ids: Guid[] = [Guid.NewGuid()]
+Console.WriteLine(ids[0])
+```
+

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,5 +1,7 @@
 - name: Language
   href: lang/spec/language-specification.html
+- name: Type System
+  href: lang/type-system.md
 - name: Compiler
   href: compiler/
 - name: API


### PR DESCRIPTION
## Summary
- document Raven type system and CLR mapping
- link type system doc in language index and site nav

## Testing
- `dotnet format Raven.sln --include docs/lang/type-system.md,docs/lang/README.md,docs/toc.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b07350788c832fbd3d9934bbb82954