### PR TITLE
Handle compiler failures gracefully in Raven.Editor

### DIFF
--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -121,17 +121,24 @@ internal class Program
 
     private static void Compile(string source)
     {
-        var solution = Workspace.CurrentSolution.WithDocumentText(_documentId, SourceText.From(source));
-        Workspace.TryApplyChanges(solution);
-        var diagnostics = Workspace.GetDiagnostics(_projectId);
-        if (diagnostics.IsDefaultOrEmpty)
+        try
         {
-            MessageBox.Query("Compilation", "Compilation succeeded", "Ok");
+            var solution = Workspace.CurrentSolution.WithDocumentText(_documentId, SourceText.From(source));
+            Workspace.TryApplyChanges(solution);
+            var diagnostics = Workspace.GetDiagnostics(_projectId);
+            if (diagnostics.IsDefaultOrEmpty)
+            {
+                MessageBox.Query("Compilation", "Compilation succeeded", "Ok");
+            }
+            else
+            {
+                var text = string.Join('\n', diagnostics.Select(d => d.ToString()));
+                MessageBox.ErrorQuery("Compilation", text, "Ok");
+            }
         }
-        else
+        catch (Exception ex)
         {
-            var text = string.Join('\n', diagnostics.Select(d => d.ToString()));
-            MessageBox.ErrorQuery("Compilation", text, "Ok");
+            MessageBox.ErrorQuery("Compilation", ex.ToString(), "Ok");
         }
     }
 }


### PR DESCRIPTION
## Summary
- catch compilation exceptions in Raven.Editor and display stack trace instead of crashing
- wrap editor content processing in try/catch to show error message on Raven failures

## Testing
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Tests.TypeSymbolInterfacesTests.Interfaces_ExcludeInheritedInterfaces)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run(fileName: "general.rav", args: []))*

------
https://chatgpt.com/codex/tasks/task_e_68b1de671a5c832f9d9cf8ad9eac078d