### PR TITLE
feat: enforce initialization for local variables

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -561,7 +561,7 @@ literal itself in keyword form. For example:
 
 ```raven
 let x: "true" | 1 = true
-// error: Cannot convert from 'true' to '"true" | 1'
+// error: Cannot assign 'true' to '"true" | 1'
 ```
 
 Boolean literals appear lowercase (`true`/`false`) to align with their

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.cs
@@ -21,11 +21,13 @@ internal class CompilerDiagnostics
     private static DiagnosticDescriptor? _unassignedOutParameter;
     private static DiagnosticDescriptor? _variableUsedLikeAType;
     private static DiagnosticDescriptor? _useOfUnassignedVariable;
+    private static DiagnosticDescriptor? _localVariableMustBeInitialized;
     private static DiagnosticDescriptor? _memberDoesNotContainDefinition;
     private static DiagnosticDescriptor? _operatorCannotBeAppliedToOperandOfType;
     private static DiagnosticDescriptor? _typeNameDoesNotExistInType;
     private static DiagnosticDescriptor? _callIsAmbiguous;
     private static DiagnosticDescriptor? _cannotConvertFromTypeToType;
+    private static DiagnosticDescriptor? _cannotAssignFromTypeToType;
     private static DiagnosticDescriptor? _noOverloadForMethod;
     private static DiagnosticDescriptor? _typeOrNamespaceNameDoesNotExistInTheNamespace;
     private static DiagnosticDescriptor? _typeExpectedWithoutWildcard;
@@ -258,6 +260,19 @@ internal class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
+    /// RAV0166: Local variable '{0}' must be initialized
+    /// </summary>
+    public static DiagnosticDescriptor LocalVariableMustBeInitialized => _localVariableMustBeInitialized ??= DiagnosticDescriptor.Create(
+        id: "RAV0166",
+        title: "Local variable must be initialized",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Local variable '{0}' must be initialized",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// RAV0117: '{0}' does not contain a definition for '{1}'
     /// </summary>
     public static DiagnosticDescriptor MemberDoesNotContainDefinition => _memberDoesNotContainDefinition ??= DiagnosticDescriptor.Create(
@@ -323,7 +338,7 @@ internal class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
-    /// RAV1503: Cannot convert from '{0}' to {1}
+    /// RAV1503: Cannot convert from '{0}' to '{1}'
     /// </summary>
     public static DiagnosticDescriptor CannotConvertFromTypeToType => _cannotConvertFromTypeToType ??= DiagnosticDescriptor.Create(
         id: "RAV1503",
@@ -331,6 +346,19 @@ internal class CompilerDiagnostics
         description: "",
         helpLinkUri: "",
         messageFormat: "Cannot convert from '{0}' to '{1}'",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// RAV1504: Cannot assign '{0}' to '{1}'
+    /// </summary>
+    public static DiagnosticDescriptor CannotAssignFromTypeToType => _cannotAssignFromTypeToType ??= DiagnosticDescriptor.Create(
+        id: "RAV1504",
+        title: "Cannot assign to type",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Cannot assign '{0}' to '{1}'",
         category: "compiler",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -635,11 +663,13 @@ internal class CompilerDiagnostics
         UnassignedOutParameter,
         VariableUsedLikeAType,
         UseOfUnassignedVariable,
+        LocalVariableMustBeInitialized,
         MemberDoesNotContainDefinition,
         OperatorCannotBeAppliedToOperandOfType,
         TypeNameDoesNotExistInType,
         CallIsAmbiguous,
         CannotConvertFromTypeToType,
+        CannotAssignFromTypeToType,
         NoOverloadForMethod,
         TypeOrNamespaceNameDoesNotExistInTheNamespace,
         TypeExpectedWithoutWildcard,
@@ -683,11 +713,13 @@ internal class CompilerDiagnostics
             "RAV0269" => UnassignedOutParameter,
             "RAV0118" => VariableUsedLikeAType,
             "RAV0165" => UseOfUnassignedVariable,
+            "RAV0166" => LocalVariableMustBeInitialized,
             "RAV0117" => MemberDoesNotContainDefinition,
             "RAV0023" => OperatorCannotBeAppliedToOperandOfType,
             "RAV0426" => TypeNameDoesNotExistInType,
             "RAV0121" => CallIsAmbiguous,
             "RAV1503" => CannotConvertFromTypeToType,
+            "RAV1504" => CannotAssignFromTypeToType,
             "RAV1501" => NoOverloadForMethod,
             "RAV0234" => TypeOrNamespaceNameDoesNotExistInTheNamespace,
             "RAV0235" => TypeExpectedWithoutWildcard,

--- a/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs
@@ -35,6 +35,9 @@ public static class DiagnosticBagExtensions
     public static void ReportUseOfUnassignedVariable(this DiagnosticBag diagnostics, string name, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.UseOfUnassignedVariable, location, name));
 
+    public static void ReportLocalVariableMustBeInitialized(this DiagnosticBag diagnostics, string name, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.LocalVariableMustBeInitialized, location, name));
+
     public static void ReportMemberDoesNotContainDefinition(this DiagnosticBag diagnostics, string container, string member, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.MemberDoesNotContainDefinition, location, container, member));
 
@@ -49,6 +52,9 @@ public static class DiagnosticBagExtensions
 
     public static void ReportCannotConvertFromTypeToType(this DiagnosticBag diagnostics, ITypeSymbol fromType, ITypeSymbol toType, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.CannotConvertFromTypeToType, location, fromType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat), toType));
