### PR TITLE
fix: restrict conversion to literal types

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -368,8 +368,8 @@ public class Compilation
 
         if (source is LiteralTypeSymbol litSrc2)
             return ClassifyConversion(litSrc2.UnderlyingType, destination);
-        if (destination is LiteralTypeSymbol litDest2)
-            return ClassifyConversion(source, litDest2.UnderlyingType);
+        if (destination is LiteralTypeSymbol)
+            return Conversion.None;
 
         if (SymbolEqualityComparer.Default.Equals(source, destination) &&
             source is not NullableTypeSymbol &&

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
@@ -61,4 +61,14 @@ class Baz {
         ]);
         verifier.Verify();
     }
+
+    [Fact]
+    public void NumericLiteralNotInUnion_ProducesDiagnostic()
+    {
+        var code = "let x: \"true\" | 1 = 2";
+        var verifier = CreateVerifier(code, [
+            new DiagnosticResult("RAV1504").WithAnySpan().WithArguments("2", "\"true\" | 1")
+        ]);
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- prevent implicit conversion to literal types from non-literal values
- cover numeric literal unions with diagnostic tests

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Compilation.cs,test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`
- `dotnet test --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68b0cf3679b8832fad28326853900e31