### PR TITLE
feat: add --no-emit option to Raven.Compiler

### DIFF
--- a/src/Raven.Compiler/ConsoleEx.cs
+++ b/src/Raven.Compiler/ConsoleEx.cs
@@ -21,6 +21,11 @@ static class ConsoleEx
         AnsiConsole.MarkupLine($"Build [red]failed with {result.Diagnostics.Count()} error(s)[/]");
     }
 
+    public static void Failed(int errorsCount)
+    {
+        AnsiConsole.MarkupLine($"Build [red]failed with {errorsCount} error(s)[/]");
+    }
+
     public static void PrintDiagnostics(IEnumerable<Diagnostic> diagnostics)
     {
         foreach (var diagnostic in diagnostics)


### PR DESCRIPTION
## Summary
- add `--no-emit` flag to Raven.Compiler CLI
- support reporting failures without an `EmitResult`
- test `--no-emit` to ensure no assembly is produced

## Testing
- `dotnet build`
- `dotnet test` *(fails: Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_NoDiagnostics, Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.Verify_ThrowsException_WhenMissingDiagnostic, Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_WithIgnoredDiagnostics, Raven.CodeAnalysis.Semantics.Tests.ImperativeContextTests.BlockExpression_InExpressionStatement_BindsAsStatement, Raven.CodeAnalysis.Semantics.Tests.ImperativeContextTests.IfStatement_BranchesCanBeStatements, Raven.CodeAnalysis.Tests.BlockExpressionTests.IfExpression_WithBlockExpressionBranch_EmitsAndRuns, Raven.CodeAnalysis.Semantics.Tests.ImperativeContextTests.IfStatement_BranchesCanBeExpressions, Raven.CodeAnalysis.Semantics.Tests.SemanticClassifierTests.ClassifiesTokensBySymbol, Raven.CodeAnalysis.Tests.Bugs.ReturnStatementUnitTests.NonUnitMethod_EmptyReturn_ReportsDiagnostic, Raven.CodeAnalysis.Semantics.Tests.NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, Raven.CodeAnalysis.Tests.Bugs.ReturnStatementUnitTests.NonUnitMethod_ReturnExpression_NotAssignable_ReportsDiagnostic, Raven.CodeAnalysis.Tests.Bugs.ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, Raven.CodeAnalysis.Tests.Diagnostics.MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType, Raven.CodeAnalysis.Tests.Diagnostics.MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion, Raven.CodeAnalysis.Tests.Bugs.ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics, Raven.CodeAnalysis.Tests.Diagnostics.MissingReturnTypeAnnotationAnalyzerTests.FunctionStatementWithoutAnnotation_SuggestsInferredReturnType, Raven.CodeAnalysis.Semantics.Tests.SymbolQueryTests.CallingInstanceMethodAsStatic_ProducesDiagnostic, Raven.CodeAnalysis.Semantics.Tests.UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesNotExistInCurrentContext_Should_ProduceDiagnostics, Raven.CodeAnalysis.Tests.Bugs.MemberAccessMissingIdentifierTests.MemberAccessWithoutIdentifier_ReportsDiagnostic, Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_Tuple, Raven.CodeAnalysis.Tests.EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromImplicitFinalExpression, Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics, Raven.CodeAnalysis.Tests.EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromEarlyReturns, Raven.CodeAnalysis.Tests.Bugs.Issue84_MemberResolutionBug.CanResolveMember, Raven.CodeAnalysis.Tests.CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates, Raven.CodeAnalysis.Semantics.Tests.ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic, Raven.CodeAnalysis.Semantics.Tests.TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree3, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree_Advanced, Raven.CodeAnalysis.Semantics.Tests.ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree5, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree4, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyTextChangeToSyntaxTree, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_AsTypeAnnotation, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_Union, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_Literal, Raven.CodeAnalysis.Tests.Workspaces.AnalyzerInfrastructureTests.GetDiagnostics_IncludesCompilerAndAnalyzerDiagnostics, Raven.CodeAnalysis.Syntax.Parser.Tests.MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_PredefinedType, Raven.CodeAnalysis.Tests.Workspaces.DiagnosticOptionsTests.RunAnalyzers_False_DisablesAnalyzerDiagnostics, Raven.CodeAnalysis.Tests.StringInterpolationTests.InterpolatedString_FormatsCorrectly, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.LiteralType_Double_UsesUnderlyingDouble, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.VariableDeclaration_WithDoubleLiteral_InferredDouble, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.VariableDeclaration_WithFloatSuffix_InferredFloat, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.VariableDeclaration_WithLargeInteger_InferredLong, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.LiteralType_Float_UsesUnderlyingSingle, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.LiteralType_Long_UsesUnderlyingInt64, Raven.CodeAnalysis.Syntax.Tests.Sandbox.Test, Raven.CodeAnalysis.Syntax.Parser.Tests.ParserNewlineTests.Terminator_SkipsTokens_UntilEndOfFile, Raven.CodeAnalysis.Semantics.Tests.UnionConversionTests.UnionNotConvertibleToExplicitType_ProducesDiagnostic, Raven.CodeAnalysis.Semantics.Tests.UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run(fileName: "main.rav", args: [])`)
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b3feebac08832f8b2688a6aec3cfda