### PR TITLE
Fix unit overload resolution for Console.WriteLine

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -446,13 +446,6 @@ public class Compilation
             return Conversion.None;
         }
 
-        if (source.SpecialType == SpecialType.System_Unit)
-        {
-            if (destination is IUnionTypeSymbol unionDest && unionDest.Types.Any(t => t.SpecialType == SpecialType.System_Unit))
-                return new Conversion(isImplicit: true, isReference: true);
-            return Conversion.None;
-        }
-
         if (source.SpecialType == SpecialType.System_Void)
             return Conversion.None;
 

--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -27,8 +27,8 @@ internal sealed class OverloadResolver
                 var param = parameters[i];
                 var arg = arguments[i];
 
-                // No value can have type 'void' or 'unit' — immediately reject this candidate.
-                if (arg.Type is { } t && (t.SpecialType == SpecialType.System_Void || t.SpecialType == SpecialType.System_Unit))
+                // No value can have type 'void' — immediately reject this candidate.
+                if (arg.Type is { } t && t.SpecialType == SpecialType.System_Void)
                 {
                     allMatch = false;
                     break;
@@ -40,7 +40,7 @@ internal sealed class OverloadResolver
                     if (arg is not BoundAddressOfExpression addr ||
                         addr.Type is not ByRefTypeSymbol argByRef ||
                         !SymbolEqualityComparer.Default.Equals(argByRef.ElementType, param.Type) ||
-                        arg.Type.SpecialType == SpecialType.System_Void || arg.Type.SpecialType == SpecialType.System_Unit)
+                        arg.Type.SpecialType == SpecialType.System_Void)
                     {
                         allMatch = false;
                         break;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs
@@ -5,20 +5,32 @@ namespace Raven.CodeAnalysis.Semantics.Tests;
 public class ExpressionSemanticTest : DiagnosticTestBase
 {
     [Fact]
-    public void Foo_Should_ProduceDiagnostic()
+    public void NestedWriteLine_WithUnitArgument_ShouldNot_ProduceDiagnostics()
     {
         string testCode =
             """
             import System.*
 
-            Console.WriteLine(Console.WriteLine());
+            Console.WriteLine(Console.WriteLine())
             """;
 
-        var verifier = CreateVerifier(
-                    testCode,
-                    [
-                         new DiagnosticResult("RAV1501").WithSpan(3, 1, 3, 39).WithArguments("WriteLine", "1")
-                    ]);
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void WriteLine_WithUnitVariable_ShouldNot_ProduceDiagnostics()
+    {
+        string testCode =
+            """
+            import System.*
+
+            let test = Console.WriteLine("Hello")
+            Console.WriteLine(test)
+            """;
+
+        var verifier = CreateVerifier(testCode);
 
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- allow unit arguments to participate in overload resolution by rejecting only void
- treat unit as a normal value type in conversion classification
- test Console.WriteLine with nested and variable unit values

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Compilation.cs,src/Raven.CodeAnalysis/OverloadResolver.cs,test/Raven.CodeAnalysis.Tests/Semantics/ExpressionSemanticTest.cs --verbosity minimal`
- `dotnet build`
- `dotnet test`
- `dotnet test --no-build --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68b42bb70038832f9de59ddfb5903f2f