### PR TITLE
fix: bind constructors for aliased qualified names

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1286,6 +1286,23 @@ partial class BlockBinder : Binder
                 receiver = memberExpr.Receiver;
                 methodName = method.Name;
             }
+            else if (boundMember is BoundTypeExpression { Type: INamedTypeSymbol namedType })
+            {
+                var argExprs = new List<BoundExpression>();
+                bool argErrors = false;
+                foreach (var arg in syntax.ArgumentList.Arguments)
+                {
+                    var boundArg = BindExpression(arg.Expression);
+                    if (boundArg is BoundErrorExpression)
+                        argErrors = true;
+                    argExprs.Add(boundArg);
+                }
+
+                if (argErrors)
+                    return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.ArgumentBindingFailed);
+
+                return BindConstructorInvocation(namedType, argExprs.ToArray(), syntax);
+            }
             else
             {
                 receiver = boundMember;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -214,6 +214,14 @@ public class AliasResolutionTest : DiagnosticTestBase
         var alias = Assert.IsAssignableFrom<IAliasSymbol>(symbol);
         Assert.Equal("ST", alias.Name);
         Assert.Equal(SymbolKind.Namespace, alias.UnderlyingSymbol.Kind);
+
+        var invocation = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single();
+        var ctorSymbol = Assert.IsAssignableFrom<IMethodSymbol>(model.GetSymbolInfo(invocation).Symbol!);
+        Assert.Equal(".ctor", ctorSymbol.Name);
+        Assert.Equal("StringBuilder", ctorSymbol.ContainingType!.Name);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure invocation binder recognizes type expressions and binds constructors even through namespace aliases
- extend alias resolution test to assert constructor binding

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --no-build` *(fails: LiteralType_Float_UsesUnderlyingSingle, LiteralType_Long_UsesUnderlyingInt64, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c53df84524832fb4e9bc3fc2efffd7