### PR TITLE
feat: support Ctrl+C to cancel editor

### DIFF
--- a/Raven.sln
+++ b/Raven.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.CodeAnalysis.Console"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiagnosticsGenerator", "tools\DiagnosticsGenerator\DiagnosticsGenerator.csproj", "{CD99ADB8-043D-4491-990D-B28198C789BF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raven.Editor.Tests", "test\Raven.Editor.Tests\Raven.Editor.Tests.csproj", "{BED97C88-1B21-4A14-9719-7D81A99A67C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -229,6 +231,18 @@ Global
 		{CD99ADB8-043D-4491-990D-B28198C789BF}.Release|x64.Build.0 = Release|Any CPU
 		{CD99ADB8-043D-4491-990D-B28198C789BF}.Release|x86.ActiveCfg = Release|Any CPU
 		{CD99ADB8-043D-4491-990D-B28198C789BF}.Release|x86.Build.0 = Release|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Debug|x86.Build.0 = Debug|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Release|x64.Build.0 = Release|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,6 +263,7 @@ Global
 		{2034A721-7A3B-470B-A7D6-8D9EA240048E} = {1BF06D1D-C317-434E-B4AF-1404CDE6D171}
 		{EA7A08E8-B4F0-471A-A3E9-9ACD8BD4626C} = {1BF06D1D-C317-434E-B4AF-1404CDE6D171}
 		{CD99ADB8-043D-4491-990D-B28198C789BF} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+		{BED97C88-1B21-4A14-9719-7D81A99A67C0} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {083D8FC4-3D3B-476A-AF17-77AC247C299F}

--- a/src/Raven.Editor/AssemblyInfo.cs
+++ b/src/Raven.Editor/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Raven.Editor.Tests")]

--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -31,6 +31,7 @@ internal class Program
     public static void Main(string[] args)
     {
         Application.Init();
+        Console.CancelKeyPress += HandleCancelKeyPress;
 
         var filePath = args.Length > 0 ? args[0] : string.Empty;
         var documentName = string.IsNullOrEmpty(filePath) ? "main.rav" : Path.GetFileName(filePath);
@@ -143,6 +144,11 @@ internal class Program
                     File.WriteAllText(filePath, editor.Text.ToString());
                 e.Handled = true;
             }
+            else if (e.KeyEvent.Key == (Key.CtrlMask | Key.C))
+            {
+                Application.RequestStop();
+                e.Handled = true;
+            }
             else if (e.KeyEvent.Key == Key.F5)
             {
                 Compile(editor.Text?.ToString() ?? string.Empty);
@@ -160,6 +166,12 @@ internal class Program
 
         Application.Run();
         Application.Shutdown();
+    }
+
+    internal static void HandleCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
+    {
+        e.Cancel = true;
+        Application.RequestStop();
     }
 
     private static void ShowCompletion(CodeTextView editor)

--- a/test/Raven.Editor.Tests/ProgramTests.cs
+++ b/test/Raven.Editor.Tests/ProgramTests.cs
@@ -1,0 +1,27 @@
+namespace Raven.Editor.Tests;
+
+using System;
+using System.Reflection;
+using Terminal.Gui;
+
+public class ProgramTests
+{
+    [Fact]
+    public void HandleCancelKeyPress_SetsCancel()
+    {
+        Application.Init(new FakeDriver());
+
+        var e = (ConsoleCancelEventArgs)Activator.CreateInstance(
+            typeof(ConsoleCancelEventArgs),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            null,
+            new object[] { ConsoleSpecialKey.ControlC },
+            null)!;
+
+        Program.HandleCancelKeyPress(null, e);
+
+        e.Cancel.ShouldBeTrue();
+
+        Application.Shutdown();
+    }
+}

--- a/test/Raven.Editor.Tests/Raven.Editor.Tests.csproj
+++ b/test/Raven.Editor.Tests/Raven.Editor.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Shouldly" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Raven.Editor\Raven.Editor.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- allow Raven.Editor to exit on Ctrl+C by handling console and key events
- expose internals for test and add unit test for cancel handler

## Testing
- `dotnet format src/Raven.Editor/Raven.Editor.csproj --include src/Raven.Editor/Program.cs,src/Raven.Editor/AssemblyInfo.cs` *(fails: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'`
- `dotnet test --filter Sample_should_compile_and_run`

------
https://chatgpt.com/codex/tasks/task_e_68b3210e784c832f856a5e589629235d