### PR TITLE
docs: add type casting proposal

### DIFF
--- a/docs/lang/proposals/type-casting.md
+++ b/docs/lang/proposals/type-casting.md
@@ -1,0 +1,49 @@
+# Proposal: Type casting
+
+> ⚠️ This proposal has **NOT** been implemented
+
+This document outlines explicit cast expressions and the `as` operator in Raven, following C# semantics.
+
+## Purpose
+
+Allow developers to perform conversions that are not covered by implicit rules, such as downcasting or numeric narrowing.
+
+## Syntax
+
+### Explicit cast
+
+`(T)expr` forcefully converts `expr` to type `T`. If the runtime conversion fails, an exception is thrown.
+
+```raven
+let d = (double)1
+let dog = (Dog)animal
+```
+
+### `as` operator
+
+`expr as T` attempts the conversion and yields `null` (or a nullable value type) when it fails.
+
+```raven
+let dog = animal as Dog
+if dog != null {
+    // safe use of dog
+}
+```
+
+## Examples
+
+```raven
+class Animal {}
+class Dog : Animal { bark() -> () => Console.WriteLine("bark") }
+
+let animal: Animal = Dog()
+let dog1 = (Dog)animal      // succeeds
+let dog2 = animal as Dog    // Dog?
+let cat  = animal as Cat    // null
+```
+
+## Limitations
+
+* Value types require nullable forms when used with `as`.
+* Failed explicit casts raise an `InvalidCastException` at runtime.
+* Pattern matching with `is` is handled separately.

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -147,7 +147,10 @@ AdditiveExpression       ::= MultiplicativeExpression {('+' | '-') Multiplicativ
 MultiplicativeExpression ::= UnaryExpression {('*' | '/' | '%') UnaryExpression} ;
 
 UnaryExpression          ::= PostfixExpression
-                           | ('+' | '-' | '!') UnaryExpression ;
+                           | ('+' | '-' | '!') UnaryExpression
+                           | CastExpression ;
+
+CastExpression           ::= '(' Type ')' UnaryExpression ;
 
 PostfixExpression        ::= PrimaryExpression { PostfixTrailer } ;
 PostfixTrailer           ::= ArgumentList

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -214,6 +214,17 @@ let a: Animal = pet   // ok: Dog and Cat derive from Animal
 let s: string = pet   // error: neither member converts to string
 ```
 
+### Cast expressions
+
+Explicit casts request a conversion to a specific type and use the same syntax as C#.
+
+```raven
+let d = (double)1
+let s = obj as string
+```
+
+`(T)expr` performs a runtime check and throws if the value cannot be converted. The `as` operator attempts the conversion and returns `null` (or a nullable value type) instead of throwing when the cast fails.
+
 ### String literals
 
 ```raven
@@ -820,8 +831,9 @@ Lowest → highest (all left-associative unless noted):
 7. Type tests: `is  as` (binds after relational)
 8. Additive: `+  -`
 9. Multiplicative: `*  /  %`
-10. Unary (prefix): `+  -  !`
-11. Postfix trailers: call `()`, member `.`, index `[]`
+10. Cast: `(T)expr`
+11. Unary (prefix): `+  -  !`
+12. Postfix trailers: call `()`, member `.`, index `[]`
 
 > **Disambiguation notes**
 >

--- a/docs/lang/type-system.md
+++ b/docs/lang/type-system.md
@@ -60,6 +60,18 @@ Console.WriteLine(ids[0])
 
 Values may convert to other types according to .NET rules. Implicit conversions include identity, `null` to any nullable type, lifting value types to their nullable counterpart, widening numeric conversions, reference conversions to base types or interfaces, boxing of value types, and conversions to a matching branch of a union. Narrowing or otherwise unsafe conversions require an explicit cast. See [type compatibility](proposals/type-compatibility.md) for a detailed list of conversion forms.
 
+### Explicit casts
+
+Raven uses C#-style cast syntax for conversions that are not implicit:
+
+```raven
+let n = (double)1
+let s = obj as string
+```
+
+`(T)expr` performs a runtime-checked cast and throws if `expr` cannot convert to `T`.
+`expr as T` attempts the conversion and yields `null` (or a nullable value type) when it fails.
+
 ## Overload resolution
 
 When multiple function overloads are available, Raven selects the candidate whose parameters require the best implicit conversions. Identity matches are preferred over numeric widening, which outrank reference or boxing conversions. User-defined conversions are considered last. Literal arguments convert to their underlying primitive type before the ranking is applied. If no candidate is strictly better, the call is reported as ambiguous.


### PR DESCRIPTION
## Summary
- propose C#-style cast expressions and the `as` operator
- document explicit casts in type system and specification
- update grammar and operator precedence for cast support

## Testing
- ⚠️ `dotnet build` *(skipped: documentation only)*
- ⚠️ `dotnet test` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_68b424dacc1c832f9c61619b27b07e7c