### PR TITLE
fix: avoid extra stack pops in expression blocks

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1567,9 +1567,22 @@ internal class ExpressionGenerator : Generator
 
     private void EmitBlock(BoundBlockExpression block)
     {
-        foreach (var s in block.Statements)
+        var statements = block.Statements.ToArray();
+
+        for (int i = 0; i < statements.Length; i++)
         {
-            EmitStatement(s);
+            var statement = statements[i];
+            var isLast = i == statements.Length - 1;
+
+            if (isLast && statement is BoundExpressionStatement exprStmt &&
+                exprStmt.Expression.Type?.SpecialType is not SpecialType.System_Void)
+            {
+                new ExpressionGenerator(this, exprStmt.Expression).Emit();
+            }
+            else
+            {
+                EmitStatement(statement);
+            }
         }
     }
 

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -121,8 +121,6 @@ internal class StatementGenerator : Generator
                 break;
             case BoundExpression expr:
                 new ExpressionGenerator(scope, expr).Emit();
-                if (expr.Type?.SpecialType is not SpecialType.System_Void)
-                    ILGenerator.Emit(OpCodes.Pop);
                 break;
         }
     }

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -650,6 +650,10 @@ public class Compilation
         {
             return GetTypeByMetadataName("System.Object");
         }
+        else if (specialType is SpecialType.System_ValueType)
+        {
+            return GetTypeByMetadataName("System.ValueType");
+        }
         else if (specialType is SpecialType.System_Nullable_T)
         {
             return GetTypeByMetadataName("System.Nullable");

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/BlockExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/BlockExpressionTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class BlockExpressionTests
+{
+    [Fact]
+    public void IfExpression_WithBlockExpressionBranch_EmitsAndRuns()
+    {
+        var code = """
+class Foo {
+    Run(flag: bool, w: int) -> object {
+        let y = if flag { 40 + w; } else { true }
+        return y
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Foo", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+        var value = method.Invoke(instance, new object[] { false, 0 });
+        Assert.Equal(true, value);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid unconditional stack pops for expression nodes during statement emission
- preserve value from final expression statements within block expressions
- cover block-expression if branch in code generation tests
- ensure `System.ValueType` resolves in special type lookup so `Unit` behaves like a value type

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Compilation.cs`
- `dotnet build`
- `dotnet test` *(fails: DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree, EarlyReturnTypeCollector_InfersUnionFromImplicitFinalExpression, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b3000326b8832f8f219c70c44fc226