### PR TITLE
fix: report missing member identifier diagnostics

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -697,6 +697,13 @@ partial class BlockBinder : Binder
         if (receiver is BoundErrorExpression)
             return receiver;
 
+        if (memberAccess.Name.Identifier.IsMissing)
+        {
+            _diagnostics.ReportIdentifierExpected(memberAccess.Name.Identifier.GetLocation());
+            _diagnostics.ReportTheNameDoesNotExistInTheCurrentContext(string.Empty, memberAccess.Name.GetLocation());
+            return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.NotFound);
+        }
+
         var name = memberAccess.Name.Identifier.Text;
 
         if (receiver is BoundNamespaceExpression nsExpr)


### PR DESCRIPTION
## Summary
- report RAV1001 and RAV0103 when member access lacks an identifier

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "MemberAccessMissingIdentifierTests.MemberAccessWithoutIdentifier_ReportsDiagnostic"`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: UnionNotConvertibleToExplicitType_ProducesDiagnostic)*

------
https://chatgpt.com/codex/tasks/task_e_68c5523f1618832f824a00c6cb3c1b8a