### PR TITLE
fix: correct diagnostics for static calls to instance methods

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,6 @@
 
 ## Semantic analysis
 
-### Bug: Invoking instance method as static reports wrong diagnostics
-Calling an instance method with a static call produces an unexpected `RAV0030` and misses the expected `RAV0117` diagnostic.
-Possible solution: adjust the binder's diagnostic logic so that static calls to instance members only report `RAV0117`.
-
 ### Bug: Spread operator in array literals doesn't enumerate
 `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` fails because spread values aren't iterated.
 Possible solution: update collection expression binding/generation to expand spread expressions when building arrays.

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1262,6 +1262,9 @@ partial class BlockBinder : Binder
         {
             var boundMember = BindMemberAccessExpression(memberAccess);
 
+            if (boundMember is BoundErrorExpression)
+                return boundMember;
+
             if (boundMember is BoundMemberAccessExpression { Member: IMethodSymbol method } memberExpr)
             {
                 var argExprs = new List<BoundExpression>();
@@ -1292,6 +1295,9 @@ partial class BlockBinder : Binder
         else if (syntax.Expression is MemberBindingExpressionSyntax memberBinding)
         {
             var boundMember = BindMemberBindingExpression(memberBinding);
+
+            if (boundMember is BoundErrorExpression)
+                return boundMember;
 
             if (boundMember is BoundMemberAccessExpression { Member: IMethodSymbol method } memberExpr)
             {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MethodBindingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MethodBindingTests.cs
@@ -1,0 +1,22 @@
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class MethodBindingTests : DiagnosticTestBase
+{
+    [Fact]
+    public void InvokingInstanceMethodAsStatic_ReportsMemberDoesNotContainDefinition()
+    {
+        string testCode = """
+        class Foo {
+            f() {}
+        }
+        Foo.f()
+        """;
+
+        var verifier = CreateVerifier(testCode,
+            [new DiagnosticResult("RAV0117").WithSpan(4, 5, 4, 6).WithArguments("Foo", "f")]);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- ensure invocation binding returns early when member access fails
- add test verifying static calls to instance methods report RAV0117
- clean up resolved TODO item

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --no-build` *(fails: Raven.CodeAnalysis.Semantics.Tests.UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, Raven.CodeAnalysis.Tests.Workspaces.AnalyzerInfrastructureTests.GetDiagnostics_IncludesCompilerAndAnalyzerDiagnostics)*
- `dotnet test test/Raven.CodeAnalysis.Tests --filter MethodBindingTests`


------
https://chatgpt.com/codex/tasks/task_e_68c470d8d384832fbee7be178131185c