### PR TITLE
docs: clarify control flow statement forms

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -95,13 +95,14 @@ Accessor                 ::= AccessorModifier? ('get' | 'set')
 
 BracketedParameterList   ::= '[' ParameterList? ']' ;
 
-(* ---------- Statements ----------
-   NOTE: Raven has no separate If/While *statements*.
-         Standalone control flow uses ExpressionStatement with IfExpression/WhileExpression. *)
+(* ---------- Statements ---------- *)
 
 Statement                ::= LocalDeclaration
                            | ReturnStatement
                            | FunctionStatement
+                           | IfStatement
+                           | WhileStatement
+                           | ForStatement
                            | ExpressionStatement ;
 
 LocalDeclaration         ::= ('let' | 'var') LocalVariableDeclarators ;
@@ -113,6 +114,10 @@ ReturnStatement          ::= 'return' Expression? ;
 FunctionStatement        ::= 'func' Identifier '(' ParameterList? ')' ReturnTypeClause? Block ;
 
 ExpressionStatement      ::= Expression ;
+
+IfStatement              ::= 'if' Expression Statement ['else' Statement] ;
+WhileStatement           ::= 'while' Expression Statement ;
+ForStatement             ::= 'for' 'each'? Identifier 'in' Expression Statement ;
 
 (* ---------- Expressions & precedence (lowest → highest) ---------- *)
 
@@ -166,8 +171,8 @@ ElementAccessTrailer     ::= '[' Expression ']' ;
 MemberBindingExpression  ::= '.' Identifier ;
 
 (* ---------- Primaries ----------
-   NOTE: Block/IfExpression/WhileExpression can appear as expressions,
-         so `if (…) … [else …]` and `while (…) …` can be used as statements via ExpressionStatement. *)
+   NOTE: Block/IfExpression/WhileExpression/ForExpression can appear as expressions.
+         Each also has a corresponding statement form when used in statement position. *)
 PrimaryExpression        ::= Literal
                            | Identifier
                            | MemberBindingExpression

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -103,8 +103,8 @@ func sayHello() {
 
 Any expression can appear as a statement.
 
-> **Note:** Control flow such as `if`, `while`, and `for` are **expressions**. When used
-> on their own line, they form an `ExpressionStatement`.
+Control flow constructs such as `if`, `while`, and `for` also have dedicated statement forms for convenience.
+`ExpressionStatement` covers the remaining expressions that may appear on their own line.
 
 ### Return statements
 


### PR DESCRIPTION
## Summary
- clarify that `if`, `while`, and `for` have dedicated statement forms
- define `IfStatement`, `WhileStatement`, and `ForStatement` in grammar

## Testing
- `dotnet build` *(skipped: documentation-only changes)*
- `dotnet test` *(skipped: documentation-only changes)*

------
https://chatgpt.com/codex/tasks/task_e_68bd333333e8832f85e9e19840aea9ec