### PR TITLE
fix: preserve skipped tokens before EOF

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -187,6 +187,7 @@ internal class SyntaxParser : ParseContext
             if (current.Kind == SyntaxKind.EndOfFileToken || current.Kind == SyntaxKind.CloseBraceToken)
             {
                 AddSkippedToPending(skippedTokens);
+                GetBaseContext()._lookaheadTokens.Clear();
                 token = Token(SyntaxKind.None);
                 return true;
             }


### PR DESCRIPTION
## Summary
- ensure TryConsumeTerminator attaches skipped tokens to EOF by clearing cached lookahead tokens

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter ParserNewlineTests.Terminator_SkipsTokens_UntilEndOfFile`


------
https://chatgpt.com/codex/tasks/task_e_68c57df527dc832fb39aea3f39d28737