### PR TITLE
refactor: manual identifier promotion

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
@@ -15,9 +15,14 @@ internal class EnumDeclarationParser : SyntaxParser
     {
         var enumKeyword = ReadToken();
 
-        if (!ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var identifier))
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
         {
-
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
         }
 
         List<GreenNode> parameterList = new List<GreenNode>();
@@ -52,7 +57,15 @@ internal class EnumDeclarationParser : SyntaxParser
 
     private GreenNode ParseMember()
     {
-        var identifier = ReadToken();
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
 
         return EnumMemberDeclaration(SyntaxList.Empty, identifier, null);
     }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -850,7 +850,15 @@ internal class ExpressionSyntaxParser : SyntaxParser
         else
             eachKeyword = Token(SyntaxKind.None);
 
-        ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var identifier);
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
         ConsumeTokenOrMissing(SyntaxKind.InKeyword, out var inKeyword);
 
         var expression = new ExpressionSyntaxParser(this).ParseExpression();

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
@@ -47,7 +47,7 @@ internal class PatternSyntaxParser : SyntaxParser
 
         // Optionally consume a variable designation
         VariableDesignationSyntax? designation = null;
-        if (IsNextToken(SyntaxKind.IdentifierToken))
+        if (CanTokenBeIdentifier(PeekToken()))
         {
             designation = ParseDesignation();
         }
@@ -57,7 +57,15 @@ internal class PatternSyntaxParser : SyntaxParser
 
     private VariableDesignationSyntax ParseDesignation()
     {
-        ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var identifier);
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
         return SingleVariableDesignation(identifier);
     }
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -76,8 +76,15 @@ internal class StatementSyntaxParser : SyntaxParser
     private StatementSyntax? ParseFunctionSyntax()
     {
         var funcKeyword = ReadToken();
-
-        ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var identifier);
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
 
         var parameterList = ParseParameterList();
 
@@ -134,7 +141,15 @@ internal class StatementSyntaxParser : SyntaxParser
                 modifiers = modifiers.Add(modifier);
             }
 
-            ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var name);
+            SyntaxToken name;
+            if (CanTokenBeIdentifier(PeekToken()))
+            {
+                name = ReadIdentifierToken();
+            }
+            else
+            {
+                name = ExpectToken(SyntaxKind.IdentifierToken);
+            }
 
             var typeAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
 
