### PR TITLE
feat: add hello world starter program to editor

### DIFF
--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -29,7 +29,9 @@ internal class Program
         Application.Init();
 
         var filePath = args.Length > 0 ? args[0] : "";
-        var text = File.Exists(filePath) ? File.ReadAllText(filePath) : string.Empty;
+        var text = File.Exists(filePath)
+            ? File.ReadAllText(filePath)
+            : "import System.Console.*\nWriteLine(\"Hello, World!\")\n";
         var sourceText = SourceText.From(text);
         var options = new CompilationOptions(OutputKind.ConsoleApplication);
 


### PR DESCRIPTION
## Summary
- initialize Raven.Editor with a Hello World snippet when no file is provided

## Testing
- `dotnet format Raven.sln --include src/Raven.Editor/Program.cs`
- `dotnet build`
- `dotnet test` *(fails: multiple compilation/tests)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: 8 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1df345a50832f8a51ecab8ed8b821