### PR TITLE
fix: report diagnostic for missing variable initializer

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,7 +1,7 @@
 # BUGS
 
 ## Overview
-`dotnet build` succeeds but `dotnet test test/Raven.CodeAnalysis.Tests` currently reports 60 failing tests. The failures cluster into the categories below based on shared root causes.
+`dotnet build` succeeds but `dotnet test test/Raven.CodeAnalysis.Tests` currently reports 55 failing tests. The failures cluster into the categories below based on shared root causes.
 
 ## Prioritized failing test categories
 
@@ -10,7 +10,6 @@
    Failing tests:
    - `ParserNewlineTests.Statement_NewlineIsTrivia_WhenInLineContinuation`
    - `ParserNewlineTests.Terminator_SkipsTokens_UntilEndOfFile`
-   - `EqualsValueClauseTests.VariableDeclaration_MissingInitializer_ProducesDiagnostic`
    - `MemberAccessMissingIdentifierTests.MemberAccessWithoutIdentifier_ReportsDiagnostic`
 
 2. **Imperative context and control-flow forms**  \

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EqualsValueClauseSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EqualsValueClauseSyntaxParser.cs
@@ -21,6 +21,6 @@ internal class EqualsValueClauseSyntaxParser : SyntaxParser
                     GetEndOfLastToken()));
         }
 
-        return SyntaxFactory.EqualsValueClause(equalsToken, expr);
+        return SyntaxFactory.EqualsValueClause(equalsToken, expr, Diagnostics);
     }
 }


### PR DESCRIPTION
## Summary
- ensure `EqualsValueClauseSyntaxParser` attaches diagnostics so `let x =` yields an expression-expected error
- update BUGS.md to remove resolved test and adjust failing test count

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: 55, passes: 290, skips: 5)*
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "EqualsValueClauseTests.VariableDeclaration_MissingInitializer_ProducesDiagnostic"`


------
https://chatgpt.com/codex/tasks/task_e_68c54ec0a914832f83cb97efd1c9eac3