### PR TITLE
docs: reference diagnostic resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,12 +38,13 @@ If your changes touch documentation only, you may skip `dotnet build` and `dotne
 * Keep services loosely coupled—prefer interfaces and dependency injection.
 
 ## Contribution Checklist
-* Format each changed file using `dotnet format <path to dir of solution or project file> --include <comma separated list with file paths>` to respect `.editorconfig` rules.
+* Format each changed code file using `dotnet format <path to dir of solution or project file> --include <comma separated list with file paths>` to respect `.editorconfig` rules. Do **not** run `dotnet format` solely to reformat Markdown files.
 * Run `dotnet build` and `dotnet test` (omit for documentation-only changes unless verification is required).
 * Ensure generated files (e.g., via `tools/NodeGenerator`) are up to date. (Required for building Raven.CodeAnalysis)
 * Add or update unit tests for every fix or feature.
 * Include concise commit messages (`feat:`, `fix:`, `docs:` etc.).
 * Provide PR summaries referencing relevant diagnostics or examples.
+* For details on diagnostics, see `docs/compiler/diagnostics.md` and `src/Raven.CodeAnalysis/DiagnosticDescriptors.xml`.
 * Update the language specification, grammar, and related docs when necessary.
 _(Only do so if explicitly instructed.)_
 


### PR DESCRIPTION
## Summary
- mention diagnostics sources in contributing guidelines
- clarify that `dotnet format` shouldn't be used for markdown-only changes

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_68b19fcace40832f8cf42abcd4d1c40a