### PR TITLE
feat(editor): add auto completion and diagnostics panes

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -3,6 +3,7 @@ namespace Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
 using System;
 using System.Collections.Generic;
 using System.Text;
+
 using Raven.CodeAnalysis.Text;
 
 using static Raven.CodeAnalysis.Syntax.InternalSyntax.SyntaxFactory;
@@ -594,7 +595,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
                 break;
         }
 
-        return expr;
+        return expr ?? new ExpressionSyntax.Missing();
     }
 
     private ExpressionSyntax ParseParenthesisOrTupleExpression()

--- a/src/Raven.Editor/CodeTextView.cs
+++ b/src/Raven.Editor/CodeTextView.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using NStack;
@@ -97,6 +98,9 @@ public class CodeTextView : TextView
         catch (Exception ex)
         {
             MessageBox.ErrorQuery("Editor", ex.ToString(), "Ok");
+
+            if (Debugger.IsAttached)
+                throw;
         }
 
         base.OnContentsChanged();

--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -23,6 +23,14 @@ internal class Program
     private static readonly RavenWorkspace Workspace = RavenWorkspace.Create();
     private static ProjectId _projectId;
     private static DocumentId _documentId;
+    private static readonly List<string> Output = new();
+    private static readonly List<string> Problems = new();
+    private static ListView? _outputView;
+    private static ListView? _problemsView;
+    private static Window? _completionWin;
+    private static ListView? _completionList;
+    private static string[] _currentCompletions = Array.Empty<string>();
+    private static string _currentPrefix = string.Empty;
 
     public static void Main(string[] args)
     {
@@ -49,9 +57,30 @@ internal class Program
         {
             Text = text,
             Width = Dim.Fill(),
-            Height = Dim.Fill(),
+            Height = Dim.Fill(10),
             WordWrap = false
         };
+
+        _outputView = new ListView(Output) { Width = Dim.Fill(), Height = Dim.Fill() };
+        _problemsView = new ListView(Problems) { Width = Dim.Fill(), Height = Dim.Fill() };
+
+        var problemsFrame = new FrameView("Problems")
+        {
+            X = 0,
+            Y = Pos.AnchorEnd(10),
+            Width = Dim.Fill(),
+            Height = 5
+        };
+        problemsFrame.Add(_problemsView);
+
+        var outputFrame = new FrameView("Output")
+        {
+            X = 0,
+            Y = Pos.AnchorEnd(5),
+            Width = Dim.Fill(),
+            Height = 5
+        };
+        outputFrame.Add(_outputView);
 
         var win = new Window("Raven Editor")
         {
@@ -60,26 +89,54 @@ internal class Program
             Width = Dim.Fill(),
             Height = Dim.Fill()
         };
-        win.Add(editor);
+        win.Add(editor, problemsFrame, outputFrame);
         Application.Top.Add(win);
 
         editor.KeyPress += e =>
         {
-            if (e.KeyEvent.Key == (Key.CtrlMask | Key.S))
+            if (_completionWin != null && e.KeyEvent.Key == Key.CursorDown)
+            {
+                _completionList!.SelectedItem = Math.Min(_completionList.SelectedItem + 1, _currentCompletions.Length - 1);
+                e.Handled = true;
+            }
+            else if (_completionWin != null && e.KeyEvent.Key == Key.CursorUp)
+            {
+                _completionList!.SelectedItem = Math.Max(_completionList.SelectedItem - 1, 0);
+                e.Handled = true;
+            }
+            else if (_completionWin != null && (e.KeyEvent.Key == Key.Enter || e.KeyEvent.Key == Key.Tab))
+            {
+                if (_currentCompletions.Length > 0)
+                {
+                    var selected = _currentCompletions[_completionList!.SelectedItem];
+                    editor.InsertText(selected.Substring(_currentPrefix.Length));
+                }
+                HideCompletion();
+                e.Handled = true;
+            }
+            else if (_completionWin != null && e.KeyEvent.Key == Key.Esc)
+            {
+                HideCompletion();
+                e.Handled = true;
+            }
+            else if (e.KeyEvent.Key == (Key.CtrlMask | Key.S))
             {
                 if (!string.IsNullOrEmpty(filePath))
                     File.WriteAllText(filePath, editor.Text.ToString());
-                e.Handled = true;
-            }
-            else if (e.KeyEvent.Key == (Key.CtrlMask | Key.Space))
-            {
-                ShowCompletion(editor);
                 e.Handled = true;
             }
             else if (e.KeyEvent.Key == Key.F5)
             {
                 Compile(editor.Text?.ToString() ?? string.Empty);
                 e.Handled = true;
+            }
+            else if (!e.KeyEvent.IsCtrl && !e.KeyEvent.IsAlt && e.KeyEvent.KeyValue >= 32 && e.KeyEvent.KeyValue <= 126)
+            {
+                Application.MainLoop.AddIdle(() =>
+                {
+                    ShowCompletion(editor);
+                    return false;
+                });
             }
         };
 
@@ -89,35 +146,64 @@ internal class Program
 
     private static void ShowCompletion(CodeTextView editor)
     {
-        var lines = editor.Text?.ToString()?.Split('\n') ?? System.Array.Empty<string>();
+        var lines = editor.Text?.ToString()?.Split('\n') ?? Array.Empty<string>();
         if (editor.CurrentRow >= lines.Length)
+        {
+            HideCompletion();
             return;
+        }
         var line = lines[editor.CurrentRow];
         var col = Math.Min(editor.CurrentColumn, line.Length);
         var start = col;
         while (start > 0 && char.IsLetter(line[start - 1]))
             start--;
-        var prefix = line[start..col];
-        var matches = Keywords.Where(k => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).OrderBy(k => k).ToArray();
-        if (matches.Length == 0)
+        _currentPrefix = line[start..col];
+        _currentCompletions = Keywords
+            .Where(k => k.StartsWith(_currentPrefix, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(k => k)
+            .ToArray();
+        if (_currentCompletions.Length == 0)
+        {
+            HideCompletion();
             return;
+        }
 
-        var list = new ListView(matches)
-        {
-            Width = Dim.Fill(),
-            Height = Dim.Fill()
-        };
-        var ok = new Button("Ok", true);
-        var dialog = new Dialog("Completions", 40, 10, ok);
-        dialog.Add(list);
-        ok.Clicked += () => Application.RequestStop();
-        list.OpenSelectedItem += args => Application.RequestStop();
-        Application.Run(dialog);
+        var height = Math.Min(10, _currentCompletions.Length + 1);
+        var width = Math.Max(20, _currentCompletions.Max(s => s.Length) + 2);
 
-        if (list.SelectedItem >= 0 && list.SelectedItem < matches.Length)
+        if (_completionWin == null)
         {
-            var selected = matches[list.SelectedItem];
-            editor.InsertText(selected.Substring(prefix.Length));
+            _completionList = new ListView(_currentCompletions) { CanFocus = false };
+            _completionWin = new Window
+            {
+                Width = width,
+                Height = height
+            };
+            _completionWin.Add(_completionList);
+            Application.Top.Add(_completionWin);
+        }
+        else
+        {
+            _completionList!.SetSource(_currentCompletions);
+            _completionWin.Width = width;
+            _completionWin.Height = height;
+        }
+
+        _completionList!.SelectedItem = 0;
+        _completionWin.X = editor.Frame.X + start;
+        _completionWin.Y = editor.Frame.Y + editor.CurrentRow + 1;
+        _completionWin.SetNeedsDisplay();
+    }
+
+    private static void HideCompletion()
+    {
+        if (_completionWin != null)
+        {
+            Application.Top.Remove(_completionWin);
+            _completionWin = null;
+            _completionList = null;
+            _currentCompletions = Array.Empty<string>();
+            _currentPrefix = string.Empty;
         }
     }
 
@@ -128,19 +214,28 @@ internal class Program
             var solution = Workspace.CurrentSolution.WithDocumentText(_documentId, SourceText.From(source));
             Workspace.TryApplyChanges(solution);
             var diagnostics = Workspace.GetDiagnostics(_projectId);
+            Output.Clear();
+            Problems.Clear();
             if (diagnostics.IsDefaultOrEmpty)
             {
-                MessageBox.Query("Compilation", "Compilation succeeded", "Ok");
+                Output.Add("Compilation succeeded");
             }
             else
             {
-                var text = string.Join('\n', diagnostics.Select(d => d.ToString()));
-                MessageBox.ErrorQuery("Compilation", text, "Ok");
+                Output.Add("Compilation failed");
+                Problems.AddRange(diagnostics.Select(d => d.ToString()));
             }
+            _outputView!.SetSource(Output);
+            _problemsView!.SetSource(Problems);
         }
         catch (Exception ex)
         {
-            MessageBox.ErrorQuery("Compilation", ex.ToString(), "Ok");
+            Output.Clear();
+            Problems.Clear();
+            Output.Add("Compilation failed");
+            Problems.Add(ex.ToString());
+            _outputView!.SetSource(Output);
+            _problemsView!.SetSource(Problems);
         }
     }
 }


### PR DESCRIPTION
## Summary
- show auto completion suggestions as you type
- display output and diagnostic lists in the editor UI

## Testing
- `dotnet format src/Raven.Editor/Raven.Editor.csproj --include src/Raven.Editor/Program.cs`
- `dotnet build`
- `dotnet test` *(fails: OutOfMemoryException)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e2ba39f8832fb537a27c7e2cb9ab