### PR TITLE
fix: guard token trivia when newline mode changes

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/BaseParseContext.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/BaseParseContext.cs
@@ -66,11 +66,18 @@ internal class BaseParseContext : ParseContext
 
     public override void SetTreatNewlinesAsTokens(bool value)
     {
-        if (_treatNewlinesAsTokens != value)
+        if (_treatNewlinesAsTokens == value)
+            return;
+
+        _treatNewlinesAsTokens = value;
+
+        var rewindPosition = Position;
+        if (value && _lastToken is { })
         {
-            _treatNewlinesAsTokens = value;
-            RewindToPosition(Position);
+            rewindPosition -= _lastToken.TrailingTrivia.Width;
         }
+
+        RewindToPosition(rewindPosition);
     }
 
     /// <summary>

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxToken.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxToken.cs
@@ -12,18 +12,23 @@ public struct SyntaxToken : IEquatable<SyntaxToken>
     private List<Diagnostic>? _diagnostics;
     private bool? _containsDiagnostics;
 
-    public string Text => Green.Text;
+    public string Text => Green?.Text ?? string.Empty;
 
-    public bool IsMissing => Green.IsMissing;
+    public bool IsMissing => Green?.IsMissing ?? true;
 
-    public int Width => Green.Width;
-    public int FullWidth => Green.FullWidth;
+    public int Width => Green?.Width ?? 0;
+    public int FullWidth => Green?.FullWidth ?? 0;
 
-    public bool HasLeadingTrivia => Green.LeadingTrivia.Count > 0;
-    public bool HasTrailingTrivia => Green.TrailingTrivia.Count > 0;
+    public bool HasLeadingTrivia => Green?.LeadingTrivia.Count > 0;
+    public bool HasTrailingTrivia => Green?.TrailingTrivia.Count > 0;
 
-    public SyntaxTriviaList LeadingTrivia => new(this, Green.LeadingTrivia, Position);
-    public SyntaxTriviaList TrailingTrivia => new(this, Green.TrailingTrivia, Position + Width);
+    public SyntaxTriviaList LeadingTrivia => Green is null
+        ? SyntaxTriviaList.Empty
+        : new(this, Green.LeadingTrivia, Position);
+
+    public SyntaxTriviaList TrailingTrivia => Green is null
+        ? SyntaxTriviaList.Empty
+        : new(this, Green.TrailingTrivia, Position + Width);
 
     internal SyntaxToken(InternalSyntax.SyntaxToken greenToken, SyntaxNode? parent, int position = 0)
     {


### PR DESCRIPTION
## Summary
- rewind to trailing trivia when toggling newline tokens
- avoid null ref when reading trivia from missing tokens

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/SyntaxToken.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/BaseParseContext.cs --verbosity normal`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~ParserNewlineTests.Statement_NewlineIsTrivia_WhenInLineContinuation" -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68c555050130832f976675a0af537123