### PR TITLE
fix: handle missing member access identifier

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -363,7 +363,20 @@ internal class ExpressionSyntaxParser : SyntaxParser
             else if (token.IsKind(SyntaxKind.DotToken)) // Member Access
             {
                 var dotToken = ReadToken();
-                var memberName = new NameSyntaxParser(this).ParseSimpleName();
+                SimpleNameSyntax memberName;
+                if (PeekToken().IsKind(SyntaxKind.IdentifierToken))
+                {
+                    memberName = new NameSyntaxParser(this).ParseSimpleName();
+                }
+                else
+                {
+                    ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var identifier);
+                    AddDiagnostic(
+                        DiagnosticInfo.Create(
+                            CompilerDiagnostics.IdentifierExpected,
+                            GetEndOfLastToken()));
+                    memberName = IdentifierName(identifier);
+                }
                 expr = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expr, dotToken, memberName);
             }
             else if (token.IsKind(SyntaxKind.OpenBracketToken)) // Element access

--- a/test/Raven.CodeAnalysis.Tests/Bugs/MemberAccessMissingIdentifierTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/MemberAccessMissingIdentifierTests.cs
@@ -1,0 +1,25 @@
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class MemberAccessMissingIdentifierTests : DiagnosticTestBase
+{
+    [Fact]
+    public void MemberAccessWithoutIdentifier_ReportsDiagnostic()
+    {
+        const string code = """
+        class C {
+            Test() -> unit {
+                let a = 1
+                let b = a.
+            }
+        }
+        """;
+
+        var verifier = CreateVerifier(code, [
+            new DiagnosticResult("RAV1001").WithAnySpan(),
+            new DiagnosticResult("RAV0103").WithAnySpan().WithArguments("")
+        ]);
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- guard member access parsing against missing identifiers by inserting a missing token and diagnostic
- add regression test covering incomplete member access

## Testing
- `dotnet run --project ../../../tools/NodeGenerator -- -f`
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs,test/Raven.CodeAnalysis.Tests/Bugs/MemberAccessMissingIdentifierTests.cs`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(failed: 51 failed)*
- `dotnet test --filter Sample_should_compile_and_run` *(failed: 8 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b33d297584832faf18a83090495c1d