### PR TITLE
Support alias conversions in ClassifyConversion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,6 @@ Possible solution: update collection expression binding/generation to expand spr
 `MultiLineCommentTrivia_IsLeadingTriviaOfToken` throws `InvalidOperationException` when parsing multi-line comments.
 Possible solution: ensure the parser includes multi-line comment trivia in the token's leading trivia list.
 
-### Bug: Tuple alias directive requires initialization
-`AliasDirective_UsesAlias_Tuple` reports `RAV0166` for an uninitialized tuple alias variable.
-Possible solution: Make sure the tuple is initialized, like so `let p: Pair = (1, 2)`, and make sure the test passes after that.
-
 ## Build
 
 ### Bug: Build fails without generated syntax and diagnostics

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -363,6 +363,17 @@ public class Compilation
 
     public Conversion ClassifyConversion(ITypeSymbol source, ITypeSymbol destination)
     {
+        static ITypeSymbol Unalias(ITypeSymbol type)
+        {
+            while (type.IsAlias && type.UnderlyingSymbol is ITypeSymbol t)
+                type = t;
+
+            return type;
+        }
+
+        source = Unalias(source);
+        destination = Unalias(destination);
+
         // Temporary
         if (destination is null) return Conversion.None;
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -56,7 +56,7 @@ public class AliasResolutionTest : DiagnosticTestBase
             """
             alias StringList = System.Collections.Generic.List<string>
 
-            let list: StringList
+            let list: StringList = StringList()
             """;
 
         var verifier = CreateVerifier(testCode);
@@ -71,7 +71,7 @@ public class AliasResolutionTest : DiagnosticTestBase
             """
             alias Pair = (x: int, y: int)
 
-            let p: Pair
+            let p: Pair = (x: 1, y: 2)
             """;
 
         var verifier = CreateVerifier(testCode);
@@ -93,7 +93,7 @@ public class AliasResolutionTest : DiagnosticTestBase
             """
             alias Number = int | string
 
-            let n: Number
+            let n: Number = 1
             """;
 
         var verifier = CreateVerifier(testCode);
@@ -221,7 +221,7 @@ public class AliasResolutionTest : DiagnosticTestBase
             """
             alias MyInt = int
 
-            let x: MyInt
+            let x: MyInt = 0
             """;
 
         var verifier = CreateVerifier(testCode);


### PR DESCRIPTION
## Summary
- unwrap alias symbols before classifying type conversions
- initialize alias-based let bindings in alias resolution tests

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~AliasResolutionTest"`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: ImperativeContextTests.BlockExpression_InExpressionStatement_BindsAsStatement, UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, ImperativeContextTests.IfStatement_BranchesCanBeStatements, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68c4731b02c4832f92f298f52c5718ff