### PR TITLE
Avoid RAV1504 for error type assignments

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -144,7 +144,9 @@ partial class BlockBinder : Binder
         {
             type = ResolveType(variableDeclarator.TypeAnnotation.Type);
 
-            if (type.TypeKind != TypeKind.Error && !IsAssignable(type, boundInitializer!.Type!))
+            if (type.TypeKind != TypeKind.Error &&
+                boundInitializer.Type!.TypeKind != TypeKind.Error &&
+                !IsAssignable(type, boundInitializer.Type!))
             {
                 _diagnostics.ReportCannotAssignFromTypeToType(
                     boundInitializer.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
@@ -1654,7 +1656,9 @@ partial class BlockBinder : Binder
                 return new BoundLocalAssignmentExpression(localSymbol, new BoundEmptyCollectionExpression(localSymbol.Type));
             }
 
-            if (!IsAssignable(localSymbol.Type, right2.Type!))
+            if (localSymbol.Type.TypeKind != TypeKind.Error &&
+                right2.Type!.TypeKind != TypeKind.Error &&
+                !IsAssignable(localSymbol.Type, right2.Type!))
             {
                 _diagnostics.ReportCannotAssignFromTypeToType(
                     right2.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
@@ -1674,7 +1678,9 @@ partial class BlockBinder : Binder
                 return new BoundFieldAssignmentExpression(right2, fieldSymbol, new BoundEmptyCollectionExpression(fieldSymbol.Type));
             }
 
-            if (!IsAssignable(fieldSymbol.Type, right2.Type!))
+            if (fieldSymbol.Type.TypeKind != TypeKind.Error &&
+                right2.Type!.TypeKind != TypeKind.Error &&
+                !IsAssignable(fieldSymbol.Type, right2.Type!))
             {
                 _diagnostics.ReportCannotAssignFromTypeToType(
                     right2.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
@@ -1699,7 +1705,9 @@ partial class BlockBinder : Binder
                 return new BoundPropertyAssignmentExpression(right2, propertySymbol, new BoundEmptyCollectionExpression(propertySymbol.Type));
             }
 
-            if (!IsAssignable(propertySymbol.Type, right2.Type!))
+            if (propertySymbol.Type.TypeKind != TypeKind.Error &&
+                right2.Type!.TypeKind != TypeKind.Error &&
+                !IsAssignable(propertySymbol.Type, right2.Type!))
             {
                 _diagnostics.ReportCannotAssignFromTypeToType(
                     right2.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ErrorTypeSymbolAssignmentTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ErrorTypeSymbolAssignmentTests.cs
@@ -1,0 +1,23 @@
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class ErrorTypeSymbolAssignmentTests : DiagnosticTestBase
+{
+    [Fact]
+    public void UndefinedIdentifierAssignedToExplicitType_DoesNotProduceAssignmentDiagnostic()
+    {
+        const string code = """
+        class Foo {
+            Test() -> unit {
+                let x: string = y;
+            }
+        }
+        """;
+
+        var verifier = CreateVerifier(code, [
+            new DiagnosticResult("RAV0103").WithAnySpan().WithArguments("y")
+        ]);
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- skip CannotAssignFromTypeToType diagnostics when either type is an ErrorTypeSymbol
- add regression test for error-type assignment without extra diagnostic

## Testing
- `dotnet format --no-restore Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Bugs/ErrorTypeSymbolAssignmentTests.cs`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: Multiple tests failing)*
- `dotnet test --filter ErrorTypeSymbolAssignmentTests`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b470bce4dc832f9f91dc3ff6da4806