### PR TITLE
feat: add object keyword

### DIFF
--- a/docs/lang/type-system.md
+++ b/docs/lang/type-system.md
@@ -8,6 +8,7 @@ Raven is a statically typed language whose types correspond directly to CLR type
 | --- | --- | --- |
 | `int` | `System.Int32` | 32-bit signed integer |
 | `string` | `System.String` | UTF-16 sequence of characters |
+| `object` | `System.Object` | base type of all .NET reference types |
 | `bool` | `System.Boolean` | logical true/false |
 | `char` | `System.Char` | UTF-16 code unit |
 | `unit` | `System.Unit` | single value `()` representing "no result" |

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -685,7 +685,7 @@ public class Compilation
             //SyntaxKind.FloatKeyword => SpecialType.System_Single,
             SyntaxKind.IntKeyword => SpecialType.System_Int32,
             //SyntaxKind.LongKeyword => SpecialType.System_Int64,
-            //SyntaxKind.ObjectKeyword => SpecialType.System_Object,
+            SyntaxKind.ObjectKeyword => SpecialType.System_Object,
             //SyntaxKind.SByteKeyword => SpecialType.System_SByte,
             //SyntaxKind.ShortKeyword => SpecialType.System_Int16,
             SyntaxKind.StringKeyword => SpecialType.System_String,

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -564,6 +564,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
             case SyntaxKind.BoolKeyword:
             case SyntaxKind.CharKeyword:
             case SyntaxKind.IntKeyword:
+            case SyntaxKind.ObjectKeyword:
                 return ParsePredefinedTypeSyntax();
 
             case SyntaxKind.IdentifierToken:

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
@@ -311,6 +311,7 @@ internal class NameSyntaxParser : SyntaxParser
             case SyntaxKind.BoolKeyword:
             case SyntaxKind.CharKeyword:
             case SyntaxKind.IntKeyword:
+            case SyntaxKind.ObjectKeyword:
             case SyntaxKind.UnitKeyword:
                 return true;
         }

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -7,6 +7,7 @@
   <TokenKind Name="StringKeyword" Text="string" IsReservedWord="true" />
   <TokenKind Name="BoolKeyword" Text="bool" IsReservedWord="true" />
   <TokenKind Name="CharKeyword" Text="char" IsReservedWord="true" />
+  <TokenKind Name="ObjectKeyword" Text="object" IsReservedWord="true" />
   <TokenKind Name="ImportKeyword" Text="import" IsReservedWord="false" />
   <TokenKind Name="AliasKeyword" Text="alias" IsReservedWord="false" />
   <TokenKind Name="NamespaceKeyword" Text="namespace" IsReservedWord="false" />

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ObjectKeywordTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ObjectKeywordTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Tests;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class ObjectKeywordTests
+{
+    [Fact]
+    public void ObjectKeyword_BindsToSystemObject()
+    {
+        var source = """
+        let o: object = null
+        """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var type = model.GetTypeInfo(declarator.TypeAnnotation!.Type).Type!;
+
+        Assert.Equal(SpecialType.System_Object, type.SpecialType);
+    }
+}


### PR DESCRIPTION
## Summary
- support `object` keyword bound to `System.Object`
- document `object` primitive type
- test `object` keyword binding

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Compilation.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs,test/Raven.CodeAnalysis.Tests/Semantics/ObjectKeywordTests.cs --no-restore`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(failing: SemanticClassifierTests.ClassifiesTokensBySymbol and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c52cdc0924832fab87867fe0df3d5b