### PR TITLE
fix: allow return before else

### DIFF
--- a/docs/compiler/design/semantic-analysis.md
+++ b/docs/compiler/design/semantic-analysis.md
@@ -63,17 +63,17 @@ In this example, `GetSymbol(binaryExpression)` retrieves the symbol (or symbols)
 
 Raven is an expression-oriented language where constructs like `if`, `while`, and
 `for` normally yield values. In statement position, these control-flow forms have
-their own statement syntax (e.g. `IfStatementSyntax`). When an expression form
-appears in a statement position—such as a block used directly—the binder rewrites
-it into a dedicated statement node (`BoundIfStatement`, `BoundWhileStatement`,
+their own statement syntax (e.g. `IfStatementSyntax`). Imperative context is
+introduced through these statements, which allows features such as explicit
+`return` statements within their bodies. When an expression form appears in a
+statement position—such as a block used directly—the binder rewrites it into the
+corresponding statement node (`BoundIfStatement`, `BoundWhileStatement`,
 `BoundForStatement`). These nodes capture the imperative intent and ensure any
 produced values are discarded.
 
 `BoundIfStatement` is flexible in its branches: each branch may be either a
 `BoundStatement` (such as a `return` or another `if`) or a `BoundExpression`. If an
-expression branch appears, its value is ignored. Block expressions may also appear
-directly as branches; they permit nested statements but do not allow imperative
-statement forms on their own.
+expression branch appears, its value is ignored.
 
 This distinction between expression and imperative contexts allows the semantic
 analysis phase to reason precisely about side effects and control flow while

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -105,7 +105,7 @@ Control flow constructs such as `if`, `while`, and `for` also have dedicated sta
 
 ### Return statements
 
-The `return` keyword exits a function, lambda, or property accessor. Because control-flow constructs are expressions, using `return` inside an expression that itself produces a value is not allowed. Explicit `return` statements may appear only in statement positions, such as within a function body or as their own expression statement. When a `return` occurs in a value context—for example, within an `if` expression assigned to a variable—the compiler reports diagnostic `RAV1900` and the block should rely on an implicit return instead.
+The `return` keyword exits a function, lambda, or property accessor. Because control-flow constructs are expressions, using `return` inside an expression that itself produces a value is not allowed. Explicit `return` statements may appear only in statement positions, such as within a function body or as their own expression statement. When a `return` occurs in a value context—for example, within an `if` expression assigned to a variable—the compiler reports diagnostic `RAV1900` and the block should rely on an implicit return instead. Within an `if` statement, the `else` keyword implicitly terminates a preceding `return`, allowing `if flag return else return` to be written without additional separators.
 
 A `return` statement may omit its expression when the surrounding function or accessor returns `unit`. See [implementation notes](dotnet-implementation.md#return-statements) for how such returns are emitted. This is equivalent to returning the `()` value explicitly.
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -176,14 +176,18 @@ internal class StatementSyntaxParser : SyntaxParser
 
         ExpressionSyntax? expression = null;
         var next = PeekToken();
-        if (next.Kind is not (SyntaxKind.SemicolonToken or SyntaxKind.CloseBraceToken or SyntaxKind.EndOfFileToken))
+        if (next.Kind is not (SyntaxKind.SemicolonToken or SyntaxKind.CloseBraceToken or SyntaxKind.EndOfFileToken or SyntaxKind.ElseKeyword))
             expression = new ExpressionSyntaxParser(this).ParseExpression();
 
         SetTreatNewlinesAsTokens(true);
 
-        if (!TryConsumeTerminator(out var terminatorToken))
+        SyntaxToken? terminatorToken = null;
+        if (PeekToken().Kind != SyntaxKind.ElseKeyword)
         {
-            SkipUntil(SyntaxKind.NewLineToken, SyntaxKind.SemicolonToken);
+            if (!TryConsumeTerminator(out terminatorToken))
+            {
+                SkipUntil(SyntaxKind.NewLineToken, SyntaxKind.SemicolonToken);
+            }
         }
 
         return ReturnStatement(returnKeyword, expression, terminatorToken, Diagnostics);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImperativeContextTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImperativeContextTests.cs
@@ -92,9 +92,8 @@ class C {
         var tree = SyntaxTree.ParseText(code);
         var compilation = CreateCompilation(tree);
         var model = compilation.GetSemanticModel(tree);
-        var exprStmt = tree.GetRoot().DescendantNodes().OfType<ExpressionStatementSyntax>()
-            .First(es => es.Expression is BlockSyntax);
-        var bound = model.GetBoundNode(exprStmt);
+        var blockStmt = tree.GetRoot().DescendantNodes().OfType<BlockStatementSyntax>().Skip(1).First();
+        var bound = model.GetBoundNode(blockStmt);
 
         Assert.IsType<BoundBlockStatement>(bound);
     }


### PR DESCRIPTION
## Summary
- allow parsing `return` immediately before `else`
- document statement-based imperative context and return termination rules
- adjust ImperativeContext tests for block statements

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Assert.IsType() Failure expected BoundReturnStatement)*

------
https://chatgpt.com/codex/tasks/task_e_68c53131543c832fa41a76593d5b2783