### PR TITLE
fix: handle literal types in overload resolution

### DIFF
--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -119,8 +119,12 @@ internal sealed class OverloadResolver
         return better;
     }
 
-    private static ITypeSymbol GetUnderlying(ITypeSymbol type) =>
-        type is NullableTypeSymbol nt ? nt.UnderlyingType : type;
+    private static ITypeSymbol GetUnderlying(ITypeSymbol type) => type switch
+    {
+        NullableTypeSymbol nt => nt.UnderlyingType,
+        LiteralTypeSymbol lt => lt.UnderlyingType,
+        _ => type,
+    };
 
     private static int GetInheritanceDistance(ITypeSymbol? derived, ITypeSymbol baseType)
     {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
+
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
@@ -117,6 +118,8 @@ public class NullableTypeTests : CompilationTestBase
 
         var param = Assert.IsType<NullableTypeSymbol>(symbol.Parameters[0].Type);
         Assert.Equal(SpecialType.System_String, param.UnderlyingType.SpecialType);
+
+        Assert.Empty(compilation.GetDiagnostics());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure overload resolution unwraps literal types
- assert no diagnostics when choosing string overload

## Testing
- `dotnet build -m:1`
- `dotnet test --no-build` *(fails: Raven.CodeAnalysis.Tests.Bugs.ReturnStatementUnitTests.NonUnitMethod_EmptyReturn_ReportsDiagnostic, Raven.CodeAnalysis.Syntax.Parser.Tests.MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken, Raven.CodeAnalysis.Tests.Bugs.ReturnStatementUnitTests.NonUnitMethod_ReturnExpression_NotAssignable_ReportsDiagnostic, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_Tuple, Raven.CodeAnalysis.Semantics.Tests.ImperativeContextTests.BlockExpression_InExpressionStatement_BindsAsStatement, Raven.CodeAnalysis.Semantics.Tests.ImperativeContextTests.IfStatement_BranchesCanBeStatements, Raven.CodeAnalysis.Semantics.Tests.ImperativeContextTests.IfStatement_BranchesCanBeExpressions, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree3, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree_Advanced, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree5, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree4, Raven.CodeAnalysis.Syntax.Parser.Tests.IncrementalSyntaxTreeUpdatesTest.ApplyTextChangeToSyntaxTree, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_AsTypeAnnotation, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_Union, Raven.CodeAnalysis.Tests.Workspaces.AnalyzerInfrastructureTests.GetDiagnostics_IncludesCompilerAndAnalyzerDiagnostics, Raven.CodeAnalysis.Syntax.Tests.Sandbox.Test, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_Literal, Raven.CodeAnalysis.Semantics.Tests.ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic, Raven.CodeAnalysis.Semantics.Tests.AliasResolutionTest.AliasDirective_UsesAlias_PredefinedType, Raven.CodeAnalysis.Semantics.Tests.SemanticClassifierTests.ClassifiesTokensBySymbol, Raven.CodeAnalysis.Tests.BlockExpressionTests.IfExpression_WithBlockExpressionBranch_EmitsAndRuns, Raven.CodeAnalysis.Tests.EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromImplicitFinalExpression, Raven.CodeAnalysis.Tests.EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromEarlyReturns, Raven.CodeAnalysis.Semantics.Tests.UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, Raven.CodeAnalysis.Semantics.Tests.SymbolQueryTests.CallingInstanceMethodAsStatic_ProducesDiagnostic, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.LiteralType_Double_UsesUnderlyingDouble, Raven.CodeAnalysis.Tests.Diagnostics.MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.VariableDeclaration_WithDoubleLiteral_InferredDouble, Raven.CodeAnalysis.Tests.Diagnostics.MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion, Raven.CodeAnalysis.Tests.Diagnostics.MissingReturnTypeAnnotationAnalyzerTests.FunctionStatementWithoutAnnotation_SuggestsInferredReturnType, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.VariableDeclaration_WithFloatSuffix_InferredFloat, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.VariableDeclaration_WithLargeInteger_InferredLong, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.LiteralType_Float_UsesUnderlyingSingle, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.LiteralType_Long_UsesUnderlyingInt64, Raven.CodeAnalysis.Syntax.Parser.Tests.EqualsValueClauseTests.VariableDeclaration_MissingInitializer_ProducesDiagnostic, Raven.CodeAnalysis.Tests.Bugs.MemberAccessMissingIdentifierTests.MemberAccessWithoutIdentifier_ReportsDiagnostic, Raven.CodeAnalysis.Tests.Bugs.ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, Raven.CodeAnalysis.Tests.Bugs.ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics, Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesNotExistInCurrentContext_Should_ProduceDiagnostics, Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics, Raven.CodeAnalysis.Semantics.Tests.UnionConversionTests.UnionNotConvertibleToExplicitType_ProducesDiagnostic, Raven.CodeAnalysis.Tests.Workspaces.DiagnosticOptionsTests.RunAnalyzers_False_DisablesAnalyzerDiagnostics, Raven.CodeAnalysis.Syntax.Parser.Tests.ParserNewlineTests.Terminator_SkipsTokens_UntilEndOfFile, Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run (main.rav))*
- `dotnet test --no-build --filter ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload`


------
https://chatgpt.com/codex/tasks/task_e_68b4265877c4832fb8de2f2084d6c8fa