### PR TITLE
docs: adopt expression-oriented terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Raven is primarily a **learning and exploration project**, aimed at:
 
 ## 🔰 Language Overview
 
-Raven is a general-purpose, expression-based language that blends functional and imperative paradigms. Its type system supports union and literal types with flow-sensitive typing similar to TypeScript, and it uses `unit` instead of `void`. As a .NET language, Raven interops seamlessly with C#, even shipping a C# analyzer for type unions. The compiler follows the Roslyn "compiler-as-a-service" architecture.
+Raven is a general-purpose, expression-oriented language with an expression-first design that blends functional and imperative paradigms. Its type system supports union and literal types with flow-sensitive typing similar to TypeScript, and it uses `unit` instead of `void`. As a .NET language, Raven interops seamlessly with C#, even shipping a C# analyzer for type unions. The compiler follows the Roslyn "compiler-as-a-service" architecture.
 
 ### Example
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,7 +4,7 @@ Raven is a general-purpose programming language.
 
 It mainly draws inspiration from Swift, Rust, and Kotlin in its syntax, and features from functional programming languages like F#.
 
-It is expression-based but supports imperative constructs when those are preferred. It also has a number of functional programming constructs, but it is an impure language and supports OOP.
+It is expression-oriented and expression-first but supports imperative constructs when those are preferred. It also has a number of functional programming constructs, but it is an impure language and supports OOP.
 
 The type system is flexible and supports type unions and literals as their own types. Types flow with expressions, similar to TypeScript. The language uses `unit` instead of `void`.
 

--- a/docs/lang/philosophy.md
+++ b/docs/lang/philosophy.md
@@ -2,6 +2,8 @@
 
 Raven is a modern programming language designed with clarity, expressiveness, and composability at its core. It draws inspiration from C#, F#, Swift, and Python — but is not bound by their conventions. Raven's guiding philosophy is to prioritize conceptual integrity, minimize syntactic noise, and empower developers to write code that reads like intention, not ceremony.
 
+It embraces an expression-first, expression-oriented design where nearly every construct yields a value.
+
 ---
 
 ## ✨ Core Principles
@@ -43,7 +45,13 @@ This symmetry improves reasoning and avoids special cases.
 
 ---
 
-### 3. **Declarative, Not Just Functional**
+### 3. **Expression-First Design**
+
+Raven is expression-oriented: almost every construct evaluates to a value, encouraging composition and reducing the distinction between statements and expressions.
+
+---
+
+### 4. **Declarative, Not Just Functional**
 
 Raven embraces declarative programming: describing *what* rather than *how*. Pattern matching, expressions-as-values, and implicit returns enable elegant problem modeling:
 
@@ -57,19 +65,19 @@ match value {
 
 ---
 
-### 4. **Contextual Precision and Modularity**
+### 5. **Contextual Precision and Modularity**
 
 Every part of Raven's compiler is context-sensitive and modular. Parsers, binders, and code generators are composable and disposable — no global state, no implicit magic. This architecture makes Raven suitable for rich tooling, speculative parsing, and precise error recovery.
 
 ---
 
-### 5. **Syntax is Structure**
+### 6. **Syntax is Structure**
 
 Raven's syntax trees are not just parsing artifacts — they are designed objects. Nodes are generated from formal XML specifications, ensuring consistency, testability, and predictability. This emphasis on structural design reflects the language's belief that **syntax is architecture**.
 
 ---
 
-### 6. **Minimalism with Purpose**
+### 7. **Minimalism with Purpose**
 
 Semicolons are optional. Newlines matter — but only when they should. Blocks, expressions, and types interleave naturally. The language does not aim to reduce all syntax, but only that which obstructs intent.
 
@@ -88,7 +96,7 @@ let x = 2; Console.WriteLine(x)
 
 ---
 
-### 7. **Target-Typed Member Access and Expression Completion**
+### 8. **Target-Typed Member Access and Expression Completion**
 
 Raven supports target-typed expressions, allowing constructs like:
 
@@ -100,7 +108,7 @@ This enables more concise and predictive IntelliSense experiences and binds expr
 
 ---
 
-### 8. **`let` vs `var`: Mutability by Design**
+### 9. **`let` vs `var`: Mutability by Design**
 
 Raven uses `let` and `var` to make **mutability an explicit decision**:
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -51,10 +51,10 @@ participates in generics, tuples, and unions like any other type.
 
 ## Statements
 
-Raven is primarily **expression-based**: most constructs yield values and can
-appear wherever an expression is expected. For clarity and early exits,
-the language nevertheless permits certain imperative statement forms, such as
-the explicit `return` statement.
+Raven is primarily **expression-oriented**: most constructs yield values and can
+appear wherever an expression is expected, reflecting its expression-first design.
+For clarity and early exits, the language nevertheless permits certain imperative
+statement forms, such as the explicit `return` statement.
 
 Statements are terminated by a **newline**, or by an **optional semicolon** `;`
 that may separate multiple statements on one line. Newlines inside

--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -9,7 +9,7 @@ Raven began as an experimental compiler exploring a Roslyn-style architecture on
 - **Emphasis on semantics and diagnostics** – The binder and semantic model were prototyped early to mirror Roslyn's flow-sensitive typing. Later, diagnostics were moved to an XML specification, reflecting a desire for maintainable, data-driven error reporting.
 - **Type system experimentation** – Union and literal types were implemented along with flow-sensitive typing. These features show a focus on modern language ideas inspired by TypeScript and F#, exploring expressive type interactions on .NET.
 - **Tooling and developer experience** – Recent work added a console editor prototype and Spectre-based diagnostic highlighting, suggesting an interest in making the compiler pleasant to use even at an experimental stage.
-- **Exploration of language styles** – The language was pushed toward a purely expression-based style inspired by functional languages, though statements were later reintroduced to balance familiarity with expressiveness.
+- **Exploration of language styles** – The language was pushed toward a purely expression-oriented, expression-first style inspired by functional languages, though statements were later reintroduced to balance familiarity with expressiveness.
 - **Limited AI involvement** – AI tooling assisted occasionally with brainstorming and minor snippets, but architecture and implementation choices were authored and reviewed manually.
 - **Lessons from Checked Exceptions Analyzer** – Work on a parallel C# Checked Exceptions Analyzer informed an understanding of Roslyn APIs and behaviors, which in turn shaped Raven's approach to syntax and semantics.
 


### PR DESCRIPTION
## Summary
- replace "expression-based" with "expression-oriented" across docs
- highlight the language's expression-first design in README, intro, spec, and project history
- expand design philosophy with an expression-first core principle

## Testing
- ⚠️ `dotnet build` *(skipped: documentation-only changes)*
- ⚠️ `dotnet test` *(skipped: documentation-only changes)*

------
https://chatgpt.com/codex/tasks/task_e_68b31bbf8c5c832fb3dcf6f729e4b505