### PR TITLE
feat: separate bound assignment statements

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -224,6 +224,7 @@ partial class BlockBinder : Binder
             BoundWhileExpression whileExpr => new BoundWhileStatement(whileExpr.Condition, ExpressionToStatement(whileExpr.Body)),
             BoundForExpression forExpr => new BoundForStatement(forExpr.Local, forExpr.Collection, ExpressionToStatement(forExpr.Body)),
             BoundBlockExpression blockExpr => new BoundBlockStatement(blockExpr.Statements),
+            BoundAssignmentExpression assignmentExpr => new BoundAssignmentStatement(assignmentExpr),
             _ => new BoundExpressionStatement(expression),
         };
     }
@@ -238,6 +239,7 @@ partial class BlockBinder : Binder
             BoundWhileExpression whileExpr => new BoundWhileStatement(whileExpr.Condition, ExpressionToStatement(whileExpr.Body)),
             BoundForExpression forExpr => new BoundForStatement(forExpr.Local, forExpr.Collection, ExpressionToStatement(forExpr.Body)),
             BoundBlockExpression blockExpr => blockExpr,
+            BoundAssignmentExpression assignmentExpr => new BoundAssignmentStatement(assignmentExpr),
             _ => expression,
         };
     }
@@ -1719,7 +1721,9 @@ partial class BlockBinder : Binder
     private BoundStatement BindAssignmentStatement(AssignmentStatementSyntax syntax)
     {
         var bound = BindAssignment(syntax.Left, syntax.Right, syntax);
-        return new BoundExpressionStatement(bound);
+        return bound is BoundAssignmentExpression assignment
+            ? new BoundAssignmentStatement(assignment)
+            : new BoundExpressionStatement(bound);
     }
 
     private BoundExpression? GetReceiver(BoundExpression left)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundAssignmentStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundAssignmentStatement.cs
@@ -1,0 +1,12 @@
+namespace Raven.CodeAnalysis;
+
+sealed partial class BoundAssignmentStatement : BoundStatement
+{
+    public BoundAssignmentExpression Expression { get; }
+
+    public BoundAssignmentStatement(BoundAssignmentExpression expression)
+    {
+        Expression = expression;
+    }
+}
+

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -35,6 +35,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundWhileStatement whileStmt => (BoundStatement)VisitWhileStatement(whileStmt)!,
             BoundForStatement forStmt => (BoundStatement)VisitForStatement(forStmt)!,
             BoundBlockStatement blockStmt => (BoundStatement)VisitBlockStatement(blockStmt)!,
+            BoundAssignmentStatement assignmentStmt => (BoundStatement)VisitAssignmentStatement(assignmentStmt)!,
             _ => statement,
         };
     }
@@ -54,9 +55,12 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundObjectCreationExpression objectCreation => (BoundExpression)VisitObjectCreationExpression(objectCreation)!,
             BoundLambdaExpression lambda => (BoundExpression)VisitLambdaExpression(lambda)!,
             BoundBlockExpression block => (BoundExpression)VisitBlockExpression(block)!,
+            BoundAssignmentExpression assignment => (BoundExpression)VisitAssignmentExpression(assignment)!,
             _ => throw new NotImplementedException($"Unhandled expression: {node.GetType().Name}"),
         };
     }
+
+    public virtual BoundNode? VisitAssignmentExpression(BoundAssignmentExpression node) => node;
 
     public virtual INamespaceSymbol VisitNamespace(INamespaceSymbol @namespace)
     {

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -106,6 +106,9 @@ internal class BoundTreeWalker : BoundTreeVisitor
             case BoundExpressionStatement expressionStatement:
                 VisitExpressionStatement(expressionStatement);
                 break;
+            case BoundAssignmentStatement assignmentStatement:
+                VisitAssignmentStatement(assignmentStatement);
+                break;
             case BoundLocalDeclarationStatement localDeclaration:
                 VisitLocalDeclarationStatement(localDeclaration);
                 break;
@@ -131,6 +134,11 @@ internal class BoundTreeWalker : BoundTreeVisitor
     {
         if (node.Expression is not null)
             VisitExpression(node.Expression);
+    }
+
+    public override void VisitAssignmentStatement(BoundAssignmentStatement node)
+    {
+        VisitExpression(node.Expression);
     }
 
     public override void VisitBinaryExpression(BoundBinaryExpression node)

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -28,6 +28,10 @@ internal class StatementGenerator : Generator
                 EmitExpressionStatement(expressionStatement);
                 break;
 
+            case BoundAssignmentStatement assignmentStatement:
+                EmitAssignmentStatement(assignmentStatement);
+                break;
+
             case BoundLocalDeclarationStatement localDeclarationStatement:
                 EmitDeclarationStatement(localDeclarationStatement);
                 break;
@@ -79,6 +83,11 @@ internal class StatementGenerator : Generator
             // The value is not used, pop it from the stack.
             ILGenerator.Emit(OpCodes.Pop);
         }
+    }
+
+    private void EmitAssignmentStatement(BoundAssignmentStatement assignmentStatement)
+    {
+        new ExpressionGenerator(this, assignmentStatement.Expression).Emit();
     }
 
     private void EmitIfStatement(BoundIfStatement ifStatement)

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -142,8 +142,16 @@ internal class MethodBodyGenerator
                     }
                     else
                     {
-                        var stmt = new BoundExpressionStatement(boundExpr);
-                        new StatementGenerator(baseGenerator, stmt).Emit();
+                        if (boundExpr is BoundAssignmentExpression assignment)
+                        {
+                            var stmt = new BoundAssignmentStatement(assignment);
+                            new StatementGenerator(baseGenerator, stmt).Emit();
+                        }
+                        else
+                        {
+                            var stmt = new BoundExpressionStatement(boundExpr);
+                            new StatementGenerator(baseGenerator, stmt).Emit();
+                        }
                     }
 
                     ILGenerator.Emit(OpCodes.Ret);
