### PR TITLE
fix: restore editor cursor after closing completions

### DIFF
--- a/src/Raven.Editor/Program.cs
+++ b/src/Raven.Editor/Program.cs
@@ -350,7 +350,11 @@ internal class Program
             _completionList = null;
             _currentItems = Array.Empty<CompletionItem>();
             _currentCompletions = Array.Empty<string>();
-            _editor?.SetFocus();
+            if (_editor != null)
+            {
+                _editor.SetFocus();
+                Application.Driver?.SetCursorVisibility(CursorVisibility.Default);
+            }
         }
     }
 

--- a/test/Raven.Editor.Tests/ProgramTests.cs
+++ b/test/Raven.Editor.Tests/ProgramTests.cs
@@ -2,8 +2,10 @@ namespace Raven.Editor.Tests;
 
 using System;
 using System.Reflection;
+
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
+
 using Terminal.Gui;
 
 public class ProgramTests
@@ -53,6 +55,8 @@ public class ProgramTests
             .Invoke(null, null);
 
         Application.Top.Focused.ShouldBe(editor);
+        Application.Driver!.GetCursorVisibility(out var visibility);
+        visibility.ShouldBe(CursorVisibility.Default);
 
         Application.Shutdown();
     }


### PR DESCRIPTION
## Summary
- ensure Raven Editor regains focus after closing completion popup so cursor stays visible
- cover HideCompletion focus behaviour with a unit test

## Testing
- `dotnet format src/Raven.Editor/Raven.Editor.csproj --include src/Raven.Editor/Program.cs`
- `dotnet format test/Raven.Editor.Tests/Raven.Editor.Tests.csproj --include test/Raven.Editor.Tests/ProgramTests.cs`
- `dotnet build`
- `dotnet test test/Raven.Editor.Tests/Raven.Editor.Tests.csproj`
- `dotnet test --filter 'FullyQualifiedName!~Sample_should_compile_and_run'` *(fails: Raven.CodeAnalysis tests)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Sample_should_compile_and_run)*

------
https://chatgpt.com/codex/tasks/task_e_68c3da1aea44832fbc3e1b4291c1a5d7