### PR TITLE
docs: document additional symbol kinds and lazy PE initialization

### DIFF
--- a/docs/compiler/design/symbols.md
+++ b/docs/compiler/design/symbols.md
@@ -4,7 +4,7 @@
 
 * **Source symbols** - Represents symbols in source code
 * **PE symbols** - Wraps metadata representing types in referenced assemblies
-* **Constructed symbols** - Represents close generic types, array types, type unions, tuple types and fields etc.
+* **Constructed symbols** - Represents closed generic types, array types, type unions, tuple types, literal and nullable types, fields etc.
 * **Synthesized symbols** - Represents concepts that are created as part of semantic analysis. Such as the implicit `Program` class and `Main` method synthesized for file-scope code, or symbols used when rewriting the Bound Tree.
 
 ## Symbol equality
@@ -21,10 +21,18 @@ The representation of an array type is `ArrayTypeSymbol`.
 
 Closed generic types are `ConstructedNamedTypeSymbols` that have "SubstituteMember" with the type parameters substituted by the type arguments.
 
-Some type symbols are specialized, exists in the language or at semantic analysis, and thus have no equivalent in .NET speak. That include `UnionTypeSymbol` and `TupleTypeSymbol`, both implementing from `INamedTypeSymbol`.
+Some type symbols are specialized, exist in the language or only during semantic analysis, and thus have no equivalent in .NET. These include `UnionTypeSymbol` and `TupleTypeSymbol`, both implementing `INamedTypeSymbol`.
 
-## PESymbols
+Other constructed type symbols serve particular purposes:
 
-### Lazy intialization
+* `NullableTypeSymbol` – wraps an underlying type in `T?`.
+* `ByRefTypeSymbol` – represents a `ref` or `out` type.
+* `LiteralTypeSymbol` – captures a specific constant value as a type for flow analysis and generics.
+* `NullTypeSymbol` – the type of the `null` literal.
+* `UnitTypeSymbol` – models the `Unit` (void) type.
 
-Every dependant type is resolved lazily via the injected `TypeResolver` which handles the creation of symbols representing arrays and closed generic types. These resolved types (mapping `Type` and `ITypeSymbol`) are cached internally.
+## PE symbols
+
+### Lazy initialization
+
+Every dependent type is resolved lazily via the injected `TypeResolver`, which creates symbols for arrays and closed generic types on demand. The resolver caches the mapping between `Type` and `ITypeSymbol` internally to avoid recomputation.


### PR DESCRIPTION
## Summary
- clarify lazy initialization in PE symbol documentation
- document additional constructed symbol kinds and their purposes
- fix typos and heading format

## Testing
- `dotnet restore Raven.sln`
- `dotnet format Raven.sln --include docs/compiler/design/symbols.md` *(warnings encountered while loading the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68b193254120832fad10f4f00da6f98d