### PR TITLE
docs: add member binding expression proposal

### DIFF
--- a/docs/lang/proposals/member-binding-expression.md
+++ b/docs/lang/proposals/member-binding-expression.md
@@ -1,0 +1,58 @@
+# Proposal: Member binding expressions
+
+> ⚠️ This proposal has **NOT** been implemented
+
+## Summary
+
+Introduce `MemberBindingExpression` to allow target-typed member access using a leading `.`. The target type of the assignment or context determines the member to bind to.
+
+## Syntax
+
+```
+.MemberName
+.MemberName(argument1, argument2)
+```
+
+Grammar:
+
+```
+member-binding-expression := '.' identifier argument-list?
+```
+
+## Examples
+
+### Enum value
+
+```raven
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+let favorite: Color = .Red
+```
+
+### Static property
+
+```raven
+let x: string = .Empty
+```
+
+### Static method
+
+```raven
+let number: int = .Parse("42")
+```
+
+The target type on the left-hand side guides resolution of the member.
+
+## Motivation
+
+Member binding expressions reduce verbosity when referring to enum members or static members of a known type. They enable concise, target-typed initialization and invocation.
+
+## Open questions
+
+- Should member binding be allowed in expression contexts other than assignment?
+- How does overload resolution interact with member binding?
+


### PR DESCRIPTION
## Summary
- propose syntax for target-typed member binding expressions

## Testing
- `dotnet build` *(fails: dotnet run --project ../../../tools/NodeGenerator exited with code 1)*
- `dotnet test` *(fails: NodeGenerator permission denied)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: NodeGenerator permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a14a40b4832fa25ec909dda11e67