### PR TITLE
feat: validate return statement types

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -47,6 +47,11 @@ real type, it participates in generics, tuples, and unions like any other type.
 
 ## Statements
 
+Raven is primarily **expression-based**: most constructs yield values and can
+appear wherever an expression is expected. For clarity and early exits,
+the language nevertheless permits certain imperative statement forms, such as
+the explicit `return` statement.
+
 Statements are terminated by a **newline**, or by an **optional semicolon** `;`
 that may separate multiple statements on one line. Newlines inside
 parentheses/brackets/braces do not terminate statements.
@@ -102,6 +107,11 @@ Any expression can appear as a statement.
 The `return` keyword exits a function, lambda, or property accessor. Because control-flow constructs are expressions, using `return` inside an expression that itself produces a value is not allowed. Explicit `return` statements may appear only in statement positions, such as within a function body or as their own expression statement. When a `return` occurs in a value context—for example, within an `if` expression assigned to a variable—the compiler reports diagnostic `RAV1900` and the block should rely on an implicit return instead.
 
 A `return` statement may omit its expression when the surrounding function or accessor returns `unit` (projected as `void` in IL). This is equivalent to returning the `()` value explicitly.
+
+Within a method-like body, each `return` is validated against the declared
+return type of that body. A `return` without an expression is treated as
+returning `unit`. If the returned expression's type is not assignable to the
+declared return type, the compiler emits a conversion diagnostic.
 
 ```raven
 func choose(flag: bool) -> int | () {

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -190,7 +190,7 @@ partial class BlockBinder : Binder
         if (returnStatement.Expression is not null)
             expr = BindExpression(returnStatement.Expression);
 
-        if (_allowReturnsInExpression && _containingSymbol is IMethodSymbol method)
+        if (_containingSymbol is IMethodSymbol method)
         {
             if (expr is null)
             {

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ReturnStatementUnitTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ReturnStatementUnitTests.cs
@@ -1,3 +1,4 @@
+using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Tests.Bugs;
@@ -15,6 +16,44 @@ class Foo {
 }
 """;
         var verifier = CreateVerifier(code);
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void NonUnitMethod_EmptyReturn_ReportsDiagnostic()
+    {
+        var code = """
+class Foo {
+    Test() -> int {
+        return;
+    }
+}
+""";
+
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id).WithSpan(3, 9, 3, 16)
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void NonUnitMethod_ReturnExpression_NotAssignable_ReportsDiagnostic()
+    {
+        var code = """
+class Foo {
+    Test() -> int {
+        return "";
+    }
+}
+""";
+
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id).WithSpan(3, 16, 3, 18)
+            ]);
+
         verifier.Verify();
     }
 }


### PR DESCRIPTION
## Summary
- specify return type checking for `return` statements in the imperative context
- validate return expressions against enclosing method return type
- add tests for empty and mismatched returns

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Bugs/ReturnStatementUnitTests.cs`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(failed: System.OutOfMemoryException, 31 failing tests)*
- `dotnet test --filter Sample_should_compile_and_run` *(failed: 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1549e9b28832fa50b9abde675bd90