### PR TITLE
test: add compilation base for semantic tests

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs
@@ -3,13 +3,11 @@ using System.Linq;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
-using Raven.CodeAnalysis.Tests;
-
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class ByRefParameterTests
+public class ByRefParameterTests : CompilationTestBase
 {
     [Fact]
     public void Parameter_WithAmpersand_HasRefKindRef()
@@ -20,7 +18,7 @@ class C {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
         var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(method)!;
@@ -37,7 +35,7 @@ class C {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
         var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(method)!;
@@ -54,7 +52,7 @@ class C {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var ctor = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
         var ctorSymbol = (IMethodSymbol)model.GetDeclaredSymbol(ctor)!;
@@ -71,7 +69,7 @@ class C {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var ctor = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
         var ctorSymbol = (IMethodSymbol)model.GetDeclaredSymbol(ctor)!;
@@ -88,7 +86,7 @@ func outer() {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var inner = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().Single(l => l.Identifier.Text == "inner");
         var symbol = (IMethodSymbol)model.GetDeclaredSymbol(inner)!;
@@ -105,7 +103,7 @@ func outer() {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var inner = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().Single(l => l.Identifier.Text == "inner");
         var symbol = (IMethodSymbol)model.GetDeclaredSymbol(inner)!;
@@ -123,7 +121,7 @@ class C {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var diagnostics = compilation.GetDiagnostics();
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
     }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ClassInheritanceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ClassInheritanceTests.cs
@@ -1,14 +1,11 @@
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
-using Raven.CodeAnalysis.Tests;
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class ClassInheritanceTests
+public class ClassInheritanceTests : CompilationTestBase
 {
     [Fact]
     public void SealedBaseClass_DerivationProducesDiagnostic()
@@ -18,8 +15,7 @@ class Parent {};
 class Derived : Parent {};
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .AddReferences(TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
         using var stream = new MemoryStream();
         var result = compilation.Emit(stream);
         Assert.False(result.Success);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/CompilationTestBase.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/CompilationTestBase.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Tests;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public abstract class CompilationTestBase
+{
+    protected virtual MetadataReference[] GetMetadataReferences()
+        => TestMetadataReferences.Default;
+
+    protected virtual CompilationOptions GetCompilationOptions()
+        => new(OutputKind.ConsoleApplication);
+
+    protected Compilation CreateCompilation(CompilationOptions? options = null, MetadataReference[]? references = null, string assemblyName = "test")
+        => Compilation.Create(assemblyName, Array.Empty<SyntaxTree>(), references ?? GetMetadataReferences(), options ?? GetCompilationOptions());
+
+    protected Compilation CreateCompilation(SyntaxTree tree, CompilationOptions? options = null, MetadataReference[]? references = null, string assemblyName = "test")
+        => Compilation.Create(assemblyName, [tree], references ?? GetMetadataReferences(), options ?? GetCompilationOptions());
+
+    protected Compilation CreateCompilation(IEnumerable<SyntaxTree> trees, CompilationOptions? options = null, MetadataReference[]? references = null, string assemblyName = "test")
+        => Compilation.Create(assemblyName, trees.ToArray(), references ?? GetMetadataReferences(), options ?? GetCompilationOptions());
+
+    protected (Compilation Compilation, SyntaxTree Tree) CreateCompilation(string source, CompilationOptions? options = null, MetadataReference[]? references = null, string assemblyName = "test")
+    {
+        var tree = SyntaxTree.ParseText(source);
+        return (CreateCompilation(tree, options, references, assemblyName), tree);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/FunctionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/FunctionTests.cs
@@ -2,12 +2,11 @@ using System.Linq;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Symbols;
-using Raven.CodeAnalysis.Tests;
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class FunctionTests
+public class FunctionTests : CompilationTestBase
 {
     [Fact]
     public void Function_WithoutReturnType_DefaultsToVoid()
@@ -18,7 +17,7 @@ func outer() {
 }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var inner = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().Single(l => l.Identifier.Text == "inner");
         var symbol = (IMethodSymbol)model.GetDeclaredSymbol(inner)!;
@@ -33,7 +32,7 @@ func test() {}
 func test() {}
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var funcs = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().ToArray();
         _ = model.GetDeclaredSymbol(funcs[0]);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImperativeContextTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImperativeContextTests.cs
@@ -3,11 +3,10 @@ using System.Linq;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
-using Raven.CodeAnalysis.Tests;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class ImperativeContextTests
+public class ImperativeContextTests : CompilationTestBase
 {
     [Fact]
     public void IfStatement_BindsAsStatement()
@@ -25,10 +24,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(code);
-        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddSyntaxTrees(tree)
-            .AddReferences(TestMetadataReferences.Default);
-
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var ifStmt = tree.GetRoot().DescendantNodes().OfType<IfStatementSyntax>().First();
         var bound = model.GetBoundNode(ifStmt);
@@ -50,10 +46,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(code);
-        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddSyntaxTrees(tree)
-            .AddReferences(TestMetadataReferences.Default);
-
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var ifStmt = tree.GetRoot().DescendantNodes().OfType<IfStatementSyntax>().First();
         var bound = (BoundIfStatement)model.GetBoundNode(ifStmt);
@@ -74,10 +67,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(code);
-        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddSyntaxTrees(tree)
-            .AddReferences(TestMetadataReferences.Default);
-
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var ifStmt = tree.GetRoot().DescendantNodes().OfType<IfStatementSyntax>().First();
         var bound = (BoundIfStatement)model.GetBoundNode(ifStmt);
@@ -100,10 +90,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(code);
-        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddSyntaxTrees(tree)
-            .AddReferences(TestMetadataReferences.Default);
-
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var exprStmt = tree.GetRoot().DescendantNodes().OfType<ExpressionStatementSyntax>()
             .First(es => es.Expression is BlockSyntax);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs
@@ -1,9 +1,11 @@
+using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
+using Xunit;
 
-namespace Raven.CodeAnalysis.Tests;
+namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class InvocationOperatorTests
+public class InvocationOperatorTests : CompilationTestBase
 {
     [Fact]
     public void InvocationOperator_BindsToInvokeMethod()
@@ -19,9 +21,7 @@ let x = t(2)
 """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddReferences(TestMetadataReferences.Default);
-
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Last();
         var symbol = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MethodOverloadTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MethodOverloadTests.cs
@@ -1,12 +1,11 @@
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Symbols;
-using Raven.CodeAnalysis.Tests;
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class MethodOverloadTests
+public class MethodOverloadTests : CompilationTestBase
 {
     [Fact]
     public void Overloads_DifferOnlyByNullableReferenceType_AreRejected()
@@ -19,9 +18,7 @@ public class MethodOverloadTests
         """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddReferences(TestMetadataReferences.Default);
-
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var methods = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().ToArray();
         _ = model.GetDeclaredSymbol(methods[0]);
@@ -42,9 +39,7 @@ public class MethodOverloadTests
         """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
-            .AddReferences(TestMetadataReferences.Default);
-
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var methods = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().ToArray();
         _ = model.GetDeclaredSymbol(methods[0]);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/NullShimTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/NullShimTests.cs
@@ -6,13 +6,11 @@ using System.Reflection;
 
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
-using Raven.CodeAnalysis.Tests;
-
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class NullShimTests
+public class NullShimTests : CompilationTestBase
 {
     [Fact]
     public void NullShimType_EmittedInUnionAttribute()
@@ -24,8 +22,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .AddReferences(TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
 
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream);
@@ -51,8 +48,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .AddReferences(TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
 
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream);
@@ -73,8 +69,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .AddReferences(TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
 
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
@@ -2,10 +2,11 @@ using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
 using System.Linq;
+using Xunit;
 
-namespace Raven.CodeAnalysis.Tests.Semantics;
+namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class SemanticClassifierTests
+public class SemanticClassifierTests : CompilationTestBase
 {
     [Fact]
     public void ClassifiesTokensBySymbol()
@@ -14,7 +15,7 @@ public class SemanticClassifierTests
 namespace N { class C { method M() -> unit {} } let x = M() }
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var result = SemanticClassifier.Classify(tree.GetRoot(), model);
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs
@@ -1,12 +1,10 @@
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
-using Raven.CodeAnalysis.Tests;
-
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class SemanticModelDiagnosticsTests
+public class SemanticModelDiagnosticsTests : CompilationTestBase
 {
     [Fact]
     public void GetDiagnostics_CollectsMethodBodyDiagnostics()
@@ -19,7 +17,7 @@ class Test {
 }
 """;
         var syntaxTree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [syntaxTree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(syntaxTree);
         var model = compilation.GetSemanticModel(syntaxTree);
 
         var diagnostics = model.GetDiagnostics();

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnionEmissionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnionEmissionTests.cs
@@ -5,13 +5,11 @@ using System.Reflection;
 
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
-using Raven.CodeAnalysis.Tests;
-
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class UnionEmissionTests
+public class UnionEmissionTests : CompilationTestBase
 {
     [Fact]
     public void CommonBaseClass_WithNull_UsesBaseTypeAndNullable()
@@ -26,8 +24,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .AddReferences(TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
 
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream);
@@ -53,8 +50,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .AddReferences(TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
 
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream);
@@ -76,8 +72,7 @@ class C {
 """;
 
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .AddReferences(TestMetadataReferences.Default);
+        var compilation = CreateCompilation(tree, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
 
         using var peStream = new MemoryStream();
         var result = compilation.Emit(peStream);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnitTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnitTypeTests.cs
@@ -3,13 +3,11 @@ using System.Linq;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
-using Raven.CodeAnalysis.Tests;
-
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
 
-public class UnitTypeTests
+public class UnitTypeTests : CompilationTestBase
 {
     [Fact]
     public void FunctionWithoutReturnType_DefaultsToUnit()
@@ -19,7 +17,7 @@ func ping() { }
 let u = ping()
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var ping = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().Single();
         var pingSymbol = (IMethodSymbol)model.GetDeclaredSymbol(ping)!;
@@ -39,7 +37,7 @@ func ping() -> () { }
 let x: () = ping()
 """;
         var tree = SyntaxTree.ParseText(source);
-        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
         var ping = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().Single();
         var pingSymbol = (IMethodSymbol)model.GetDeclaredSymbol(ping)!;


### PR DESCRIPTION
## Summary
- provide `CompilationTestBase` to unify compilation setup for semantic tests
- leverage common base across semantic test classes

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/Semantics/CompilationTestBase.cs,test/Raven.CodeAnalysis.Tests/Semantics/ClassInheritanceTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/UnitTypeTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/NullShimTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/SemanticModelDiagnosticsTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/ImperativeContextTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/MethodOverloadTests.cs,test/Raven.CodeAnalysis.Tests/Semantics/UnionEmissionTests.cs` *(warnings: workspace load issues)*
- `dotnet build --no-restore -nologo -clp:ErrorsOnly`
- `dotnet test --no-build --verbosity normal --filter "FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run"` *(fails: logger failure and test failures)*
- `dotnet test --no-build --filter Sample_should_compile_and_run` *(fails: no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f7b28614832fb15416d6d1a04686