### PR TITLE
feat: separate keyword and reserved word syntax facts

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
@@ -134,7 +134,7 @@ internal class Lexer : ILexer
                         _stringBuilder.Append(ch);
                     }
 
-                    if (!SyntaxFacts.ParseReservedWord(GetStringBuilderValue(), out syntaxKind))
+                    if (!SyntaxFacts.TryParseKeyword(GetStringBuilderValue(), out syntaxKind))
                     {
                         syntaxKind = SyntaxKind.IdentifierToken;
                     }

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.Identifier.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.Identifier.cs
@@ -4,11 +4,6 @@ namespace Raven.CodeAnalysis.Syntax;
 
 public static partial class SyntaxFacts
 {
-    public static bool IsKeywordKind(SyntaxKind kind)
-    {
-        return kind.ToString().EndsWith("Keyword", StringComparison.Ordinal);
-    }
-
     public static bool CanBeIdentifier(SyntaxKind kind)
     {
         return kind == SyntaxKind.IdentifierToken ||

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
@@ -18,4 +18,16 @@ public class LexerTests
         var value = Assert.IsType<double>(token.Value);
         Assert.Equal(0.12d, value);
     }
+
+    [Theory]
+    [InlineData("unit", SyntaxKind.UnitKeyword)]
+    [InlineData("and", SyntaxKind.AndToken)]
+    public void Keyword_IsParsedAsKeywordToken(string text, SyntaxKind expected)
+    {
+        var lexer = new Lexer(new StringReader(text));
+        var token = lexer.ReadToken();
+
+        Assert.Equal(expected, token.Kind);
+        Assert.Equal(text, token.Text);
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/SyntaxFactsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/SyntaxFactsTests.cs
@@ -1,0 +1,42 @@
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+public class SyntaxFactsTests
+{
+    [Theory]
+    [InlineData("unit", SyntaxKind.UnitKeyword)]
+    [InlineData("and", SyntaxKind.AndToken)]
+    public void TryParseKeyword_ReturnsExpectedKind(string text, SyntaxKind expected)
+    {
+        SyntaxFacts.TryParseKeyword(text, out var kind).ShouldBeTrue();
+        kind.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TryParseKeyword_ReturnsFalse_ForNonKeyword()
+    {
+        SyntaxFacts.TryParseKeyword("+", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsKeywordKind_DistinguishesKinds()
+    {
+        SyntaxFacts.IsKeywordKind(SyntaxKind.ImportKeyword).ShouldBeTrue();
+        SyntaxFacts.IsKeywordKind(SyntaxKind.AndToken).ShouldBeTrue();
+        SyntaxFacts.IsKeywordKind(SyntaxKind.PlusToken).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsReservedWordKind_OnlyForReserved()
+    {
+        SyntaxFacts.IsReservedWordKind(SyntaxKind.UnitKeyword).ShouldBeFalse();
+        SyntaxFacts.IsReservedWordKind(SyntaxKind.AndToken).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParseReservedWord_ReturnsExpected()
+    {
+        SyntaxFacts.TryParseReservedWord("and", out var kind).ShouldBeTrue();
+        kind.ShouldBe(SyntaxKind.AndToken);
+        SyntaxFacts.TryParseReservedWord("unit", out _).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- generate keyword and reserved word lookups separately
- use keyword parsing in lexer
- add tests covering keyword classification

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs,src/Raven.CodeAnalysis/Syntax/SyntaxFacts.Identifier.cs,test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs,tools/NodeGenerator/TokenGenerator.cs,test/Raven.CodeAnalysis.Tests/Syntax/SyntaxFactsTests.cs -v normal`
- `dotnet build`
- `dotnet test`
- `dotnet test --no-build --filter Sample_should_compile_and_run`


------
https://chatgpt.com/codex/tasks/task_e_68b48c2b8290832f967ff64f7ae645b6