### PR TITLE
docs: mention UnionTypeSymbol and TupleTypeSymbol

### DIFF
--- a/docs/compiler/design/symbols.md
+++ b/docs/compiler/design/symbols.md
@@ -25,6 +25,8 @@ Some type symbols are specialized, exist in the language or only during semantic
 
 Other constructed type symbols serve particular purposes:
 
+* `UnionTypeSymbol` – models a value whose type can be any of its constituent types.
+* `TupleTypeSymbol` – packs named elements into a fixed-size tuple backed by `System.ValueTuple`.
 * `NullableTypeSymbol` – wraps an underlying type in `T?`.
 * `ByRefTypeSymbol` – represents a `ref` or `out` type.
 * `LiteralTypeSymbol` – captures a specific constant value as a type for flow analysis and generics.


### PR DESCRIPTION
## Summary
- explain UnionTypeSymbol and TupleTypeSymbol as constructed type symbols

## Testing
- `dotnet format Raven.sln --include docs/compiler/design/symbols.md` (warnings were encountered while loading the workspace)


------
https://chatgpt.com/codex/tasks/task_e_68b1955b42d0832f9b2ed4853b7a34f2