### PR TITLE
Handle missing binary operators without exceptions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1192,8 +1192,7 @@ partial class BlockBinder : Binder
         }
 
         // 3. Inbyggda operatorer
-        var op = BoundBinaryOperator.Lookup(Compilation, opKind, left.Type, right.Type);
-        if (op is not null)
+        if (BoundBinaryOperator.TryLookup(Compilation, opKind, left.Type, right.Type, out var op))
         {
             return new BoundBinaryExpression(left, op, right);
         }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/BoundBinaryOperatorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/BoundBinaryOperatorTests.cs
@@ -1,0 +1,31 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class BoundBinaryOperatorTests : CompilationTestBase
+{
+    [Fact]
+    public void TryLookup_InvalidOperator_ReturnsFalse()
+    {
+        var compilation = CreateCompilation();
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var boolType = compilation.GetSpecialType(SpecialType.System_Boolean);
+
+        var success = BoundBinaryOperator.TryLookup(compilation, SyntaxKind.PlusToken, intType, boolType, out var op);
+
+        Assert.False(success);
+        Assert.Equal(BinaryOperatorKind.None, op.OperatorKind);
+    }
+
+    [Fact]
+    public void Bind_InvalidOperator_ReportsDiagnostic()
+    {
+        var source = "let x = 1 + true";
+        var (compilation, _) = CreateCompilation(source);
+        var diagnostic = Assert.Single(compilation.GetDiagnostics());
+        Assert.Equal(CompilerDiagnostics.OperatorCannotBeAppliedToOperandsOfTypes, diagnostic.Descriptor);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `Lookup` with `TryLookup` so missing binary operators yield a `None` operator instead of `null`
- Update binder logic to consume `TryLookup`
- Adjust tests to verify the `None` result

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/BoundTree/BoundBinaryOperator.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/BoundBinaryOperatorTests.cs --no-restore`
- `dotnet build`
- `dotnet test` *(fails: System.ArgumentOutOfRangeException in logger)*
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter BoundBinaryOperatorTests`

------
https://chatgpt.com/codex/tasks/task_e_68b327e6dd50832fb5b517740575f55c