### PR TITLE
fix: update completion list selection highlight

### DIFF
--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -125,11 +125,15 @@ internal class Program
             if (_completionWin != null && e.KeyEvent.Key == Key.CursorDown)
             {
                 _completionList!.SelectedItem = Math.Min(_completionList.SelectedItem + 1, _currentCompletions.Length - 1);
+                _completionList.EnsureSelectedItemVisible();
+                _completionList.SetNeedsDisplay();
                 e.Handled = true;
             }
             else if (_completionWin != null && e.KeyEvent.Key == Key.CursorUp)
             {
                 _completionList!.SelectedItem = Math.Max(_completionList.SelectedItem - 1, 0);
+                _completionList.EnsureSelectedItemVisible();
+                _completionList.SetNeedsDisplay();
                 e.Handled = true;
             }
             else if (_completionWin != null && (e.KeyEvent.Key == Key.Enter || e.KeyEvent.Key == Key.Tab))


### PR DESCRIPTION
## Summary
- ensure completion list refreshes when navigating with arrow keys

## Testing
- `dotnet format Raven.sln --include src/Raven.Editor/Program.cs -v diag`
- `dotnet build`
- `dotnet test` *(fails: multiple failing tests)*
- `dotnet test test/Raven.Editor.Tests`
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e9336084832f87f7dfffa35930ab