### PR TITLE
feat: highlight interpolated string delimiters

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticClassifier.cs
+++ b/src/Raven.CodeAnalysis/SemanticClassifier.cs
@@ -19,7 +19,12 @@ public static class SemanticClassifier
                 tokenMap[descendant] = SemanticClassification.Keyword;
             }
             // Literals
-            else if (kind == SyntaxKind.StringLiteralToken)
+            else if (kind == SyntaxKind.StringLiteralToken ||
+                     kind == SyntaxKind.StringStartToken ||
+                     kind == SyntaxKind.StringEndToken ||
+                     kind == SyntaxKind.DollarToken ||
+                     (kind == SyntaxKind.OpenBraceToken && descendant.Parent is InterpolationSyntax) ||
+                     (kind == SyntaxKind.CloseBraceToken && descendant.Parent is InterpolationSyntax))
             {
                 tokenMap[descendant] = SemanticClassification.StringLiteral;
             }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
@@ -1,7 +1,9 @@
+using System.Linq;
+
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
-using System.Linq;
+
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
@@ -39,5 +41,34 @@ namespace N { class C { let f = 0 public P: int => f method M(p: int) -> int { l
 
         var localToken = result.Tokens.Keys.First(t => t.Text == "l");
         result.Tokens[localToken].ShouldBe(SemanticClassification.Local);
+    }
+
+    [Fact]
+    public void InterpolatedString_ClassifiesDelimiters()
+    {
+        var source = """
+class C {
+    M(name: string) -> string {
+        return "Hello ${name}";
+    }
+}
+""";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+        var model = compilation.GetSemanticModel(tree);
+        var result = SemanticClassifier.Classify(tree.GetRoot(), model);
+
+        var tokens = tree.GetRoot().DescendantTokens().ToList();
+        var startQuote = tokens.First(t => t.Kind == SyntaxKind.StringStartToken);
+        var endQuote = tokens.First(t => t.Kind == SyntaxKind.StringEndToken);
+        var dollar = tokens.First(t => t.Kind == SyntaxKind.DollarToken);
+        var openBrace = tokens.First(t => t.Kind == SyntaxKind.OpenBraceToken && t.Parent is InterpolationSyntax);
+        var closeBrace = tokens.First(t => t.Kind == SyntaxKind.CloseBraceToken && t.Parent is InterpolationSyntax);
+
+        result.Tokens[startQuote].ShouldBe(SemanticClassification.StringLiteral);
+        result.Tokens[endQuote].ShouldBe(SemanticClassification.StringLiteral);
+        result.Tokens[dollar].ShouldBe(SemanticClassification.StringLiteral);
+        result.Tokens[openBrace].ShouldBe(SemanticClassification.StringLiteral);
+        result.Tokens[closeBrace].ShouldBe(SemanticClassification.StringLiteral);
     }
 }


### PR DESCRIPTION
## Summary
- classify interpolation delimiters and quotes as string literals
- test semantic classification of interpolated string parts

## Testing
- `dotnet build`
- `dotnet test --filter FullyQualifiedName!=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: MultiLineCommentTrivia_IsLeadingTriviaOfToken, BlockExpressionTests.IfExpression_WithBlockExpressionBranch_EmitsAndRuns)*
- `dotnet test --filter FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.SemanticClassifierTests.InterpolatedString_ClassifiesDelimiters`
- `dotnet test --filter FullyQualifiedName=Raven.CodeAnalysis.Tests.SampleProgramsTests.Sample_should_compile_and_run` *(fails: SampleProgramsTests.Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a0bc52f8832fa84c8d870a8c8607