@@ -186,7 +194,7 @@ internal class MethodBodyGenerator
                 field,
                 field.Initializer!);
 
-            var statement = new BoundExpressionStatement(assignment);
+            var statement = new BoundAssignmentStatement((BoundAssignmentExpression)assignment);
             new StatementGenerator(baseGenerator, statement).Emit();
         }
     }

--- a/src/Raven.CodeAnalysis/SemanticModel.DataFlowAnalysis.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.DataFlowAnalysis.cs
@@ -90,8 +90,8 @@ internal sealed class AssignmentCollector : SyntaxWalker
 
     public override void VisitAssignmentStatement(AssignmentStatementSyntax node)
     {
-        var bound = _semanticModel.GetBoundNode(node) as BoundExpressionStatement;
-        if (bound?.Expression is BoundAssignmentExpression assignment && assignment.Symbol is ILocalSymbol local)
+        var bound = _semanticModel.GetBoundNode(node) as BoundAssignmentStatement;
+        if (bound?.Expression.Symbol is ILocalSymbol local)
             Written.Add(local);
 
         base.VisitAssignmentStatement(node);
@@ -267,10 +267,9 @@ internal sealed class DataFlowWalker : SyntaxWalker
 
     public override void VisitAssignmentStatement(AssignmentStatementSyntax node)
     {
-        var boundStmt = _semanticModel.GetBoundNode(node) as BoundExpressionStatement;
-        var bound = boundStmt?.Expression as BoundAssignmentExpression;
+        var bound = _semanticModel.GetBoundNode(node) as BoundAssignmentStatement;
 
-        if (bound?.Symbol is ILocalSymbol local)
+        if (bound?.Expression.Symbol is ILocalSymbol local)
         {
             _writtenInside.Add(local);
             _dataFlowsOut.Add(local);

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/AssignmentStatementTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/AssignmentStatementTests.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class AssignmentStatementTests
+{
+    [Fact]
+    public void AssignmentStatement_EmitsAndRuns()
+    {
+        var code = """
+class Foo {
+    Run() -> int {
+        var x: int = 0
+        x = 42
+        return x
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Foo", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+        var value = (int)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal(42, value);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce BoundAssignmentStatement and convert assignment constructs to use it
- update binder, tree visitors, and code generation for new statement node
- add failing codegen test for assignment statements

## Testing
- `dotnet build`
- `dotnet test` *(fails: DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, DiagnosticVerifierTest.GetResult_NoDiagnostics, DiagnosticVerifierTest.Verify_ThrowsException_WhenMissingDiagnostic, DiagnosticVerifierTest.GetResult_WithIgnoredDiagnostics, Issue84_MemberResolutionBug.CanResolveMember, Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree3, Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree, Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree_Advanced, Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree5, Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree4, Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyTextChangeToSyntaxTree, SemanticClassifierTests.ClassifiesTokensBySymbol, ReturnStatementUnitTests.NonUnitMethod_EmptyReturn_ReportsDiagnostic, ReturnStatementUnitTests.NonUnitMethod_ReturnExpression_NotAssignable_ReportsDiagnostic, UnionConversionTests.UnionNotConvertibleToExplicitType_ProducesDiagnostic, UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType, MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion, MissingReturnTypeAnnotationAnalyzerTests.FunctionStatementWithoutAnnotation_SuggestsInferredReturnType, NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, UnionEmissionTests.CommonInterface_UsesInterfaceInSignature, ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic, EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromImplicitFinalExpression, ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable, EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromEarlyReturns, SymbolQueryTests.CallingInstanceMethodAsStatic_ProducesDiagnostic, LiteralTypeFlowTests.LiteralType_Double_UsesUnderlyingDouble, LiteralTypeFlowTests.VariableDeclaration_WithDoubleLiteral_InferredDouble, LiteralTypeFlowTests.VariableDeclaration_WithFloatSuffix_InferredFloat, UnionReturnTests.FinalExpressionUnitIsBoxed, UnionReturnTests.ValueTypesInUnionAreBoxedWhenReturning, LiteralTypeFlowTests.VariableDeclaration_WithLargeInteger_InferredLong, LiteralTypeFlowTests.LiteralType_Float_UsesUnderlyingSingle, NamespaceResolutionTest.ConsoleDoesNotExistInCurrentContext_Should_ProduceDiagnostics, LiteralTypeFlowTests.LiteralType_Long_UsesUnderlyingInt64, MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken, NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, AliasResolutionTest.AliasDirective_UsesAlias_Tuple, NamespaceResolutionTest.ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics, Syntax.Tests.Sandbox.Test, CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates, ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, AliasResolutionTest.AliasDirective_UsesAlias_AsTypeAnnotation, ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics, AliasResolutionTest.AliasDirective_UsesAlias_Union, StringInterpolationTests.InterpolatedString_FormatsCorrectly, AliasResolutionTest.AliasDirective_UsesAlias_Literal, ImperativeContextTests.BlockExpression_InExpressionStatement_BindsAsStatement, ImperativeContextTests.IfStatement_BranchesCanBeStatements, ImperativeContextTests.IfStatement_BranchesCanBeExpressions, AliasResolutionTest.AliasDirective_UsesAlias_PredefinedType, SampleProgramsTests.Sample_should_compile_and_run (fileName: "main.rav", args: [])*

------
https://chatgpt.com/codex/tasks/task_e_68b2f01ba1e4832fa6efe48ea322b498