### PR TITLE
Fix multi-line comment trivia test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,10 +6,6 @@
 `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` fails because spread values aren't iterated.
 Possible solution: update collection expression binding/generation to expand spread expressions when building arrays.
 
-### Bug: Multi-line comment trivia parsing fails
-`MultiLineCommentTrivia_IsLeadingTriviaOfToken` throws `InvalidOperationException` when parsing multi-line comments.
-Possible solution: ensure the parser includes multi-line comment trivia in the token's leading trivia list.
-
 ## Build
 
 ### Bug: Build fails without generated syntax and diagnostics

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/MultiLineCommentTriviaTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/MultiLineCommentTriviaTest.cs
@@ -16,11 +16,11 @@ public class MultiLineCommentTriviaTest
 
         var root = syntaxTree.GetRoot();
 
-        var ifExpression = root.DescendantNodes()
-            .OfType<IfExpressionSyntax>()
+        var ifStatement = root.DescendantNodes()
+            .OfType<IfStatementSyntax>()
             .First();
 
-        var trivia = ((BlockSyntax)ifExpression.Expression).CloseBraceToken.LeadingTrivia.FirstOrDefault(x => x.Kind == SyntaxKind.MultiLineCommentTrivia);
+        var trivia = ((BlockStatementSyntax)ifStatement.ThenStatement).CloseBraceToken.LeadingTrivia.FirstOrDefault(x => x.Kind == SyntaxKind.MultiLineCommentTrivia);
 
         trivia.ShouldNotBeNull();
     }


### PR DESCRIPTION
## Summary
- adjust multi-line comment trivia test to parse if-statement and verify comment on block's closing brace
- remove resolved TODO entry

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "MultiLineCommentTriviaTest"`


------
https://chatgpt.com/codex/tasks/task_e_68c47bce0a38832f91233bef2854491a