### PR TITLE
fix: allow literal assignments to union types

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -366,8 +366,6 @@ public class Compilation
                 ? new Conversion(isImplicit: true, isIdentity: true)
                 : Conversion.None;
 
-        if (source is LiteralTypeSymbol litSrc2)
-            return ClassifyConversion(litSrc2.UnderlyingType, destination);
         if (destination is LiteralTypeSymbol)
             return Conversion.None;
 
@@ -477,6 +475,9 @@ public class Compilation
 
             return new Conversion(isImplicit: true, isBoxing: source.IsValueType);
         }
+
+        if (source is LiteralTypeSymbol litSrc2)
+            return ClassifyConversion(litSrc2.UnderlyingType, destination);
 
         if (IsReferenceConversion(source, destination))
         {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LiteralUnionAssignmentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LiteralUnionAssignmentTests.cs
@@ -1,0 +1,16 @@
+using Raven.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class LiteralUnionAssignmentTests : DiagnosticTestBase
+{
+    [Fact]
+    public void MatchingValue_AssignsToLiteralUnion()
+    {
+        var code = "let x: \"true\" | 1 = 1";
+        var verifier = CreateVerifier(code);
+        verifier.Verify();
+    }
+
+}


### PR DESCRIPTION
## Summary
- allow conversions from literals to matching union members
- add test verifying literal assignment to literal union

## Testing
- `dotnet build`
- `dotnet test --filter FullyQualifiedName~LiteralUnionAssignmentTests`
- `dotnet test` *(fails: RAV1501 No overload for method 'WriteLine' takes 1 arguments; Sample_should_compile_and_run exit code 134)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: exit code 134)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d2dbdcf4832f829124ae4177acba