### PR TITLE
fix: adjust token lookup for completions

### DIFF
--- a/src/Raven.CodeAnalysis/CompletionService.cs
+++ b/src/Raven.CodeAnalysis/CompletionService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using Raven.CodeAnalysis.Syntax;
@@ -18,7 +19,14 @@ public class CompletionService
     /// <returns>A sequence of completion items applicable at the position.</returns>
     public IEnumerable<CompletionItem> GetCompletions(Compilation compilation, SyntaxTree syntaxTree, int position)
     {
-        var token = syntaxTree.GetRoot().FindToken(position);
+        // Completion requests typically originate from the caret position which
+        // lies *after* the character that triggered completion.  Because
+        // FindToken looks for the token that contains the provided position and
+        // token spans are end-exclusive, passing the caret position directly
+        // results in the token to the right being returned.  Adjust the search
+        // position to ensure the token to the left of the caret is used.
+        var searchPosition = Math.Max(0, position - 1);
+        var token = syntaxTree.GetRoot().FindToken(searchPosition);
         var semanticModel = compilation.GetSemanticModel(syntaxTree);
 
         return CompletionProvider.GetCompletions(token, semanticModel, position);

--- a/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Linq;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Completion;
+
+public class CompletionServiceTests
+{
+    [Fact]
+    public void GetCompletions_AfterDot_ReturnsMembers()
+    {
+        var code = """
+import System.*;
+
+Console.
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
+        var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences([
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+            ]);
+
+        var service = new CompletionService();
+        var position = code.LastIndexOf('.') + 1;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "WriteLine");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure completion service uses token to the left of the caret
- add regression test for member access completions

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompletionService.cs,test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs`
- `dotnet build`
- `dotnet test` *(fails: DiagnosticVerifierTest.* etc.)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b43433cdc4832fadca46f41bee1a76