### PR TITLE
fix: preserve tuple generic parameters

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
@@ -65,7 +65,11 @@ internal partial class PENamedTypeSymbol : PESymbol, INamedTypeSymbol
     public ImmutableArray<IMethodSymbol> Constructors => GetMembers(".ctor").OfType<IMethodSymbol>().ToImmutableArray();
     public IMethodSymbol? StaticConstructor { get; }
     public ImmutableArray<ITypeSymbol> TypeArguments { get; }
-    public ImmutableArray<ITypeParameterSymbol> TypeParameters => _typeParameters ??= _typeInfo.GenericTypeParameters.Select(x => (ITypeParameterSymbol)new PETypeParameterSymbol(x, this, this, this.ContainingNamespace, [])).ToImmutableArray();
+    public ImmutableArray<ITypeParameterSymbol> TypeParameters =>
+        _typeParameters ??=
+            _typeInfo.GenericTypeParameters
+                .Select(t => (ITypeParameterSymbol)_typeResolver.ResolveType(t)!)
+                .ToImmutableArray();
     public ITypeSymbol? ConstructedFrom { get; }
     public bool IsAbstract => _typeInfo.IsAbstract;
     public bool IsSealed => _typeInfo.IsSealed;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/TupleTypeSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TupleTypeSemanticTests.cs
@@ -52,6 +52,27 @@ public class TupleTypeSemanticTests
     }
 
     [Fact]
+    public void TupleExpression_TargetTyped_WithoutNames_Succeeds()
+    {
+        var source = """
+        let pair: (int, string) = (42, "Bar")
+        """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        Assert.Empty(compilation.GetDiagnostics());
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var initializerType = model.GetTypeInfo(declarator.Initializer!.Value).Type;
+        var annotationType = model.GetTypeInfo(declarator.TypeAnnotation!.Type).Type;
+
+        Assert.True(SymbolEqualityComparer.Default.Equals(annotationType, initializerType));
+    }
+
+    [Fact]
     public void TupleExpression_TargetTypedMismatch_ReportsDiagnostic()
     {
         var source = "let t: (int, string) = (1, 2)";


### PR DESCRIPTION
## Summary
- ensure tuple type parameters are reused when resolving metadata
- add regression test for explicit tuple variable assignment

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs,test/Raven.CodeAnalysis.Tests/Semantics/TupleTypeSemanticTests.cs`
- `dotnet build`
- `dotnet test --no-build --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(fails: MultiLineCommentTrivia_IsLeadingTriviaOfToken)*
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --no-build --filter TupleExpression_TargetTyped_WithoutNames_Succeeds`
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --no-build --filter Sample_should_compile_and_run` *(fails: exit code 134)*

------
https://chatgpt.com/codex/tasks/task_e_68b210c624dc832fac2c4cf6df34c1b4