### PR TITLE
fix: handle return without terminator before else

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -189,6 +189,13 @@ internal class StatementSyntaxParser : SyntaxParser
                 SkipUntil(SyntaxKind.NewLineToken, SyntaxKind.SemicolonToken);
             }
         }
+        else
+        {
+            // When the next token is an 'else', the return statement has no
+            // explicit terminator. Use a placeholder so downstream consumers
+            // don't encounter a null token.
+            terminatorToken = Token(SyntaxKind.None);
+        }
 
         return ReturnStatement(returnKeyword, expression, terminatorToken, Diagnostics);
     }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
@@ -215,6 +215,21 @@ public class ParserNewlineTests
     }
 
     [Fact]
+    public void ReturnStatement_BeforeElse_UsesNoneTerminator()
+    {
+        var source = "return else";
+        var lexer = new Lexer(new StringReader(source));
+        var context = new BaseParseContext(lexer);
+        var parser = new StatementSyntaxParser(context);
+
+        var statement = (ReturnStatementSyntax)parser.ParseStatement().CreateRed();
+        Assert.Equal(SyntaxKind.None, statement.TerminatorToken.Kind);
+
+        var nextToken = parser.PeekToken();
+        Assert.Equal(SyntaxKind.ElseKeyword, nextToken.Kind);
+    }
+
+    [Fact]
     public void Function_MissingIdentifier_ProducesMissingToken()
     {
         var source = "func () {}";


### PR DESCRIPTION
## Summary
- ensure return statements directly followed by `else` receive a placeholder terminator token
- test parser behavior for return statements preceding `else`

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "ReturnStatement_BeforeElse_UsesNoneTerminator" -v minimal`
- `dotnet test test/Raven.CodeAnalysis.Tests -v minimal` *(fails: StringInterpolationTests.InterpolatedString_FormatsCorrectly)*

------
https://chatgpt.com/codex/tasks/task_e_68c5801b0cd8832f97bad601ef744bdd