### PR TITLE
feat: apply completion item replacement span

### DIFF
--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -26,7 +26,6 @@ internal class Program
     private static ListView? _completionList;
     private static CompletionItem[] _currentItems = Array.Empty<CompletionItem>();
     private static string[] _currentCompletions = Array.Empty<string>();
-    private static string _currentPrefix = string.Empty;
 
     public static void Main(string[] args)
     {
@@ -125,10 +124,7 @@ internal class Program
                 if (_currentItems.Length > 0)
                 {
                     var item = _currentItems[_completionList!.SelectedItem];
-                    var insertion = item.InsertionText;
-                    if (insertion.StartsWith(_currentPrefix, StringComparison.OrdinalIgnoreCase))
-                        insertion = insertion[_currentPrefix.Length..];
-                    editor.InsertText(insertion);
+                    ApplyCompletion(editor, item);
                 }
                 HideCompletion();
                 e.Handled = true;
@@ -194,7 +190,6 @@ internal class Program
         var start = col;
         while (start > 0 && char.IsLetter(line[start - 1]))
             start--;
-        _currentPrefix = line[start..col];
 
         var sourceText = SourceText.From(text);
         var solution = Workspace.CurrentSolution.WithDocumentText(_documentId, sourceText);
@@ -239,6 +234,29 @@ internal class Program
         _completionWin.SetNeedsDisplay();
     }
 
+    internal static void ApplyCompletion(CodeTextView editor, CompletionItem item)
+    {
+        var text = editor.Text?.ToString() ?? string.Empty;
+        var before = text[..item.ReplacementSpan.Start];
+        var after = text[item.ReplacementSpan.End..];
+        var newText = before + item.InsertionText + after;
+        editor.Text = newText;
+
+        var cursorPos = item.ReplacementSpan.Start + (item.CursorOffset ?? item.InsertionText.Length);
+        var lines = newText.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');
+        var position = 0;
+        for (var row = 0; row < lines.Length; row++)
+        {
+            var lineLength = lines[row].Length;
+            if (cursorPos <= position + lineLength)
+            {
+                editor.CursorPosition = new Point(cursorPos - position, row);
+                break;
+            }
+            position += lineLength + 1;
+        }
+    }
+
     private static void HideCompletion()
     {
         if (_completionWin != null)
@@ -248,7 +266,6 @@ internal class Program
             _completionList = null;
             _currentItems = Array.Empty<CompletionItem>();
             _currentCompletions = Array.Empty<string>();
-            _currentPrefix = string.Empty;
         }
     }
 

--- a/test/Raven.Editor.Tests/CompletionTests.cs
+++ b/test/Raven.Editor.Tests/CompletionTests.cs
@@ -1,0 +1,44 @@
+namespace Raven.Editor.Tests;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Terminal.Gui;
+
+public class CompletionTests
+{
+    [Fact]
+    public void ApplyCompletion_ReplacesSpanAndPositionsCursor()
+    {
+        Application.Init(new FakeDriver());
+
+        var workspace = RavenWorkspace.Create();
+        var projectId = workspace.AddProject("TestProject");
+        var documentId = DocumentId.CreateNew(projectId);
+
+        var editor = new TestCodeTextView(workspace, projectId, documentId)
+        {
+            Text = "abc"
+        };
+
+        var item = new CompletionItem("foo", "foo", new TextSpan(1, 1), CursorOffset: 1);
+
+        Program.ApplyCompletion(editor, item);
+
+        editor.Text!.ToString().ShouldBe("afooc");
+        editor.CursorPosition.ShouldBe(new Point(2, 0));
+
+        Application.Shutdown();
+    }
+    private sealed class TestCodeTextView : CodeTextView
+    {
+        public TestCodeTextView(RavenWorkspace workspace, ProjectId projectId, DocumentId documentId)
+            : base(workspace, projectId, documentId)
+        {
+        }
+
+        public override void OnContentsChanged()
+        {
+            // Skip heavy workspace updates for unit tests
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- honor `CompletionItem` replacement span and cursor offset when committing completion items in the editor
- add Raven.Editor tests to verify completion inserts text and positions caret

## Testing
- `dotnet format src/Raven.Editor/Raven.Editor.csproj --include Program.cs`
- `dotnet format test/Raven.Editor.Tests/Raven.Editor.Tests.csproj --include CompletionTests.cs`
- `dotnet build`
- `dotnet test --no-build` *(fails: multiple tests)*
- `dotnet test --filter ApplyCompletion_ReplacesSpanAndPositionsCursor --no-build`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b4524020b4832f929565fc84b99c27