### PR TITLE
fix: resolve void as unit

### DIFF
--- a/src/Raven.CodeAnalysis/TypeResolver.cs
+++ b/src/Raven.CodeAnalysis/TypeResolver.cs
@@ -100,6 +100,13 @@ internal class TypeResolver(Compilation compilation)
         if (_cache.TryGetValue(type, out var cached))
             return cached;
 
+        if (type == typeof(void))
+        {
+            var unit = compilation.GetSpecialType(SpecialType.System_Unit);
+            _cache[type] = unit;
+            return unit;
+        }
+
         if (type.Name == "Null")
             return compilation.NullTypeSymbol;
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnitTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnitTypeTests.cs
@@ -48,4 +48,17 @@ let x: () = ping()
         Assert.NotNull(initType);
         Assert.Equal(SpecialType.System_Unit, initType!.SpecialType);
     }
+
+    [Fact]
+    public void TypeResolver_Wraps_Void_In_UnitTypeSymbol()
+    {
+        var compilation = CreateCompilation();
+        compilation.EnsureSetup();
+
+        var type = compilation.GetType(typeof(void));
+
+        Assert.NotNull(type);
+        Assert.Equal(SpecialType.System_Unit, type!.SpecialType);
+        Assert.Same(compilation.UnitTypeSymbol, type);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure TypeResolver wraps `System.Void` as `UnitTypeSymbol`
- test coverage for void to unit mapping

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/TypeResolver.cs,test/Raven.CodeAnalysis.Tests/Semantics/UnitTypeTests.cs --verify-no-changes`
- `dotnet build`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(fails: System.OutOfMemoryException, diagnostics)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: assert exit code 134)*

------
https://chatgpt.com/codex/tasks/task_e_68b40175a8d4832f9b42b49053c0eec8