### PR TITLE
feat: add member binding expression

### DIFF
--- a/docs/lang/proposals/member-binding-expression.md
+++ b/docs/lang/proposals/member-binding-expression.md
@@ -1,8 +1,6 @@
 # Proposal: Member binding expressions
 
-> ⚠️ This proposal has been implemented by allowing the expression in a
-> `MemberAccessExpression` to be `null`. A dedicated syntax node is still
-> required for maintainability and to support method binding.
+> ✅ Implemented via a dedicated `MemberBindingExpression` syntax node.
 
 ## Summary
 

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -125,6 +125,7 @@ AssignmentOperator       ::= '=' | '+=' | '-=' | '*=' | '/=' | '%=' ;
 
 Assignable               ::= Identifier
                            | MemberAccessExpression
+                           | MemberBindingExpression
                            | ElementAccessExpression
                            | TupleDeconstruction ;
 
@@ -159,11 +160,14 @@ Argument                 ::= [Identifier ':'] Expression ;
 MemberAccessTrailer      ::= '.' Identifier ;
 ElementAccessTrailer     ::= '[' Expression ']' ;
 
+MemberBindingExpression  ::= '.' Identifier ;
+
 (* ---------- Primaries ----------
    NOTE: Block/IfExpression/WhileExpression can appear as expressions,
          so `if (…) … [else …]` and `while (…) …` can be used as statements via ExpressionStatement. *)
 PrimaryExpression        ::= Literal
                            | Identifier
+                           | MemberBindingExpression
                            | ObjectCreationExpression
                            | TupleExpression
                            | ParenthesizedExpression

--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -79,6 +79,7 @@ internal abstract class Binder
         {
             IdentifierNameSyntax id => BindIdentifierReference(id),
             MemberAccessExpressionSyntax memberAccess => BindMemberAccessReference(memberAccess),
+            MemberBindingExpressionSyntax memberBinding => BindMemberBindingReference(memberBinding),
             InvocationExpressionSyntax invocation => BindInvocationReference(invocation),
             _ => ParentBinder?.BindReferencedSymbol(node) ?? SymbolInfo.None,
         };
@@ -109,6 +110,11 @@ internal abstract class Binder
     }
 
     internal virtual SymbolInfo BindMemberAccessReference(MemberAccessExpressionSyntax node)
+    {
+        return SymbolInfo.None; // To be overridden in specific binders
+    }
+
+    internal virtual SymbolInfo BindMemberBindingReference(MemberBindingExpressionSyntax node)
     {
         return SymbolInfo.None; // To be overridden in specific binders
     }

--- a/src/Raven.CodeAnalysis/Binder/LocalScopeBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/LocalScopeBinder.cs
@@ -50,6 +50,11 @@ class LocalScopeBinder : Binder
         return ParentBinder?.BindMemberAccessReference(node) ?? default;
     }
 
