### PR TITLE
feat: expand semantic classifications

### DIFF
--- a/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
+++ b/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
@@ -21,6 +21,8 @@ public class ColorScheme
     public AnsiColor Comment { get; internal set; }
     public AnsiColor Field { get; internal set; }
     public AnsiColor Parameter { get; internal set; }
+    public AnsiColor Property { get; internal set; }
+    public AnsiColor Local { get; internal set; }
     public AnsiColor Error { get; internal set; }
     public AnsiColor Warning { get; internal set; }
     public AnsiColor Info { get; internal set; }
@@ -37,6 +39,8 @@ public class ColorScheme
         Comment = AnsiColor.Green,
         Field = AnsiColor.Cyan,
         Parameter = AnsiColor.Blue,
+        Property = AnsiColor.BrightGreen,
+        Local = AnsiColor.BrightMagenta,
         Error = AnsiColor.BrightRed,
         Warning = AnsiColor.BrightGreen,
         Info = AnsiColor.BrightBlue
@@ -54,6 +58,8 @@ public class ColorScheme
         Comment = AnsiColor.BrightGreen,
         Field = AnsiColor.Cyan,
         Parameter = AnsiColor.Blue,
+        Property = AnsiColor.Green,
+        Local = AnsiColor.Magenta,
         Error = AnsiColor.BrightRed,
         Warning = AnsiColor.BrightGreen,
         Info = AnsiColor.BrightBlue
@@ -222,6 +228,8 @@ public static class ConsoleSyntaxHighlighter
         SemanticClassification.Namespace => ColorScheme.Namespace,
         SemanticClassification.Field => ColorScheme.Field,
         SemanticClassification.Parameter => ColorScheme.Parameter,
+        SemanticClassification.Property => ColorScheme.Property,
+        SemanticClassification.Local => ColorScheme.Local,
         _ => ColorScheme.Default
     };
 

--- a/src/Raven.CodeAnalysis/SemanticClassifier.cs
+++ b/src/Raven.CodeAnalysis/SemanticClassifier.cs
@@ -65,6 +65,7 @@ public static class SemanticClassifier
             ITypeSymbol => SemanticClassification.Type,
             IMethodSymbol => SemanticClassification.Method,
             IParameterSymbol => SemanticClassification.Parameter,
+            ILocalSymbol => SemanticClassification.Local,
             IFieldSymbol => SemanticClassification.Field,
             IPropertySymbol => SemanticClassification.Property,
             _ => SemanticClassification.Default
@@ -110,6 +111,7 @@ public enum SemanticClassification
     Type,
     Method,
     Parameter,
+    Local,
     Property,
     Field
 }

--- a/src/Raven.Editor/CodeTextView.cs
+++ b/src/Raven.Editor/CodeTextView.cs
@@ -198,6 +198,8 @@ public class CodeTextView : TextView
             SemanticClassification.Namespace => new(Color.BrightCyan, background),
             SemanticClassification.Field => new(Color.Cyan, background),
             SemanticClassification.Parameter => new(Color.Blue, background),
+            SemanticClassification.Property => new(Color.BrightGreen, background),
+            SemanticClassification.Local => new(Color.BrightMagenta, background),
             _ => new(Color.BrightBlue, background)
         };
     }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
@@ -11,7 +11,7 @@ public class SemanticClassifierTests
     public void ClassifiesTokensBySymbol()
     {
         var source = """
-namespace N { class C { method M() -> unit {} } let x = M() }
+namespace N { class C { let f = 0 public P: int => f method M(p: int) -> int { let l = p l } } }
 """;
         var tree = SyntaxTree.ParseText(source);
         var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default);
@@ -26,5 +26,17 @@ namespace N { class C { method M() -> unit {} } let x = M() }
 
         var methodToken = result.Tokens.Keys.First(t => t.Text == "M");
         result.Tokens[methodToken].ShouldBe(SemanticClassification.Method);
+
+        var fieldToken = result.Tokens.Keys.First(t => t.Text == "f");
+        result.Tokens[fieldToken].ShouldBe(SemanticClassification.Field);
+
+        var propertyToken = result.Tokens.Keys.First(t => t.Text == "P");
+        result.Tokens[propertyToken].ShouldBe(SemanticClassification.Property);
+
+        var parameterToken = result.Tokens.Keys.First(t => t.Text == "p");
+        result.Tokens[parameterToken].ShouldBe(SemanticClassification.Parameter);
+
+        var localToken = result.Tokens.Keys.First(t => t.Text == "l");
+        result.Tokens[localToken].ShouldBe(SemanticClassification.Local);
     }
 }


### PR DESCRIPTION
## Summary
- classify local symbols and add semantic `Local`
- map property and local classifications to colors in console and editor
- broaden semantic classifier tests to cover fields, properties, parameters, and locals

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/SemanticClassifier.cs,src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs,src/Raven.Editor/CodeTextView.cs,test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs`
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Tests.Semantics.SemanticClassifierTests.ClassifiesTokensBySymbol and others)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f920da60832f87e16e3e060cbf19