### PR TITLE
feat: add console-based editor prototype

### DIFF
--- a/Raven.sln
+++ b/Raven.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp", "test\TestApp\Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TypeUnionAnalyzer.Tests", "test\TypeUnionAnalyzer.Tests\TypeUnionAnalyzer.Tests.csproj", "{BA1526F3-4525-4658-BA57-AAA630F4F97C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Editor", "src\Raven.Editor\Raven.Editor.csproj", "{2034A721-7A3B-470B-A7D6-8D9EA240048E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -187,6 +189,18 @@ Global
 		{BA1526F3-4525-4658-BA57-AAA630F4F97C}.Release|x64.Build.0 = Release|Any CPU
 		{BA1526F3-4525-4658-BA57-AAA630F4F97C}.Release|x86.ActiveCfg = Release|Any CPU
 		{BA1526F3-4525-4658-BA57-AAA630F4F97C}.Release|x86.Build.0 = Release|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Debug|x64.Build.0 = Debug|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Debug|x86.Build.0 = Debug|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Release|x64.ActiveCfg = Release|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Release|x64.Build.0 = Release|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Release|x86.ActiveCfg = Release|Any CPU
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -204,6 +218,7 @@ Global
 		{C3F3E59F-D1D5-48FD-98C9-E9F4F446E3F3} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 		{32F44C2B-6639-4D68-9127-EF685C4FFEEA} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 		{BA1526F3-4525-4658-BA57-AAA630F4F97C} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
+		{2034A721-7A3B-470B-A7D6-8D9EA240048E} = {1BF06D1D-C317-434E-B4AF-1404CDE6D171}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {083D8FC4-3D3B-476A-AF17-77AC247C299F}

--- a/src/Raven.Editor/CodeTextView.cs
+++ b/src/Raven.Editor/CodeTextView.cs
@@ -1,0 +1,70 @@
+using NStack;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Text;
+using Terminal.Gui;
+using Attribute = Terminal.Gui.Attribute;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Raven.Editor;
+
+/// <summary>
+/// Simple text view with Raven-based syntax highlighting.
+/// </summary>
+public class CodeTextView : TextView
+{
+    private readonly Dictionary<List<Rune>, SyntaxToken[]> _lineTokens = new();
+
+    private static readonly Attribute KeywordAttr = new(Color.BrightBlue, Color.Black);
+    private static readonly Attribute NumberAttr = new(Color.BrightYellow, Color.Black);
+    private static readonly Attribute StringAttr = new(Color.BrightGreen, Color.Black);
+
+    /// <inheritdoc />
+    public override void OnContentsChanged()
+    {
+        _lineTokens.Clear();
+        base.OnContentsChanged();
+    }
+
+    /// <inheritdoc />
+    protected override void SetNormalColor(List<Rune> line, int idx)
+    {
+        if (!_lineTokens.TryGetValue(line, out var tokens))
+        {
+            var text = new string(line.Select(r => (char)r).ToArray());
+            var tree = SyntaxTree.ParseText(text);
+            tokens = tree.GetRoot().DescendantTokens().ToArray();
+            _lineTokens[line] = tokens;
+        }
+
+        foreach (var token in tokens)
+        {
+            var span = token.Span;
+            if (idx >= span.Start && idx < span.End)
+            {
+                if (SyntaxFacts.IsReservedWordKind(token.Kind))
+                {
+                    Driver.SetAttribute(KeywordAttr);
+                    return;
+                }
+
+                if (token.Kind == SyntaxKind.NumericLiteralToken)
+                {
+                    Driver.SetAttribute(NumberAttr);
+                    return;
+                }
+
+                if (token.Kind == SyntaxKind.StringLiteralToken || token.Kind == SyntaxKind.CharacterLiteralToken)
+                {
+                    Driver.SetAttribute(StringAttr);
+                    return;
+                }
+
+                break;
+            }
+        }
+
+        base.SetNormalColor(line, idx);
+    }
+}

--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Diagnostics;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Text;
+using Terminal.Gui;
+
+namespace Raven.Editor;
+
+internal class Program
+{
+    private static readonly string[] Keywords = Enum.GetValues(typeof(SyntaxKind))
+        .Cast<SyntaxKind>()
+        .Where(SyntaxFacts.IsReservedWordKind)
+        .Select(k => SyntaxFacts.GetSyntaxTokenText(k)!)
+        .ToArray();
+
+    public static void Main(string[] args)
+    {
+        Application.Init();
+
+        var filePath = args.Length > 0 ? args[0] : "";
+        var text = File.Exists(filePath) ? File.ReadAllText(filePath) : string.Empty;
+
+        var editor = new CodeTextView
+        {
+            Text = text,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            WordWrap = false
+        };
+
+        var win = new Window("Raven Editor")
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+        win.Add(editor);
+        Application.Top.Add(win);
+
+        editor.KeyPress += e =>
+        {
+            if (e.KeyEvent.Key == (Key.CtrlMask | Key.S))
+            {
+                if (!string.IsNullOrEmpty(filePath))
+                    File.WriteAllText(filePath, editor.Text.ToString());
+                e.Handled = true;
+            }
+            else if (e.KeyEvent.Key == (Key.CtrlMask | Key.Space))
+            {
+                ShowCompletion(editor);
+                e.Handled = true;
+            }
+            else if (e.KeyEvent.Key == Key.F5)
+            {
+                Compile(editor.Text?.ToString() ?? string.Empty);
+                e.Handled = true;
+            }
+        };
+
+        Application.Run();
+        Application.Shutdown();
+    }
+
+    private static void ShowCompletion(CodeTextView editor)
+    {
+        var lines = editor.Text?.ToString()?.Split('\n') ?? System.Array.Empty<string>();
+        if (editor.CurrentRow >= lines.Length)
+            return;
+        var line = lines[editor.CurrentRow];
+        var col = Math.Min(editor.CurrentColumn, line.Length);
+        var start = col;
+        while (start > 0 && char.IsLetter(line[start - 1]))
+            start--;
+        var prefix = line[start..col];
+        var matches = Keywords.Where(k => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).OrderBy(k => k).ToArray();
+        if (matches.Length == 0)
+            return;
+
+        var list = new ListView(matches)
+        {
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+        var ok = new Button("Ok", true);
+        var dialog = new Dialog("Completions", 40, 10, ok);
+        dialog.Add(list);
+        ok.Clicked += () => Application.RequestStop();
+        list.OpenSelectedItem += args => Application.RequestStop();
+        Application.Run(dialog);
+
+        if (list.SelectedItem >= 0 && list.SelectedItem < matches.Length) {
+        var selected = matches[list.SelectedItem];
+        editor.InsertText(selected.Substring(prefix.Length));
+    }
+    }
+
+    private static void Compile(string source)
+    {
+        var sourceText = SourceText.From(source);
+        var options = new CompilationOptions(OutputKind.ConsoleApplication);
+        var workspace = RavenWorkspace.Create();
+        var projectId = workspace.AddProject("EditorProject", compilationOptions: options);
+        var project = workspace.CurrentSolution.GetProject(projectId)!;
+        var document = project.AddDocument("main.rav", sourceText);
+        project = document.Project;
+        workspace.TryApplyChanges(project.Solution);
+        var diagnostics = workspace.GetDiagnostics(projectId);
+        if (diagnostics.IsDefaultOrEmpty)
+        {
+            MessageBox.Query("Compilation", "Compilation succeeded", "Ok");
+        }
+        else
+        {
+            var text = string.Join('\n', diagnostics.Select(d => d.ToString()));
+            MessageBox.ErrorQuery("Compilation", text, "Ok");
+        }
+    }
+}

--- a/src/Raven.Editor/Raven.Editor.csproj
+++ b/src/Raven.Editor/Raven.Editor.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Terminal.Gui" Version="1.14.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Raven.CodeAnalysis\Raven.CodeAnalysis.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add `Raven.Editor` console app using Terminal.Gui
- highlight keywords, numbers and strings via Raven syntax
- add keyword completion and F5 compilation using Raven workspace

## Testing
- `dotnet format src/Raven.Editor/Raven.Editor.csproj --include Program.cs,CodeTextView.cs`
- `dotnet build`
- `dotnet test` *(fails: DiagnosticVerifierTest assertions)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: assertion in Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a9f94650832fb399f36ed7a46787