### PR TITLE
fix: provide base type for error symbols

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/ErrorTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ErrorTypeSymbol.cs
@@ -35,36 +35,31 @@ internal partial class ErrorTypeSymbol : SourceSymbol, IErrorTypeSymbol
 
     public bool IsNamespace => false;
 
-    public bool IsType => false;
+    public bool IsType => true;
 
-    public INamedTypeSymbol? BaseType => throw new NotImplementedException();
+    public INamedTypeSymbol? BaseType => _compilation.GetSpecialType(SpecialType.System_Object);
 
     public TypeKind TypeKind { get; }
 
     public ITypeSymbol? OriginalDefinition { get; }
 
-    public int Arity => throw new NotImplementedException();
+    public int Arity => 0;
 
-    public INamedTypeSymbol UnderlyingTupleType => throw new NotImplementedException();
+    public INamedTypeSymbol UnderlyingTupleType => this;
 
-    public ImmutableArray<IFieldSymbol> TupleElements => throw new NotImplementedException();
+    public ImmutableArray<IFieldSymbol> TupleElements => [];
 
     public ImmutableArray<ISymbol> GetMembers() => [];
 
     public ImmutableArray<ISymbol> GetMembers(string name) => [];
 
-    public ITypeSymbol? LookupType(string name)
-    {
-        throw new NotImplementedException();
-    }
+    public ITypeSymbol? LookupType(string name) => null;
 
     public bool IsMemberDefined(string name, out ISymbol? symbol)
     {
-        throw new NotSupportedException();
+        symbol = null;
+        return false;
     }
 
-    public ITypeSymbol Construct(params ITypeSymbol[] typeArguments)
-    {
-        throw new NotImplementedException();
-    }
+    public ITypeSymbol Construct(params ITypeSymbol[] typeArguments) => this;
 }

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ErrorTypeSymbolBaseTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ErrorTypeSymbolBaseTypeTests.cs
@@ -1,0 +1,32 @@
+using System;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class ErrorTypeSymbolBaseTypeTests
+{
+    [Fact]
+    public void UndefinedTypeInVariableDeclaration_ReportsDiagnostic()
+    {
+        const string source = "let x: Missing = 0";
+
+        var tree = SyntaxTree.ParseText(source);
+
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
+        var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
+
+        var compilation = Compilation.Create("test", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences([
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Collections.dll")),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location)
+            ]);
+
+        var diagnostics = compilation.GetDiagnostics();
+
+        Assert.Contains(diagnostics, d => d.Descriptor == CompilerDiagnostics.TheNameDoesNotExistInTheCurrentContext);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid NotImplementedException by giving ErrorTypeSymbol a System.Object base type
- return safe defaults for other ErrorTypeSymbol members
- add regression test for undefined types with Console reference

## Testing
- `dotnet format test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --include test/Raven.CodeAnalysis.Tests/Bugs/ErrorTypeSymbolBaseTypeTests.cs -v diagnostic`
- `DOTNET_CLI_DISABLE_TERMINAL_OUTPUT=1 dotnet build`
- `DOTNET_CLI_DISABLE_TERMINAL_OUTPUT=1 dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter ErrorTypeSymbolBaseTypeTests`
- `DOTNET_CLI_DISABLE_TERMINAL_OUTPUT=1 dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter Sample_should_compile_and_run` *(fails: TerminalLogger error)*

------
https://chatgpt.com/codex/tasks/task_e_68b214f1bcc4832f86e6e02219cea3c3