+
+    public static void ReportCannotAssignFromTypeToType(this DiagnosticBag diagnostics, ITypeSymbol fromType, ITypeSymbol toType, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.CannotAssignFromTypeToType, location, fromType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat), toType));
 
     public static void ReportNoOverloadForMethod(this DiagnosticBag diagnostics, string method, int count, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.NoOverloadForMethod, location, method, count));

--- a/test/Raven.CodeAnalysis.Tests/Bugs/UninitializedLocalTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/UninitializedLocalTests.cs
@@ -5,7 +5,7 @@ namespace Raven.CodeAnalysis.Tests.Bugs;
 public class UninitializedLocalTests : DiagnosticTestBase
 {
     [Fact]
-    public void LocalDeclarationWithoutInitializer_NoDiagnostics()
+    public void VarDeclarationWithoutInitializer_ProducesDiagnostic()
     {
         const string code = """
         class Foo {
@@ -15,7 +15,26 @@ public class UninitializedLocalTests : DiagnosticTestBase
         }
         """;
 
-        var verifier = CreateVerifier(code);
+        var verifier = CreateVerifier(code, [
+            new DiagnosticResult("RAV0166").WithAnySpan().WithArguments("x")
+        ]);
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void LetDeclarationWithoutInitializer_ProducesDiagnostic()
+    {
+        const string code = """
+        class Foo {
+            Test() -> unit {
+                let x: int;
+            }
+        }
+        """;
+
+        var verifier = CreateVerifier(code, [
+            new DiagnosticResult("RAV0166").WithAnySpan().WithArguments("x")
+        ]);
         verifier.Verify();
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
@@ -57,7 +57,7 @@ class Baz {
     {
         var code = "let x: \"true\" | 1 = true";
         var verifier = CreateVerifier(code, [
-            new DiagnosticResult("RAV1503").WithAnySpan().WithArguments("true", "\"true\" | 1")
+            new DiagnosticResult("RAV1504").WithAnySpan().WithArguments("true", "\"true\" | 1")
         ]);
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- report RAV0166 when a `let` or `var` is declared without an initializer
- use "Cannot assign" wording for assignment type errors while keeping "Cannot convert" for other contexts
- add tests for uninitialized locals

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompilerDiagnostics.cs,src/Raven.CodeAnalysis/DiagnosticsBagExtensions.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs,docs/lang/spec/language-specification.md,test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs` *(failed: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test` *(fails: multiple unit tests)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: 4 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c4c325b4832fafd8a44c2eabcc1e