+    internal override SymbolInfo BindMemberBindingReference(MemberBindingExpressionSyntax node)
+    {
+        return ParentBinder?.BindMemberBindingReference(node) ?? default;
+    }
+
     internal override SymbolInfo BindInvocationReference(InvocationExpressionSyntax node)
     {
         return ParentBinder?.BindInvocationReference(node) ?? default;

--- a/src/Raven.CodeAnalysis/SemanticClassifier.cs
+++ b/src/Raven.CodeAnalysis/SemanticClassifier.cs
@@ -80,6 +80,8 @@ public static class SemanticClassifier
         {
             if (node.Parent is MemberAccessExpressionSyntax ma && ma.Name == node)
                 node = ma;
+            else if (node.Parent is MemberBindingExpressionSyntax mb && mb.Name == node)
+                node = mb;
             else if (node.Parent is QualifiedNameSyntax qn && qn.Right == node)
                 node = qn;
             else if (node.Parent is InvocationExpressionSyntax inv && inv.Expression == node)

--- a/src/Raven.CodeAnalysis/SemanticModel.DataFlowAnalysis.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.DataFlowAnalysis.cs
@@ -197,6 +197,21 @@ internal sealed class DataFlowWalker : SyntaxWalker
         base.VisitMemberAccessExpression(node);
     }
 
+    public override void VisitMemberBindingExpression(MemberBindingExpressionSyntax node)
+    {
+        var bound = _semanticModel.GetBoundNode(node);
+        var symbol = bound?.GetSymbolInfo().Symbol;
+
+        if (symbol is ILocalSymbol local)
+        {
+            _readInside.Add(local);
+            if (!_writtenInside.Contains(local) && !_assignedOnEntry.Contains(local))
+                _dataFlowsIn.Add(local);
+        }
+
+        base.VisitMemberBindingExpression(node);
+    }
+
     public override void VisitInvocationExpression(InvocationExpressionSyntax node)
     {
         Visit(node.Expression);

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -197,6 +197,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
         {
             if (expr is not IdentifierNameSyntax
                 and not MemberAccessExpressionSyntax
+                and not MemberBindingExpressionSyntax
                 and not ElementAccessExpressionSyntax)
             {
                 AddDiagnostic(
@@ -593,6 +594,14 @@ internal class ExpressionSyntaxParser : SyntaxParser
             case SyntaxKind.OpenBracketToken:
                 expr = ParseCollectionExpression();
                 break;
+
+            case SyntaxKind.DotToken:
+                {
+                    var dot = ReadToken();
+                    var name = new NameSyntaxParser(this).ParseSimpleName();
+                    expr = MemberBindingExpression(dot, name);
+                    break;
+                }
         }
 
         return expr ?? new ExpressionSyntax.Missing();

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -276,7 +276,11 @@
     <Slot Name="CloseBracketToken" Type="Token" />
   </Node>
   <Node Name="MemberAccessExpression" Inherits="Expression" HasExplicitKind="true">
-    <Slot Name="Expression" Type="Expression" IsNullable="true" />
+    <Slot Name="Expression" Type="Expression" />
+    <Slot Name="OperatorToken" Type="Token" />
+    <Slot Name="Name" Type="SimpleName" />
+  </Node>
+  <Node Name="MemberBindingExpression" Inherits="Expression">
     <Slot Name="OperatorToken" Type="Token" />
     <Slot Name="Name" Type="SimpleName" />
   </Node>

--- a/test/Raven.CodeAnalysis.Tests/Semantics/TargetTypedExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TargetTypedExpressionTests.cs
@@ -27,4 +27,18 @@ class Program {
         var verifier = CreateVerifier(testCode);
         verifier.Verify();
     }
+
+    [Fact]
+    public void TargetTypedMethodBinding_UsesAssignmentType()
+    {
+        string testCode = """
+class Program {
+    static Run() -> unit {
+        let number: int = .Parse("42")
+    }
+}
+""";
+        var verifier = CreateVerifier(testCode);
+        verifier.Verify();
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/MemberBindingExpressionSyntaxTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/MemberBindingExpressionSyntaxTest.cs
@@ -1,0 +1,17 @@
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+public class MemberBindingExpressionSyntaxTest
+{
+    [Fact]
+    public void MemberBinding_Parses()
+    {
+        var tree = SyntaxTree.ParseText(".Foo");
+        var root = tree.GetRoot();
+        var stmt = ((GlobalStatementSyntax)root.Members[0]).Statement;
+        var expression = Assert.IsType<ExpressionStatementSyntax>(stmt).Expression;
+        Assert.IsType<MemberBindingExpressionSyntax>(expression);
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated `MemberBindingExpression` syntax node for target-typed member access
- bind `.Member` against target type and clean up null handling
- update grammar, semantics and tests for member bindings

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/Binder.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs,src/Raven.CodeAnalysis/Binder/LocalScopeBinder.cs,src/Raven.CodeAnalysis/SemanticClassifier.cs,src/Raven.CodeAnalysis/SemanticModel.DataFlowAnalysis.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs,test/Raven.CodeAnalysis.Tests/Semantics/TargetTypedExpressionTests.cs,test/Raven.CodeAnalysis.Tests/Syntax/MemberBindingExpressionSyntaxTest.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test`
- `dotnet test --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68b2bb270b00832fb7dff861438709cf