### PR TITLE
Handle all BoundExpressionReason cases in SymbolInfo conversion

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundExpressionExtensions.cs
@@ -26,6 +26,12 @@ static class BoundExpressionExtensions
             BoundExpressionReason.Inaccessible => CandidateReason.Inaccessible,
             BoundExpressionReason.WrongArity => CandidateReason.WrongArity,
             BoundExpressionReason.OverloadResolutionFailed => CandidateReason.OverloadResolutionFailure,
+            BoundExpressionReason.TypeMismatch => CandidateReason.None,
+            BoundExpressionReason.MissingType => CandidateReason.NotFound,
+            BoundExpressionReason.ConstantExpected => CandidateReason.None,
+            BoundExpressionReason.UnsupportedOperation => CandidateReason.None,
+            BoundExpressionReason.OtherError => CandidateReason.None,
+            BoundExpressionReason.ArgumentBindingFailed => CandidateReason.OverloadResolutionFailure,
             _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, null)
         };
     }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SymbolInfoReasonTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SymbolInfoReasonTests.cs
@@ -1,0 +1,32 @@
+using Raven.CodeAnalysis;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class SymbolInfoReasonTests : CompilationTestBase
+{
+    [Theory]
+    [InlineData((int)BoundExpressionReason.None, CandidateReason.None)]
+    [InlineData((int)BoundExpressionReason.NotFound, CandidateReason.NotFound)]
+    [InlineData((int)BoundExpressionReason.OverloadResolutionFailed, CandidateReason.OverloadResolutionFailure)]
+    [InlineData((int)BoundExpressionReason.Ambiguous, CandidateReason.Ambiguous)]
+    [InlineData((int)BoundExpressionReason.Inaccessible, CandidateReason.Inaccessible)]
+    [InlineData((int)BoundExpressionReason.WrongArity, CandidateReason.WrongArity)]
+    [InlineData((int)BoundExpressionReason.TypeMismatch, CandidateReason.None)]
+    [InlineData((int)BoundExpressionReason.MissingType, CandidateReason.NotFound)]
+    [InlineData((int)BoundExpressionReason.ConstantExpected, CandidateReason.None)]
+    [InlineData((int)BoundExpressionReason.UnsupportedOperation, CandidateReason.None)]
+    [InlineData((int)BoundExpressionReason.OtherError, CandidateReason.None)]
+    [InlineData((int)BoundExpressionReason.ArgumentBindingFailed, CandidateReason.OverloadResolutionFailure)]
+    public void GetSymbolInfo_ConvertsReason(int boundReasonValue, CandidateReason candidateReason)
+    {
+        var boundReason = (BoundExpressionReason)boundReasonValue;
+        var compilation = CreateCompilation();
+        var error = new BoundErrorExpression(compilation.ErrorTypeSymbol, null, boundReason);
+
+        var info = error.GetSymbolInfo();
+
+        Assert.Equal(candidateReason, info.CandidateReason);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure BoundExpressionExtensions.Convert covers all BoundExpressionReason values
- add SymbolInfoReasonTests to verify conversions

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/BoundTree/BoundExpressionExtensions.cs,test/Raven.CodeAnalysis.Tests/Semantics/SymbolInfoReasonTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test` *(fails: DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, StringInterpolationTests.InterpolatedString_FormatsCorrectly, and more)*
- `dotnet test --filter SymbolInfoReasonTests`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b42eb5d10c832fb68c612f94a4d4dd