### PR TITLE
fix: support literal values in TypeUnion analyzer

### DIFF
--- a/src/TypeUnionAnalyzer/Analyzer.cs
+++ b/src/TypeUnionAnalyzer/Analyzer.cs
@@ -44,7 +44,7 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor InvalidPatternRule = new DiagnosticDescriptor(
         id: "TU004",
         title: "Pattern does not match TypeUnion",
-        messageFormat: "Type '{1}' is not allowed by {0}",
+        messageFormat: "Type {1} is not allowed by {0}",
         category: "TypeChecking",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true
@@ -53,7 +53,7 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor MustBeObjectTypeRule = new DiagnosticDescriptor(
         id: "TU005",
         title: "TypeUnion must be declared with object type",
-        messageFormat: "{0} must be declared with type 'object' when using [TypeUnion]",
+        messageFormat: "{0} must be declared with type object when using [TypeUnion]",
         category: "TypeChecking",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true
@@ -830,7 +830,7 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
     }
 
     private static string FormatTypeList(ImmutableArray<ITypeSymbol> types)
-        => string.Join(" or ", types.Select(t => $"'{FormatTypeName(t)}'"));
+        => string.Join(" or ", types.Select(FormatTypeName));
 
     private static bool IsNullShim(ITypeSymbol type)
         => type.Name == "Null" && type.ContainingNamespace?.IsGlobalNamespace == true;
@@ -847,8 +847,8 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
     private static string FormatValue(TypedConstant tc)
     {
         if (tc.Value is ITypeSymbol t)
-            return $"'{FormatTypeName(t)}'";
-        return $"'{FormatConstant(tc.Value)}'";
+            return FormatTypeName(t);
+        return FormatConstant(tc.Value);
     }
 
     private static string FormatConstant(object? value)

--- a/src/TypeUnionAnalyzer/Analyzer.cs
+++ b/src/TypeUnionAnalyzer/Analyzer.cs
@@ -1,5 +1,7 @@
-using System.Collections.Immutable;
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -193,8 +195,9 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
                 continue;
 
             var argType = context.SemanticModel.GetTypeInfo(argExpr).Type;
+            var argConst = context.SemanticModel.GetConstantValue(argExpr);
 
-            bool isCompatible = IsAnyImplicit(argType, allowedTypes, context.SemanticModel.Compilation);
+            bool isCompatible = IsAnyImplicit(argType, argConst.HasValue ? argConst.Value : null, allowedTypes, context.SemanticModel.Compilation);
 
             if (!isCompatible)
             {
@@ -375,9 +378,11 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
         {
             var whenTrueType = context.SemanticModel.GetTypeInfo(conditional.WhenTrue).Type;
             var whenFalseType = context.SemanticModel.GetTypeInfo(conditional.WhenFalse).Type;
+            var whenTrueConst = context.SemanticModel.GetConstantValue(conditional.WhenTrue);
+            var whenFalseConst = context.SemanticModel.GetConstantValue(conditional.WhenFalse);
 
-            bool isTrueCompatible = IsAnyImplicit(whenTrueType, unionTypes, compilation);
-            bool isFalseCompatible = IsAnyImplicit(whenFalseType, unionTypes, compilation);
+            bool isTrueCompatible = IsAnyImplicit(whenTrueType, whenTrueConst.HasValue ? whenTrueConst.Value : null, unionTypes, compilation);
+            bool isFalseCompatible = IsAnyImplicit(whenFalseType, whenFalseConst.HasValue ? whenFalseConst.Value : null, unionTypes, compilation);
 
             if (!isTrueCompatible || !isFalseCompatible)
             {
@@ -396,8 +401,9 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
 
         // Normal return expression
         var returnType = context.SemanticModel.GetTypeInfo(expr).Type;
+        var returnConst = context.SemanticModel.GetConstantValue(expr);
 
-        bool isCompatible = IsAnyImplicit(returnType, unionTypes, compilation);
+        bool isCompatible = IsAnyImplicit(returnType, returnConst.HasValue ? returnConst.Value : null, unionTypes, compilation);
         if (!isCompatible)
         {
             var diagnostic = Diagnostic.Create(
@@ -411,14 +417,25 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsAnyImplicit(ITypeSymbol? source, TypedConstant unionTypes, Compilation compilation)
+    private static bool IsAnyImplicit(ITypeSymbol? source, object? constantValue, TypedConstant unionTypes, Compilation compilation)
     {
-        if (source == null)
+        if (source == null && constantValue == null)
             return ContainsNullType(unionTypes);
 
-        return unionTypes.Values.Any(tc =>
-            tc.Value is ITypeSymbol target &&
-            compilation.ClassifyConversion(source, target).IsImplicit);
+        foreach (var tc in unionTypes.Values)
+        {
+            if (tc.Value is ITypeSymbol target)
+            {
+                if (source != null && compilation.ClassifyConversion(source, target).IsImplicit)
+                    return true;
+            }
+            else if (Equals(constantValue, tc.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void AnalyzeIsPattern(SyntaxNodeAnalysisContext context)
@@ -450,7 +467,7 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
 
             var compilation = context.SemanticModel.Compilation;
 
-            var isCompatible = IsAnyImplicit(targetType, allowedTypes, compilation);
+            var isCompatible = IsAnyImplicit(targetType, null, allowedTypes, compilation);
             if (!isCompatible)
             {
                 var diagnostic = Diagnostic.Create(
@@ -511,7 +528,7 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
                 if (label.Pattern is DeclarationPatternSyntax declarationPattern)
                 {
                     var patternType = context.SemanticModel.GetTypeInfo(declarationPattern.Type).Type;
-                    if (patternType != null && !IsAnyImplicit(patternType, allowedTypes, compilation))
+                    if (patternType != null && !IsAnyImplicit(patternType, null, allowedTypes, compilation))
                     {
                         var diagnostic = Diagnostic.Create(
                             InvalidPatternRule,
@@ -561,7 +578,7 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
             if (arm.Pattern is DeclarationPatternSyntax declarationPattern)
             {
                 var patternType = context.SemanticModel.GetTypeInfo(declarationPattern.Type).Type;
-                if (patternType != null && !IsAnyImplicit(patternType, allowedTypes, compilation))
+                if (patternType != null && !IsAnyImplicit(patternType, null, allowedTypes, compilation))
                 {
                     var diagnostic = Diagnostic.Create(
                         InvalidPatternRule,
@@ -689,8 +706,9 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
             }
 
             var rightType = context.SemanticModel.GetTypeInfo(assignment.Right).Type;
+            var rightConst = context.SemanticModel.GetConstantValue(assignment.Right);
 
-            if (!IsAnyImplicit(rightType, allowedTypes, context.SemanticModel.Compilation))
+            if (!IsAnyImplicit(rightType, rightConst.HasValue ? rightConst.Value : null, allowedTypes, context.SemanticModel.Compilation))
             {
                 var diagnostic = Diagnostic.Create(
                     IncompatibleTypeRule,
@@ -818,14 +836,30 @@ public class TypeUnionParameterAnalyzer : DiagnosticAnalyzer
         => type.Name == "Null" && type.ContainingNamespace?.IsGlobalNamespace == true;
 
     private static bool ContainsNullType(TypedConstant typeArgs)
-        => typeArgs.Values.Any(v => v.Value is ITypeSymbol t && IsNullShim(t));
+        => typeArgs.Values.Any(v => (v.Value is ITypeSymbol t && IsNullShim(t)) || v.Value is null);
 
     private static string FormatTypeName(ITypeSymbol? type)
         => type == null || IsNullShim(type) ? "null" : type.ToDisplayString();
 
     private static string FormatTypeList(TypedConstant typeArgs)
-        => string.Join(" or ",
-            typeArgs.Values.Select(v => v.Value is ITypeSymbol t ? $"'{FormatTypeName(t)}'" : "unknown"));
+        => string.Join(" or ", typeArgs.Values.Select(FormatValue));
+
+    private static string FormatValue(TypedConstant tc)
+    {
+        if (tc.Value is ITypeSymbol t)
+            return $"'{FormatTypeName(t)}'";
+        return $"'{FormatConstant(tc.Value)}'";
+    }
+
+    private static string FormatConstant(object? value)
+        => value switch
+        {
+            null => "null",
+            string s => SymbolDisplay.FormatLiteral(s, true),
+            char c => SymbolDisplay.FormatLiteral(c, true),
+            bool b => b ? "true" : "false",
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? value?.ToString() ?? "unknown"
+        };
 
     private static bool IsNotUnionCompatibleType(ITypeSymbol type, Compilation compilation) => type.SpecialType != SpecialType.System_Object &&
                type.TypeKind != TypeKind.Dynamic &&

--- a/test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs
+++ b/test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs
@@ -76,7 +76,25 @@ class C {
 }";
         var diagnostics = await GetDiagnosticsAsync(source);
         var info = Assert.Single(diagnostics.Where(d => d.Id == "TU001"));
-        Assert.Contains("'null'", info.GetMessage());
+        Assert.Contains("null", info.GetMessage());
+    }
+
+    [Fact]
+    public async Task ParameterDiagnostic_DoesNotQuoteTypeNames()
+    {
+        var source = @"
+using System;
+[AttributeUsage(AttributeTargets.Parameter)]
+class TypeUnionAttribute : Attribute { public TypeUnionAttribute(params Type[] types) {} }
+class C {
+    static void M([TypeUnion(typeof(int), typeof(bool))] object p) {}
+}";
+        var diagnostics = await GetDiagnosticsAsync(source);
+        var info = Assert.Single(diagnostics.Where(d => d.Id == "TU001"));
+        var message = info.GetMessage();
+        Assert.Contains("int or bool", message);
+        Assert.DoesNotContain("'int'", message);
+        Assert.DoesNotContain("'bool'", message);
     }
 
     [Fact]

--- a/test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs
+++ b/test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs
@@ -126,4 +126,20 @@ class C {
         Assert.Contains(diagnostics, d => d.Id == "TU001" && d.GetMessage().Contains("Variable 'x'"));
         Assert.Contains(diagnostics, d => d.Id == "TU001" && d.GetMessage().Contains("Variable 'y'"));
     }
+
+    [Fact]
+    public async Task LiteralValueUnion_DisplaysValuesAndChecksCompatibility()
+    {
+        var source = @"
+using System;
+[AttributeUsage(AttributeTargets.Parameter)]
+class TypeUnionAttribute : Attribute { public TypeUnionAttribute(params object[] types) {} }
+class C {
+    static void M([TypeUnion(""yes"", ""no"")] object p) {}
+    static void Test() { M(""yes""); M(""maybe""); }
+}";
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Contains(diagnostics.Where(d => d.Id == "TU001"), d => d.GetMessage().Contains("\"yes\"") && d.GetMessage().Contains("\"no\""));
+        Assert.Single(diagnostics.Where(d => d.Id == "TU002"));
+    }
 }


### PR DESCRIPTION
## Summary
- support literal values in `TypeUnion` attributes within analyzer
- test literal value unions

## Testing
- `dotnet format Raven.sln --include src/TypeUnionAnalyzer/Analyzer.cs --include test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs -v diagnostic`
- `dotnet build`
- `dotnet test` *(fails: GetResult_WithMatchedDiagnostics, GetResult_NoDiagnostics, Verify_ThrowsException_WhenMissingDiagnostic, GetResult_WithIgnoredDiagnostics, MultiLineCommentTrivia_IsLeadingTriviaOfToken, OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic, TargetTypedMethodBinding_UsesAssignmentType, ReturnTypeCollector_InfersUnionFromImplicitFinalExpression, ReturnTypeCollector_InfersUnionFromEarlyReturns, CallingInstanceMethodAsStatic_ProducesDiagnostic, WildcardTypeImport_MakesStaticMembersAvailable, ArrayCollectionExpressions_SpreadEnumerates, ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, UnionNotConvertibleToExplicitType_ProducesDiagnostic, ExplicitReturnInIfExpressionInitializerProducesDiagnostics, IfStatement_BranchesCanBeStatements, UnionAssignedToObject_ReturnsNoDiagnostic, IfStatement_BranchesCanBeExpressions, InterpolatedString_FormatsCorrectly, CommonBaseClass_WithNull_UsesBaseTypeAndNullable, ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, WriteLine_WithUnitVariable_ShouldNot_ProduceDiagnostics, ApplyChangedTextToSyntaxTree3, ApplyChangedTextToSyntaxTree, ApplyChangedTextToSyntaxTree_Advanced, ApplyChangedTextToSyntaxTree5, ApplyChangedTextToSyntaxTree4, ApplyTextChangeToSyntaxTree, MemberAccessWithoutIdentifier_ReportsDiagnostic, LiteralType_Double_UsesUnderlyingDouble, VariableDeclaration_WithDoubleLiteral_InferredDouble, Sandbox.Test, VariableDeclaration_WithFloatSuffix_InferredFloat, ConsoleDoesNotExistInCurrentContext_Should_ProduceDiagnostics, VariableDeclaration_WithLargeInteger_InferredLong, ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, LiteralType_Float_UsesUnderlyingSingle, ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics, NonUnitMethod_EmptyReturn_ReportsDiagnostic, LiteralType_Long_UsesUnderlyingInt64, NonUnitMethod_ReturnExpression_NotAssignable_ReportsDiagnostic, SemanticClassifierTests.ClassifiesTokensBySymbol, VariableDeclaration_MissingInitializer_ProducesDiagnostic, IfExpression_WithBlockExpressionBranch_EmitsAndRuns, ParserNewlineTests.Terminator_SkipsTokens_UntilEndOfFile, MethodWithoutAnnotation_SuggestsInferredReturnType, MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion, FunctionStatementWithoutAnnotation_SuggestsInferredReturnType, DiagnosticOptionsTests.RunAnalyzers_False_DisablesAnalyzerDiagnostics, ConsoleSyntaxHighlighterTests.UnderlinesDiagnosticSpans_WhenEnabled, AnalyzerInfrastructureTests.GetDiagnostics_IncludesCompilerAndAnalyzerDiagnostics, AliasDirective_UsesAlias_Tuple, Issue84_MemberResolutionBug.CanResolveMember, AliasDirective_UsesAlias_AsTypeAnnotation, AliasDirective_UsesAlias_Union, AliasDirective_UsesAlias_Literal, AliasDirective_UsesAlias_PredefinedType, Sample_should_compile_and_run(fileName: "main.rav", args: [])`

------
https://chatgpt.com/codex/tasks/task_e_68b44a5facf8832fb8704d9cbf6ec18d