### PR TITLE
fix: infer underlying type from literals

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -155,6 +155,21 @@ let pet = if flag { Dog() } else { Cat() }
 // pet has type: Dog | Cat
 ```
 
+Literal expressions infer the underlying primitive type when used to initialize
+`let` or `var` bindings. To retain a literal's singleton type, an explicit
+annotation is required.
+
+```raven
+var i = 0       // i : int
+let j = 0       // j : int
+var k: 1 = 1    // k : 1
+```
+
+Overload resolution applies the same rule: a literal argument converts to its
+underlying type when selecting among method overloads. For example,
+`Console.WriteLine(1)` binds to `Console.WriteLine(int)` if such an overload
+exists, and `Console.WriteLine("test")` chooses `Console.WriteLine(string)`.
+
 Functions and lambdas without an annotated return type infer their result by
 collecting the types of all explicit `return` statements and the final expression
 of the body. If no value-returning path exists, the type defaults to `unit`.

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -165,6 +165,17 @@ let j = 0       // j : int
 var k: 1 = 1    // k : 1
 ```
 
+Numeric literals choose an underlying primitive type. Integer literals default
+to `int` but upgrade to `long` when the value exceeds the `int` range.
+Floating-point literals default to `double`; appending `f` or `F` produces a
+`float` literal.
+
+```raven
+var l = 4_000_000_000  // l : long
+var f = 3.14f          // f : float
+var d = 3.14           // d : double
+```
+
 Overload resolution applies the same rule: a literal argument converts to its
 underlying type when selecting among method overloads. For example,
 `Console.WriteLine(1)` binds to `Console.WriteLine(int)` if such an overload

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -130,6 +130,8 @@ partial class BlockBinder : Binder
         else if (variableDeclarator.TypeAnnotation is null)
         {
             type = boundInitializer!.Type!;
+            if (type is LiteralTypeSymbol literal)
+                type = literal.UnderlyingType;
         }
         else
         {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
@@ -11,6 +11,22 @@ namespace Raven.CodeAnalysis.Semantics.Tests;
 public class LiteralTypeFlowTests : DiagnosticTestBase
 {
     [Fact]
+    public void VariableDeclaration_WithLiteral_InferredUnderlyingType()
+    {
+        var code = "var i = 0";
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+
+        Assert.Equal(SpecialType.System_Int32, local.Type.SpecialType);
+    }
+
+    [Fact]
     public void Literal_ImplicitlyConvertsToUnderlyingType()
     {
         var code = "let x: bool = true";

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
@@ -27,6 +27,22 @@ public class LiteralTypeFlowTests : DiagnosticTestBase
     }
 
     [Fact]
+    public void LetDeclaration_WithLiteral_InferredUnderlyingType()
+    {
+        var code = "let i = 0";
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+
+        Assert.Equal(SpecialType.System_Int32, local.Type.SpecialType);
+    }
+
+    [Fact]
     public void Literal_ImplicitlyConvertsToUnderlyingType()
     {
         var code = "let x: bool = true";

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
@@ -43,6 +43,38 @@ public class LiteralTypeFlowTests : DiagnosticTestBase
     }
 
     [Fact]
+    public void VariableDeclaration_WithFloatSuffix_InferredFloat()
+    {
+        var code = "var f = 3.14f"; // explicit float literal
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+
+        Assert.Equal(SpecialType.System_Single, local.Type.SpecialType);
+    }
+
+    [Fact]
+    public void VariableDeclaration_WithDoubleLiteral_InferredDouble()
+    {
+        var code = "var d = 3.14"; // default double
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+
+        Assert.Equal(SpecialType.System_Double, local.Type.SpecialType);
+    }
+
+    [Fact]
     public void Literal_ImplicitlyConvertsToUnderlyingType()
     {
         var code = "let x: bool = true";


### PR DESCRIPTION
## Summary
- ensure `var` declarations initialize to literal's underlying type instead of a literal type
- add regression test for literal variable type inference

## Testing
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(fails: 35, passes: 234)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: 4, passes: 6)*

------
https://chatgpt.com/codex/tasks/task_e_68b157b1bea0832f96712fa70a41c750