### PR TITLE
docs: clarify type compatibility

### DIFF
--- a/docs/lang/proposals/type-compatibility.md
+++ b/docs/lang/proposals/type-compatibility.md
@@ -2,81 +2,88 @@
 
 > ⚠️ 🧩 This proposal has been partly implemented
 
-This document outlines type compatibility
+This document outlines type compatibility and conversion rules in Raven.
 
-## 
+## Object compatibility
 
-All types are derived from and convertible to `Object`.
+Reference types inherit from `System.Object`. Value types such as primitives and [unit](../spec/language-specification.md#unit-type) are structs; they do not derive from `object` but can be boxed when a reference is required.
+
+```raven
+let o: object = ()      // box the unit value
+let p: object = 42      // box an int
+```
 
 ## Overload resolution
 
-Overload resolution work like in .NET.
+Overload resolution follows .NET conventions. Literal arguments convert to their underlying type when selecting an overload. `unit` participates as a value type and can be boxed like any other struct.
 
-`Unit` participates as a struct, thus is convertible and boxable as `Object`.
+```raven
+func foo(x: int) {}
+func foo(x: double) {}
+
+foo(1)    // chooses foo(int)
+foo(1.0)  // chooses foo(double)
+```
 
 ## Type literals
 
-Type literals are types (Literal types, `LiteralTypeSymbol`) in the that contains a constant value, and it has an underlying type.
+Type literals are types (`LiteralTypeSymbol`) that represent a constant value and carry an underlying primitive type. See [target typing](../spec/language-specification.md#target-typing) for how literals interact with context.
 
 Examples:
 
 ```raven
-42 // Literal type: 42 (underlying type: int/System.Int or System.Int64 - depending on size)
-
-0.2 // Literal type: 0.2 (underlying type: int/System.Float or double/System.Double - depending on size)
-
-true // Literal type: true (underlying type: bool/System.Boolean)
+42      // literal type: 42 (underlying int/System.Int32 or long/System.Int64 depending on size)
+0.2     // literal type: 0.2 (underlying float/System.Single or double/System.Double depending on suffix or size)
+true    // literal type: true (underlying bool/System.Boolean)
 ```
 
 ### Conversions
 
-Type literals are convertible to their underlying type. And that is important in overload resolution.
+Type literals convert to their underlying type. This is important for overload resolution and variable declarations.
+
+```raven
+let x: int = 2 + 3        // literal ints convert to int
+let y: double = 3         // literal int converts to double
+```
 
 ### Arithmetic operations
 
-This applies to literal types with an underlying type that supports arithmetic operations and have addition implemented.
+Arithmetic is permitted on literal types whose underlying type defines the operator.
 
 ```raven
-let x = 2 + 3 // x: int
+let a = 2 + 3             // a : int
+let b = 1.0 + 2           // b : double (2 converts to double)
 ```
 
-Inside of expressions:
+### Inside expressions
 
 ```raven
-foo(3) // 2 + 3 is treated as literal type 3, and convertible to target int
-foo(2 + 3) // 2 + 3 is treated as type literal, and convertible to target int
-
 func foo(x: int) {}
-```
-
-```raven
-let x : int = 2
-let sum = x + 3 // int + literal type 3  -> int
+foo(3)                     // literal 3 converts to int
+foo(2 + 3)                 // result of addition converts to int
 ```
 
 ### Variable declarations
 
 #### Explicit type
 
-This is valid:
-
 ```raven
-let a : true = true
+let a: true = true
 ```
 
-Even if not useful.
+Even though unusual, a variable can have a literal type.
 
 #### Implicit type
 
-When you are assigning a type literal expression in a implicitly-typed variable declaration (with `let` or `var`), the type will be the underlying type.
+When a declaration relies on inference, the literal's underlying type becomes the variable's type. See [type inference](../spec/language-specification.md#type-inference) for details.
 
 ```raven
-let a = true // int
-let b = true // bool
+let a = true      // a : bool
+let b = 0.2       // b : double
 ```
-
 
 ## Terminology
 
-* **literal type** - the type representation, or symbol, of a literal or constant value
-* **literal type expression** - the actual expression representing a literal or constant value
+* **literal type** - the type representation or symbol of a literal or constant value
+* **literal type expression** - the expression that yields a literal or constant value
+


### PR DESCRIPTION
## Summary
- clarify object vs value type compatibility and boxing
- explain literal conversions and overload resolution
- add examples for arithmetic and variable declarations

## Testing
- `dotnet build` *(fails: SyntaxKind not found, compilation errors)*
- `dotnet test` *(fails: numerous failing tests and parameter count issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b41c320ce0832f98e8b11ee9de1d8f