### PR TITLE
docs: add collection type proposals

### DIFF
--- a/docs/lang/proposals/array-type.md
+++ b/docs/lang/proposals/array-type.md
@@ -1,0 +1,28 @@
+# Proposal: Array type syntax
+
+> ⚠️ This proposal has **NOT** been implemented
+
+## Summary
+
+Introduce `ArrayTypeSyntax` to express array types using brackets after a type name.
+
+## Syntax
+
+```
+Type[]
+```
+
+The element type may be a simple or fully qualified name.
+
+## Examples
+
+```raven
+let numbers: Int[] = [1, 2, 3]
+let names: System.String[] = ["Tony", "Steve"]
+
+fun head(values: Int[]): Int {
+    return values[0]
+}
+```
+
+Array types can be used anywhere a type is expected, including variable declarations, parameters, and return types.

--- a/docs/lang/proposals/list-type.md
+++ b/docs/lang/proposals/list-type.md
@@ -1,0 +1,34 @@
+# Proposal: List type syntax
+
+> ⚠️ This proposal has **NOT** been implemented
+
+## Summary
+
+Introduce a built-in `List` type and a shorthand `[]` to denote lists. The bracket form mirrors [collection expressions](collection-expression.md) and produces a `ListTypeSyntax` node.
+
+## Syntax
+
+Explicit form:
+```
+List<T>
+```
+
+Shorthand form:
+```
+[]
+```
+
+## Examples
+
+```raven
+let heroes: List<String> = ["Iron Man", "Thor"]
+let numbers: [] = [1, 2, 3]
+
+fun printAll(values: []): Unit {
+    for v in values {
+        Console.WriteLine(v)
+    }
+}
+```
+
+List types can appear in variable declarations, parameters, and return positions. Target typing works the same as with collection expressions.


### PR DESCRIPTION
## Summary
- add array type syntax proposal
- add list type syntax proposal referencing collection expressions

## Testing
- `dotnet format Raven.sln --include docs/lang/proposals/array-type.md docs/lang/proposals/list-type.md --no-restore`
- `dotnet build`
- `dotnet test`
- `dotnet test --filter Sample_should_compile_and_run`

------
https://chatgpt.com/codex/tasks/task_e_68b075eb3724832faf855ca62e1ff4e0