### PR TITLE
fix: hide property and event accessors

### DIFF
--- a/src/Raven.CodeAnalysis/CompletionProvider.cs
+++ b/src/Raven.CodeAnalysis/CompletionProvider.cs
@@ -123,7 +123,12 @@ public static class CompletionProvider
 
                     foreach (var member in members.Where(m => string.IsNullOrEmpty(prefix) || m.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
                     {
-                        if (member is IMethodSymbol method && method.ContainingSymbol is IPropertySymbol)
+                        if (member is IMethodSymbol method &&
+                            (method.MethodKind == MethodKind.PropertyGet ||
+                             method.MethodKind == MethodKind.PropertySet ||
+                             method.MethodKind == MethodKind.EventAdd ||
+                             method.MethodKind == MethodKind.EventRemove ||
+                             method.MethodKind == MethodKind.EventRaise))
                             continue;
 
                         var insertText = member is IMethodSymbol ? member.Name + "()" : member.Name;
@@ -209,7 +214,12 @@ public static class CompletionProvider
                 if (symbol is IMethodSymbol { IsConstructor: true })
                     continue;
 
-                if (symbol is IMethodSymbol && symbol.ContainingSymbol is IPropertySymbol)
+                if (symbol is IMethodSymbol method &&
+                    (method.MethodKind == MethodKind.PropertyGet ||
+                     method.MethodKind == MethodKind.PropertySet ||
+                     method.MethodKind == MethodKind.EventAdd ||
+                     method.MethodKind == MethodKind.EventRemove ||
+                     method.MethodKind == MethodKind.EventRaise))
                     continue;
 
                 if (!string.IsNullOrEmpty(tokenText) &&

--- a/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
@@ -100,4 +100,36 @@ Console.Out.
         Assert.Contains(items, i => i.DisplayText == "WriteLine");
         Assert.DoesNotContain(items, i => i.DisplayText == "Synchronized");
     }
+
+    [Fact]
+    public void GetCompletions_OnType_DoesNotIncludeAccessorMethods()
+    {
+        var code = """
+import System.*;
+
+Console.
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
+        var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences([
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+            ]);
+
+        var service = new CompletionService();
+        var position = code.LastIndexOf('.') + 1;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.DoesNotContain(items, i => i.DisplayText == "get_Out");
+        Assert.DoesNotContain(items, i => i.DisplayText == "set_Out");
+        Assert.DoesNotContain(items, i => i.DisplayText == "add_CancelKeyPress");
+        Assert.DoesNotContain(items, i => i.DisplayText == "remove_CancelKeyPress");
+    }
 }


### PR DESCRIPTION
## Summary
- ignore property and event accessor methods in member completion
- add regression test to ensure accessor methods are excluded

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompletionProvider.cs,test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs`
- `dotnet build`
- `dotnet test` *(fails: System.InvalidOperationException : The test method expected 1 parameter value, but 2 parameter values were provided.)*
- `dotnet test --filter Sample_should_compile_and_run` *(fails: Assert.Equal() Failure)*
- `dotnet test --filter GetCompletions_OnType_DoesNotIncludeAccessorMethods`


------
https://chatgpt.com/codex/tasks/task_e_68c3e4445c9c832f9942598cad586457