### PR TITLE
fix: allow compatible types in TypeUnion analyzer

### DIFF
--- a/docs/compiler/development/analyzers.md
+++ b/docs/compiler/development/analyzers.md
@@ -11,11 +11,12 @@ Raven currently provides analyzers for two different contexts:
   serves as a reference for building analyzers that operate on Raven syntax and semantics.
   When the inferred type is `Unit` (the language's `void`), the analyzer suppresses the
   suggestion.
-- **TypeUnionAnalyzer** (C#) – enforces the semantics of `[TypeUnion]` attributes in C#
-  code. Members annotated with `TypeUnionAttribute` must use `object` or `dynamic` as
-  their CLR type, and any value assigned, returned, or matched against them must implicitly
-  convert to at least one of the declared union members. The analyzer also validates
-  pattern and switch cases and only permits `null` when `null` is included in the union.
+ - **TypeUnionAnalyzer** (C#) – enforces the semantics of `[TypeUnion]` attributes in C#
+  code. Members annotated with `TypeUnionAttribute` must use a CLR type that is assignable
+  from all declared union members (e.g., `object`, `dynamic`, or a suitable base type), and
+  any value assigned, returned, or matched against them must implicitly convert to at least
+  one of the declared union members. The analyzer also validates pattern and switch cases
+  and only permits `null` when `null` is included in the union.
 
 The `Raven.Compiler` CLI uses `RavenWorkspace` to attach analyzers during compilation. Any
 analyzer diagnostics appear alongside regular compilation errors and warnings.

--- a/src/TestDep/Foo.cs
+++ b/src/TestDep/Foo.cs
@@ -49,7 +49,7 @@ public class Foo
 
     }
 
-    public static void Test6([TypeUnion("yes", "no", typeof(Null))] object? v)
+    public static void Test6([TypeUnion("yes", "no", typeof(Null))] string? v)
     {
 
     }

--- a/src/TypeUnionAnalyzer/README.md
+++ b/src/TypeUnionAnalyzer/README.md
@@ -17,8 +17,9 @@ If you want to, you can use `dynamic`, because it is basically `object`.
 ## Union semantics
 
 `TypeUnionAttribute` lists the set of concrete types that a value may take. Any parameter,
-field, property, or return annotated with `[TypeUnion]` must have a CLR type of `object` or
-`dynamic`. At each usage site the analyzer verifies that the value assigned, returned, or
+field, property, or return annotated with `[TypeUnion]` must have a CLR type that is
+assignable from all of the specified values (such as `object`, `dynamic`, or a common base
+type). At each usage site the analyzer verifies that the value assigned, returned, or
 matched against the member implicitly converts to at least one of the allowed types. Pattern
 matching and switch sections are checked in the same way. `null` is only permitted when
 `typeof(void)` (representing the `null` type) is explicitly included in the attribute's type


### PR DESCRIPTION
## Summary
- relax TypeUnionAnalyzer to accept any declaration type compatible with all union values
- add tests for compatible and incompatible declaration types
- document new TypeUnion analyzer behavior and update sample code

## Testing
- `dotnet format Raven.sln --include src/TypeUnionAnalyzer/Analyzer.cs,test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs,src/TestDep/Foo.cs --verbosity diagnostic`
- `dotnet format Raven.sln --include test/TypeUnionAnalyzer.Tests/TypeUnionAnalyzerTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test` *(fails: OutOfMemoryException, many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b44f52e454832fa92b09e65225f323