### PR TITLE
feat(editor): open file from CLI and display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ write to the console when compiling a single file.
 
 > ⚠️ **When the arguments are omitted**, there is a hardcoded input file, and a hardcoded output file path (`test.dll`).
 
+### Run the editor
+
+```bash
+dotnet run --project src/Raven.Editor -- <path-to-file>
+```
+
+When a file path is supplied, the editor opens the file and displays its name in the window title.
+
 ---
 
 ## 📂 Repository Structure

--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -32,7 +32,8 @@ internal class Program
     {
         Application.Init();
 
-        var filePath = args.Length > 0 ? args[0] : "";
+        var filePath = args.Length > 0 ? args[0] : string.Empty;
+        var documentName = string.IsNullOrEmpty(filePath) ? "main.rav" : Path.GetFileName(filePath);
         var text = File.Exists(filePath)
             ? File.ReadAllText(filePath)
             : "import System.Console.*\n\nWriteLine(\"Hello, World!\")\n";
@@ -41,7 +42,7 @@ internal class Program
 
         _projectId = Workspace.AddProject("EditorProject", compilationOptions: options);
         _documentId = DocumentId.CreateNew(_projectId);
-        var solution = Workspace.CurrentSolution.AddDocument(_documentId, "main.rav", sourceText);
+        var solution = Workspace.CurrentSolution.AddDocument(_documentId, documentName, sourceText);
 
         var targetFrameworkTfm = "net9.0";
 
@@ -92,7 +93,11 @@ internal class Program
         };
         outputFrame.Add(_outputView);
 
-        var win = new Window("Raven Editor")
+        var windowTitle = string.IsNullOrEmpty(filePath)
+            ? "Raven Editor"
+            : $"Raven Editor - {documentName}";
+
+        var win = new Window(windowTitle)
         {
             X = 0,
             Y = 0,


### PR DESCRIPTION
## Summary
- allow Raven.Editor to load a file specified on the command line
- show the opened file's name in the editor window title
- document how to launch Raven.Editor with a file

## Testing
- `dotnet format src/Raven.Editor/Raven.Editor.csproj --include src/Raven.Editor/Program.cs`
- `dotnet build`
- `dotnet test` *(fails: RAV1501 No overload for method 'WriteLine' takes 1 arguments)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Expected 0 Actual 134)*

------
https://chatgpt.com/codex/tasks/task_e_68b31e28df34832fbde3e459d0be69cc