@@ -250,7 +265,7 @@ internal class StatementSyntaxParser : SyntaxParser
 
         if (CanTokenBeIdentifier(PeekToken()))
         {
-            identifier = ToIdentifierToken(ReadToken());
+            identifier = ReadIdentifierToken();
         }
 
         EqualsValueClauseSyntax? initializer = null;

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -44,20 +44,6 @@ internal class SyntaxParser : ParseContext
     public bool IsNextToken(SyntaxKind kind, [NotNullWhen(true)] out SyntaxToken token)
     {
         token = PeekToken();
-        if (kind == SyntaxKind.IdentifierToken)
-        {
-            if (token.Kind == SyntaxKind.IdentifierToken)
-                return true;
-
-            if (CanTokenBeIdentifier(token))
-            {
-                token = ToIdentifierToken(token);
-                return true;
-            }
-
-            return false;
-        }
-
         if (token.Kind == kind)
         {
             return true;
@@ -68,17 +54,6 @@ internal class SyntaxParser : ParseContext
     public bool IsNextToken(SyntaxKind kind)
     {
         var token = PeekToken();
-        if (kind == SyntaxKind.IdentifierToken)
-        {
-            if (token.Kind == SyntaxKind.IdentifierToken)
-                return true;
-
-            if (CanTokenBeIdentifier(token))
-                return true;
-
-            return false;
-        }
-
         if (token.Kind == kind)
         {
             return true;
@@ -90,25 +65,6 @@ internal class SyntaxParser : ParseContext
     {
         token = PeekToken();
 
-        if (kind == SyntaxKind.IdentifierToken)
-        {
-            if (token.Kind == SyntaxKind.IdentifierToken)
-            {
-                token = ReadToken();
-                return true;
-            }
-
-            if (CanTokenBeIdentifier(token))
-            {
-                token = ReadToken();
-                token = ToIdentifierToken(token);
-                UpdateLastToken(token);
-                return true;
-            }
-
-            return false;
-        }
-
         if (token.Kind == kind)
         {
             token = ReadToken();
@@ -116,6 +72,18 @@ internal class SyntaxParser : ParseContext
         }
 
         return false;
+    }
+
+    protected SyntaxToken ReadIdentifierToken()
+    {
+        var token = ReadToken();
+        if (CanTokenBeIdentifier(token))
+        {
+            token = ToIdentifierToken(token);
+            UpdateLastToken(token);
+        }
+
+        return token;
     }
 
     public bool ConsumeTokenOrMissing(SyntaxKind kind, [NotNullWhen(true)] out SyntaxToken token)

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -18,7 +18,15 @@ internal class TypeDeclarationParser : SyntaxParser
 
         var structOrClassKeyword = ReadToken();
 
-        ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var identifier);
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
 
         var baseType = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
 
@@ -119,7 +127,15 @@ internal class TypeDeclarationParser : SyntaxParser
     {
         ReadToken();
 
-        ConsumeTokenOrNull(SyntaxKind.IdentifierToken, out var identifier);
+        SyntaxToken? identifier = null;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            ConsumeTokenOrNull(SyntaxKind.IdentifierToken, out identifier);
+        }
 
         // Check is open paren
 
@@ -169,8 +185,12 @@ internal class TypeDeclarationParser : SyntaxParser
 
     private MemberDeclarationSyntax ParseMethodOrConstructorDeclarationBase(SyntaxList modifiers)
     {
-        if (!ConsumeToken(SyntaxKind.IdentifierToken, out var identifier) &&
-            !ConsumeToken(SyntaxKind.SelfKeyword, out identifier))
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else if (!ConsumeToken(SyntaxKind.SelfKeyword, out identifier))
         {
             identifier = MissingToken(SyntaxKind.IdentifierToken);
         }
@@ -377,7 +397,15 @@ internal class TypeDeclarationParser : SyntaxParser
                 modifiers = modifiers.Add(modifier);
             }
 
-            ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var name);
+            SyntaxToken name;
+            if (CanTokenBeIdentifier(PeekToken()))
+            {
+                name = ReadIdentifierToken();
+            }
+            else
+            {
+                name = ExpectToken(SyntaxKind.IdentifierToken);
+            }
 
             var typeAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
 
@@ -411,7 +439,15 @@ internal class TypeDeclarationParser : SyntaxParser
     {
         var letOrVarKeyword = ReadToken();
 
-        ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var identifier);
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
 
         EqualsValueClauseSyntax? initializer = null;
 
@@ -461,7 +497,15 @@ internal class TypeDeclarationParser : SyntaxParser
                 modifiers = modifiers.Add(modifier);
             }
 
-            ConsumeTokenOrMissing(SyntaxKind.IdentifierToken, out var name);
+            SyntaxToken name;
+            if (CanTokenBeIdentifier(PeekToken()))
+            {
+                name = ReadIdentifierToken();
+            }
+            else
+            {
+                name = ExpectToken(SyntaxKind.IdentifierToken);
+            }
 
             var typeAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
 

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/IdentifierTokenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/IdentifierTokenTests.cs
@@ -1,0 +1,81 @@
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+
+using Xunit;
+
+using IS = Raven.CodeAnalysis.Syntax.InternalSyntax;
+using ParserInternal = Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class IdentifierTokenTests
+{
+    private sealed class SingleTokenLexer : ILexer
+    {
+        private readonly ParserInternal.Token[] _tokens;
+        private int _index;
+
+        public SingleTokenLexer(ParserInternal.Token token)
+        {
+            _tokens = new[] { token, new ParserInternal.Token(SyntaxKind.EndOfFileToken, string.Empty) };
+        }
+
+        public bool IsEndOfFile => _index >= _tokens.Length - 1;
+
+        public ParserInternal.Token ReadToken() => _tokens[_index++];
+
+        public IEnumerable<ParserInternal.Token> ReadTokens(int count)
+        {
+            var result = new List<ParserInternal.Token>();
+            for (int i = 0; i < count; i++)
+                result.Add(ReadToken());
+            return result;
+        }
+
+        public void ReadAndDiscardTokens(int count) => _index += count;
+
+        public ParserInternal.Token PeekToken(int index = 0) => _tokens[_index + index];
+
+        public void ResetToPosition(int length) { }
+
+        public void CreateCheckpoint() { }
+
+        public void RewindToCheckpoint() { }
+
+        public void ClearCheckpoint() { }
+    }
+
+    private sealed class TestParser : SyntaxParser
+    {
+        public TestParser(ParseContext parent) : base(parent)
+        {
+        }
+
+        public IS.SyntaxToken ReadIdentifier() => ReadIdentifierToken();
+    }
+
+    [Fact]
+    public void ConsumeToken_DoesNotPromoteKeyword()
+    {
+        var lexer = new SingleTokenLexer(new ParserInternal.Token(SyntaxKind.EnumKeyword, "enum"));
+        var context = new BaseParseContext(lexer);
+        var parser = new SyntaxParser(context);
+
+        Assert.False(parser.ConsumeToken(SyntaxKind.IdentifierToken, out IS.SyntaxToken token));
+        Assert.Equal(SyntaxKind.EnumKeyword, token.Kind);
+        Assert.Equal(SyntaxKind.EnumKeyword, context.PeekToken().Kind);
+    }
+
+    [Fact]
+    public void ReadIdentifierToken_PromotesKeyword()
+    {
+        var lexer = new SingleTokenLexer(new ParserInternal.Token(SyntaxKind.ImportKeyword, "import"));
+        var context = new BaseParseContext(lexer);
+        var parser = new TestParser(context);
+
+        var token = parser.ReadIdentifier();
+
+        Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+        Assert.Equal("import", token.Text);
+    }
+}


### PR DESCRIPTION
## Summary
- stop auto-promoting keywords when peeking or consuming tokens
- introduce `ReadIdentifierToken` helper and update parsers
- cover keyword-as-identifier behavior with unit tests

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs,test/Raven.CodeAnalysis.Tests/Syntax/Parser/IdentifierTokenTests.cs`
- `dotnet build`
- `dotnet test` *(fails: Test host process crashed)*
- `dotnet test --no-build --filter IdentifierTokenTests`
- `dotnet test --no-build --filter Sample_should_compile_and_run` *(fails: Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b4850516dc832fa057e28b977e44ac