### PR TITLE
docs: document unit shim after void calls

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -42,8 +42,12 @@ Raven has no `void` type. The absence of a meaningful value is represented by th
 spelled `unit` or `()`. Functions without an explicit return type implicitly
 return `unit`. When interacting with .NET, methods that return `void` are
 projected as returning `unit`, and Raven's `unit` emits as `void` unless the
-value is observed. The `unit` type is a value type (struct). Because `unit` is a
-real type, it participates in generics, tuples, and unions like any other type.
+value is observed. After any call that returns metadata `void`, the compiler
+loads `Unit.Value` so the invocation still produces a `unit` result. In an
+expression statement that value is discarded, but it enables nesting
+`unit`-returning calls such as `Console.WriteLine(Console.WriteLine("foo"))`.
+The `unit` type is a value type (struct). Because `unit` is a real type, it
+participates in generics, tuples, and unions like any other type.
 
 ## Statements
 


### PR DESCRIPTION
## Summary
- clarify that calls returning metadata `void` push `Unit.Value` so they compose as `unit` expressions

## Testing
- no tests: documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68b30f826774832fbf25e7deec1cfa08