### PR TITLE
fix: allow expression continuation across newlines

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EqualsValueClauseSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EqualsValueClauseSyntaxParser.cs
@@ -11,6 +11,11 @@ internal class EqualsValueClauseSyntaxParser : SyntaxParser
     {
         var equalsToken = ReadToken();
 
+        // Ensure that any newline following the '=' is treated as trivia so the
+        // initializer expression can continue on the next line without being
+        // prematurely terminated.
+        SetTreatNewlinesAsTokens(false);
+
         var expr = new ExpressionSyntaxParser(this).ParseExpression();
 
         if (expr.IsMissing)

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -551,12 +551,11 @@ internal class ExpressionSyntaxParser : SyntaxParser
 
         token = PeekToken();
 
-        if (!IsIdentifierToken(token)
-            && HasLeadingEndOfLineTrivia(token))
-        {
-            AddDiagnostic(DiagnosticInfo.Create(CompilerDiagnostics.IdentifierExpected, GetSpanOfLastToken()));
-            return new ExpressionSyntax.Missing(diagnostics: Diagnostics);
-        }
+        // Allow expressions to continue on the next line. Previously any token
+        // with leading end-of-line trivia was treated as a missing identifier,
+        // causing line continuations like `let x =\n    42` to fail with a
+        // diagnostic. By removing this check the parser treats the newline as
+        // trivia and correctly parses the following expression token.
 
         switch (token.Kind)
         {


### PR DESCRIPTION
## Summary
- treat newlines after `=` as trivia so initializers can span lines
- relax primary expression parsing to allow tokens following a newline

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests -c Release --filter "ParserNewlineTests.Statement_NewlineIsTrivia_WhenInLineContinuation" -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68c564c257a0832f8752880d7d4c9520