### PR TITLE
docs: document CompletionService

### DIFF
--- a/docs/compiler/development/completion-service.md
+++ b/docs/compiler/development/completion-service.md
@@ -1,0 +1,15 @@
+# Completion Service
+
+The `CompletionService` provides code completion items for the editor.
+It queries the syntax tree and semantic model to suggest tokens and symbols
+that are valid at a given position.
+
+## Usage
+
+```csharp
+var service = new CompletionService();
+var items = service.GetCompletions(compilation, syntaxTree, position);
+```
+
+Each returned `CompletionItem` describes a text snippet that can be inserted
+at the requested position.

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -44,6 +44,8 @@
       href: development/source-generation.md
     - name: Node generator
       href: development/node-generator.md
+    - name: Completion service
+      href: development/completion-service.md
     - name: Analyzers
       href: development/analyzers.md
     - name: CIL

--- a/src/Raven.CodeAnalysis/CompletionService.cs
+++ b/src/Raven.CodeAnalysis/CompletionService.cs
@@ -1,11 +1,21 @@
-using System;
+using System.Collections.Generic;
 
 using Raven.CodeAnalysis.Syntax;
 
 namespace Raven.CodeAnalysis;
 
+/// <summary>
+/// Provides completion items for a given position in a syntax tree.
+/// </summary>
 public class CompletionService
 {
+    /// <summary>
+    /// Gets the completion items available at the specified position.
+    /// </summary>
+    /// <param name="compilation">The compilation that contains the syntax tree.</param>
+    /// <param name="syntaxTree">The syntax tree being queried.</param>
+    /// <param name="position">The position within the syntax tree.</param>
+    /// <returns>A sequence of completion items applicable at the position.</returns>
     public IEnumerable<CompletionItem> GetCompletions(Compilation compilation, SyntaxTree syntaxTree, int position)
     {
         var token = syntaxTree.GetRoot().FindToken(position);


### PR DESCRIPTION
## Summary
- document the CompletionService class and its GetCompletions method
- add a developer guide for CompletionService and link it in compiler docs

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b2da9a41ec832fad4c97039e813f49