### PR TITLE
fix: pop stack for unit returns

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -63,7 +63,13 @@ internal class StatementGenerator : Generator
             var expressionType = returnStatement.Expression.Type;
             var returnType = MethodSymbol.ReturnType;
 
-            if (expressionType.IsValueType && (returnType.SpecialType is SpecialType.System_Object || returnType is IUnionTypeSymbol))
+            if (returnType.SpecialType == SpecialType.System_Unit)
+            {
+                // The method returns void in IL, so discard the unit value.
+                ILGenerator.Emit(OpCodes.Pop);
+            }
+            else if (expressionType?.IsValueType == true &&
+                     (returnType.SpecialType is SpecialType.System_Object || returnType is IUnionTypeSymbol))
             {
                 ILGenerator.Emit(OpCodes.Box, ResolveClrType(expressionType));
             }

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -253,10 +253,14 @@ internal class MethodBodyGenerator
                 var expressionType = exprStmt.Expression.Type;
                 var returnType = MethodSymbol.ReturnType;
 
-                if (expressionType is not null &&
-                    expressionType.IsValueType &&
-                    (returnType.SpecialType is SpecialType.System_Object ||
-                     returnType is IUnionTypeSymbol))
+                if (returnType.SpecialType == SpecialType.System_Unit)
+                {
+                    ILGenerator.Emit(OpCodes.Pop);
+                }
+                else if (expressionType is not null &&
+                         expressionType.IsValueType &&
+                         (returnType.SpecialType is SpecialType.System_Object ||
+                          returnType is IUnionTypeSymbol))
                 {
                     ILGenerator.Emit(OpCodes.Box, ResolveClrType(expressionType));
                 }

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UnitReturnTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UnitReturnTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class UnitReturnTests
+{
+    [Fact]
+    public void UnitMethod_ReturningUnitExpression_EmitsAndRuns()
+    {
+        var code = """
+class Foo {
+    Test() -> unit {
+        return ()
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Foo", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Test")!;
+        var value = method.Invoke(instance, Array.Empty<object>());
+        Assert.Null(value);
+    }
+}


### PR DESCRIPTION
## Summary
- discard unit value before returning from methods compiled as `void`
- add regression test for returning unit expression

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs,src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs,test/Raven.CodeAnalysis.Tests/CodeGen/UnitReturnTests.cs`
- `dotnet build`
- `dotnet test` *(fails: Sample_should_compile_and_run and others)*
- `dotnet test --no-build --filter Sample_should_compile_and_run` *(no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b307fe2a40832fa73e29434114ed0c