### PR TITLE
feat: allow contextual keywords as identifiers

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -361,7 +361,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
             {
                 var dotToken = ReadToken();
                 SimpleNameSyntax memberName;
-                if (PeekToken().IsKind(SyntaxKind.IdentifierToken))
+                if (CanTokenBeIdentifier(PeekToken()))
                 {
                     memberName = new NameSyntaxParser(this).ParseSimpleName();
                 }
@@ -456,9 +456,14 @@ internal class ExpressionSyntaxParser : SyntaxParser
 
         // Try to parse optional name:
         if (PeekToken(1).IsKind(SyntaxKind.ColonToken)
-            && PeekToken().IsKind(SyntaxKind.IdentifierToken))
+            && CanTokenBeIdentifier(PeekToken()))
         {
-            var name = ReadToken(); // identifier
+            var name = ReadToken(); // identifier or keyword
+            if (name.Kind != SyntaxKind.IdentifierToken)
+            {
+                name = ToIdentifierToken(name);
+                UpdateLastToken(name);
+            }
             var colon = ReadToken(); // colon
             nameColon = NameColon(IdentifierName(name), colon);
         }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
@@ -143,9 +143,14 @@ internal class NameSyntaxParser : SyntaxParser
             return WildcardName(name);
         }
 
-        if (name.IsKind(SyntaxKind.IdentifierToken))
+        if (CanTokenBeIdentifier(name))
         {
-            ReadToken();
+            name = ReadToken();
+            if (name.Kind != SyntaxKind.IdentifierToken)
+            {
+                name = ToIdentifierToken(name);
+                UpdateLastToken(name);
+            }
 
             if (
                 PeekToken().IsKind(SyntaxKind.LessThanToken) &&
@@ -221,9 +226,14 @@ internal class NameSyntaxParser : SyntaxParser
 
             NameColonSyntax? nameColon = null;
 
-            if (PeekToken(1).IsKind(SyntaxKind.ColonToken) && PeekToken().IsKind(SyntaxKind.IdentifierToken))
+            if (PeekToken(1).IsKind(SyntaxKind.ColonToken) && CanTokenBeIdentifier(PeekToken()))
             {
                 var name = ReadToken();
+                if (name.Kind != SyntaxKind.IdentifierToken)
+                {
+                    name = ToIdentifierToken(name);
+                    UpdateLastToken(name);
+                }
                 var colon = ReadToken();
                 nameColon = NameColon(IdentifierName(name), colon);
             }

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.Identifier.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.Identifier.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Raven.CodeAnalysis.Syntax;
+
+public static partial class SyntaxFacts
+{
+    public static bool IsKeywordKind(SyntaxKind kind)
+    {
+        return kind.ToString().EndsWith("Keyword", StringComparison.Ordinal);
+    }
+
+    public static bool CanBeIdentifier(SyntaxKind kind)
+    {
+        return kind == SyntaxKind.IdentifierToken ||
+               (IsKeywordKind(kind) && !IsReservedWordKind(kind));
+    }
+}

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxTokenExtension.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxTokenExtension.cs
@@ -6,4 +6,9 @@ public static class SyntaxTokenExtension
     {
         return SyntaxFacts.IsReservedWordKind(token.Kind);
     }
+
+    public static bool CanBeIdentifier(this SyntaxToken token)
+    {
+        return SyntaxFacts.CanBeIdentifier(token.Kind);
+    }
 }


### PR DESCRIPTION
## Summary
- allow keywords to act as identifiers when not reserved
- expose SyntaxFacts helpers for keyword/identifier checks
- update parsers to transform contextual keywords into identifier tokens

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/SyntaxTokenExtension.cs,src/Raven.CodeAnalysis/Syntax/SyntaxFacts.Identifier.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs -v minimal`
- `dotnet build`
- `dotnet test` *(fails: DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics, DiagnosticVerifierTest.GetResult_NoDiagnostics, DiagnosticVerifierTest.Verify_ThrowsException_WhenMissingDiagnostic, DiagnosticVerifierTest.GetResult_WithIgnoredDiagnostics, CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates, Issue84_MemberResolutionBug.CanResolveMember, ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics, AnalyzerInfrastructureTests.GetDiagnostics_IncludesCompilerAndAnalyzerDiagnostics, SymbolQueryTests.CallingInstanceMethodAsStatic_ProducesDiagnostic, ReturnStatementUnitTests.NonUnitMethod_EmptyReturn_ReportsDiagnostic, DiagnosticOptionsTests.RunAnalyzers_False_DisablesAnalyzerDiagnostics, MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType, NamespaceResolutionTest.ConsoleDoesNotExistInCurrentContext_Should_ProduceDiagnostics, MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion, ReturnStatementUnitTests.NonUnitMethod_ReturnExpression_NotAssignable_ReportsDiagnostic, IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree3, IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree, IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree_Advanced, IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree5, IncrementalSyntaxTreeUpdatesTest.ApplyChangedTextToSyntaxTree4, IncrementalSyntaxTreeUpdatesTest.ApplyTextChangeToSyntaxTree, MissingReturnTypeAnnotationAnalyzerTests.FunctionStatementWithoutAnnotation_SuggestsInferredReturnType, NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, NamespaceResolutionTest.ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics, SemanticClassifierTests.ClassifiesTokensBySymbol, EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromImplicitFinalExpression, ParserNewlineTests.Terminator_SkipsTokens_UntilEndOfFile, EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromEarlyReturns, UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, ImperativeContextTests.BlockExpression_InExpressionStatement_BindsAsStatement, ImperativeContextTests.IfStatement_BranchesCanBeStatements, ImperativeContextTests.IfStatement_BranchesCanBeExpressions, ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic, ExpressionSemanticTest.WriteLine_WithUnitVariable_ShouldNot_ProduceDiagnostics, ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable, ConsoleSyntaxHighlighterTests.UnderlinesDiagnosticSpans_WhenEnabled, LiteralTypeFlowTests.LiteralType_Double_UsesUnderlyingDouble, EqualsValueClauseTests.VariableDeclaration_MissingInitializer_ProducesDiagnostic, MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken, LiteralTypeFlowTests.VariableDeclaration_WithDoubleLiteral_InferredDouble, MemberAccessMissingIdentifierTests.MemberAccessWithoutIdentifier_ReportsDiagnostic, LiteralTypeFlowTests.VariableDeclaration_WithFloatSuffix_InferredFloat, LiteralTypeFlowTests.VariableDeclaration_WithLargeInteger_InferredLong, Syntax.Tests.Sandbox.Test, LiteralTypeFlowTests.LiteralType_Float_UsesUnderlyingSingle, UnionConversionTests.UnionNotConvertibleToExplicitType_ProducesDiagnostic, UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, LiteralTypeFlowTests.LiteralType_Long_UsesUnderlyingInt64, StringInterpolationTests.InterpolatedString_FormatsCorrectly, NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, BlockExpressionTests.IfExpression_WithBlockExpressionBranch_EmitsAndRuns, AliasResolutionTest.AliasDirective_UsesAlias_Tuple, AliasResolutionTest.AliasDirective_UsesAlias_AsTypeAnnotation, AliasResolutionTest.AliasDirective_UsesAlias_Union, AliasResolutionTest.AliasDirective_UsesAlias_Literal, AliasResolutionTest.AliasDirective_UsesAlias_PredefinedType, SampleProgramsTests.Sample_should_compile_and_run)`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b47c073308832faccd35eb182732f6