### PR TITLE
feat: add member completion for values and types

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
@@ -4,18 +4,80 @@ using System.Linq;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
+using Xunit;
 
 namespace Raven.CodeAnalysis.Tests.Completion;
 
 public class CompletionServiceTests
 {
     [Fact]
-    public void GetCompletions_AfterDot_ReturnsMembers()
+    public void GetCompletions_AfterDot_OnType_ReturnsStaticMembers()
     {
         var code = """
 import System.*;
 
-Console.
+string.
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
+        var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences([
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+            ]);
+
+        var service = new CompletionService();
+        var position = code.LastIndexOf('.') + 1;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "IsNullOrEmpty");
+        Assert.DoesNotContain(items, i => i.DisplayText == "Length");
+    }
+
+    [Fact]
+    public void GetCompletions_AfterDot_OnVariable_ReturnsInstanceMembers()
+    {
+        var code = """
+import System.*;
+
+let text = "";
+text.
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
+        var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences([
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+            ]);
+
+        var service = new CompletionService();
+        var position = code.LastIndexOf('.') + 1;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "Length");
+        Assert.DoesNotContain(items, i => i.DisplayText == "IsNullOrEmpty");
+    }
+
+    [Fact]
+    public void GetCompletions_AfterDot_OnProperty_ReturnsInstanceMembers()
+    {
+        var code = """
+import System.*;
+
+Console.Out.
 """;
 
         var syntaxTree = SyntaxTree.ParseText(code);
@@ -36,5 +98,6 @@ Console.
         var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
 
         Assert.Contains(items, i => i.DisplayText == "WriteLine");
+        Assert.DoesNotContain(items, i => i.DisplayText == "Synchronized");
     }
 }


### PR DESCRIPTION
## Summary
- expand member access completion to support both instance and type members
- add tests for variable, property, and type completions

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompletionProvider.cs,test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs --verbosity diagnostic`
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.Samples.SampleProgramsTests.Sample_should_compile_and_run` *(fails: DiagnosticVerifierTest & others)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: SampleProgramsTests)*

------
https://chatgpt.com/codex/tasks/task_e_68b49fc6bd6c832fb28d7c214a292706