### PR TITLE
feat: allow aliasing of literal types

### DIFF
--- a/docs/compiler/diagnostics.md
+++ b/docs/compiler/diagnostics.md
@@ -394,5 +394,5 @@ let x = .ToString() // RAV2010
 Alias directive targets an unsupported symbol.
 
 ```raven
-alias five = 5 // RAV2020
+alias Bad = notatype // RAV2020
 ```

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -6,7 +6,7 @@
 CompilationUnit          ::= {ImportDirective} {AliasDirective} {Declaration | Statement} EOF ;
 
 ImportDirective          ::= 'import' QualifiedName ('.' '*')? ; (* Namespace imports require '.*'; applying '.*' to a type imports its static members and nested types *)
-AliasDirective           ::= 'alias' Identifier '=' Type ; (* Target may be a fully qualified name, type expression, or predefined type: bool | char | int | string | unit | '()' *)
+AliasDirective           ::= 'alias' Identifier '=' Type ; (* Target may be a fully qualified name, type expression, literal type, or predefined type: bool | char | int | string | unit | '()' *)
 
 (* ---------- Modifiers ---------- *)
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -395,6 +395,7 @@ alias Pair = (x: int, y: int)
 alias Number = int | string
 alias Flag = bool
 alias Text = string
+alias Five = 5
 
 let sb = SB()
 PrintLine("Hi")
@@ -405,9 +406,9 @@ Aliasing a method binds a specific overload. Multiple directives using the
 same alias name may appear to alias additional overloads, forming an overload
 set.
 
-Predefined types may be aliased directly. The supported built-in alias targets are `bool`, `char`, `int`, `string`, and `unit` (spelled `unit` or `()`).
+Predefined and literal types may be aliased directly. The supported built-in alias targets are `bool`, `char`, `int`, `string`, `unit` (spelled `unit` or `()`), and any literal value.
 Raven has no `void`; `unit` is projected to and from .NET `void`.
-If the alias target is invalid, the compiler emits diagnostic `RAV2020`, which lists the supported targets such as types, namespaces, unions, tuples, and these predefined types.
+If the alias target is invalid, the compiler emits diagnostic `RAV2020`, which lists the supported targets such as types, namespaces, unions, tuples, these predefined types, and literal values.
 
 Aliases require fully qualified names for namespaces, types, and members to
 avoid ambiguity; type expressions are written directly. Alias directives may

--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -188,6 +188,41 @@ internal sealed class AliasUnionTypeSymbol : AliasSymbol, IUnionTypeSymbol
     public IEnumerable<ITypeSymbol> Types => _type.Types;
 }
 
+internal sealed class AliasLiteralTypeSymbol : AliasSymbol, ITypeSymbol
+{
+    private readonly LiteralTypeSymbol _type;
+
+    public AliasLiteralTypeSymbol(string name, LiteralTypeSymbol underlying)
+        : base(name, underlying)
+    {
+        _type = underlying;
+    }
+
+    public bool IsNamespace => _type.IsNamespace;
+
+    public bool IsType => _type.IsType;
+
+    public ImmutableArray<ISymbol> GetMembers() => _type.GetMembers();
+
+    public ImmutableArray<ISymbol> GetMembers(string name) => _type.GetMembers(name);
+
+    public ITypeSymbol? LookupType(string name) => _type.LookupType(name);
+
+    public bool IsMemberDefined(string name, out ISymbol? symbol) => _type.IsMemberDefined(name, out symbol);
+
+    public INamedTypeSymbol? BaseType => _type.BaseType;
+
+    public ITypeSymbol? OriginalDefinition => _type.OriginalDefinition;
+
+    public SpecialType SpecialType => _type.SpecialType;
+
+    public TypeKind TypeKind => _type.TypeKind;
+
+    public bool IsReferenceType => _type.IsReferenceType;
+
+    public bool IsValueType => _type.IsValueType;
+}
+
 internal sealed class AliasMethodSymbol : AliasSymbol, IMethodSymbol
 {
     private readonly IMethodSymbol _method;
@@ -272,6 +307,7 @@ internal static class AliasSymbolFactory
         INamespaceSymbol n => new AliasNamespaceSymbol(name, n),
         IUnionTypeSymbol u => new AliasUnionTypeSymbol(name, u),
         INamedTypeSymbol t => new AliasNamedTypeSymbol(name, t),
+        LiteralTypeSymbol l => new AliasLiteralTypeSymbol(name, l),
         IMethodSymbol m => new AliasMethodSymbol(name, m),
         IPropertySymbol p => new AliasPropertySymbol(name, p),
         IFieldSymbol f => new AliasFieldSymbol(name, f),

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -109,6 +109,30 @@ public class AliasResolutionTest : DiagnosticTestBase
     }
 
     [Fact]
+    public void AliasDirective_UsesAlias_Literal()
+    {
+        string testCode =
+            """
+            alias Five = 5
+
+            let x: Five = 5
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        var result = verifier.GetResult();
+        verifier.Verify();
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().First(id => id.Identifier.Text == "Five");
+        var symbol = model.GetSymbolInfo(identifier).Symbol;
+        Assert.NotNull(symbol);
+        Assert.True(symbol!.IsAlias);
+        var alias = Assert.IsAssignableFrom<IAliasSymbol>(symbol);
+        Assert.IsType<LiteralTypeSymbol>(alias.UnderlyingSymbol);
+    }
+
+    [Fact]
     public void AliasDirective_UsesMemberAlias_Method()
     {
         string testCode =


### PR DESCRIPTION
## Summary
- support aliasing literal-value types via new `AliasLiteralTypeSymbol`
- document and test literal type aliases

## Testing
- `dotnet build`
- `dotnet test` *(fails: Failed: 78, Passed: 216, Skipped: 4)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Failed: 8, Passed: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a1101730832f817b6377e02c69ff