### PR TITLE
fix: allow target-typed expressions in assignments

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -784,6 +784,10 @@ partial class BlockBinder : Binder
                     var left = BindExpression(assign.LeftHandSide);
                     return left.Type;
 
+                case AssignmentStatementSyntax assign when assign.Right.Contains(node):
+                    var leftStmt = BindExpression(assign.Left);
+                    return leftStmt.Type;
+
                 case ReturnStatementSyntax returnStmt:
                     return _containingSymbol is IMethodSymbol method ? method.ReturnType : null;
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/TargetTypedExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TargetTypedExpressionTests.cs
@@ -41,4 +41,21 @@ class Program {
         var verifier = CreateVerifier(testCode);
         verifier.Verify();
     }
+
+    [Fact]
+    public void TargetTypedMethodBinding_UsesAssignmentStatementType()
+    {
+        string testCode = """
+enum Color { Red, Blue }
+
+class Program {
+    static Run() -> unit {
+        var color: Color = .Red
+        color = .Blue
+    }
+}
+""";
+        var verifier = CreateVerifier(testCode);
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- honor target typing for assignment statements by checking the left-hand side when binding descendant expressions
- cover assignment statements in target-typed expression tests

## Testing
- `dotnet build`
- `dotnet test --filter TargetTypedMethodBinding_UsesAssignmentStatementType`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: Raven.CodeAnalysis.Semantics.Tests.ImperativeContextTests.BlockExpression_InExpressionStatement_BindsAsStatement, Raven.CodeAnalysis.Tests.Bugs.Issue84_MemberResolutionBug.CanResolveMember, ...)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run(fileName: "main.rav", args: []), SampleProgramsTests.Sample_should_compile_and_run(fileName: "enums.rav", args: []))*

------
https://chatgpt.com/codex/tasks/task_e_68b2e97783f4832fa74bfe11f4e5c180