### PR TITLE
feat: support string literal type concatenation

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
@@ -188,4 +188,36 @@ let x = if true { "true" } else { 1 }
         Assert.Equal("Hello, World!", literalType.ConstantValue);
     }
 
+    [Fact]
+    public void BinaryExpression_StringLiteralAndNumericLiteralConcatenation_ReturnsLiteralType()
+    {
+        var code = "let result: \"Hello1\" = \"Hello\" + 1";
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+        var literalType = Assert.IsType<LiteralTypeSymbol>(local.Type);
+        Assert.Equal("Hello1", literalType.ConstantValue);
+    }
+
+    [Fact]
+    public void BinaryExpression_NumericLiteralAndStringLiteralConcatenation_ReturnsLiteralType()
+    {
+        var code = "let result: \"1Hello\" = 1 + \"Hello\"";
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+        var literalType = Assert.IsType<LiteralTypeSymbol>(local.Type);
+        Assert.Equal("1Hello", literalType.ConstantValue);
+    }
+
 }


### PR DESCRIPTION
## Summary
- handle concatenation of string literal types in binder, producing a new `LiteralTypeSymbol`
- add test ensuring concatenated literals retain their literal type value

## Testing
- `dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs --verbosity diagnostic`
- `dotnet format test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --include test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test` *(fails: multiple tests fail)*
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter BinaryExpression_StringLiteralConcatenation_ReturnsLiteralType -v normal`


------
https://chatgpt.com/codex/tasks/task_e_68b187cf3ad8832fa7079714035e5660