### PR TITLE
fix: handle null statements in syntax rewriter

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -75,8 +75,6 @@
    - `CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType`
    - `SampleProgramsTests.Sample_should_load_into_compilation` (all sample `.rav` files)
 
-10. **Incremental syntax tree updates**  \
-    Applying text edits fails to produce consistent trees, suggesting the incremental update algorithm or cache invalidation is incomplete. The spec currently has no guidance on incremental behavior.
 
 ## Conclusion
 The failing tests point to regressions across parsing, binding, diagnostics, and tooling. Each category above groups tests sharing the same underlying issue, guiding future investigation.
@@ -92,7 +90,6 @@ The failing tests point to regressions across parsing, binding, diagnostics, and
 - **Analyzer diagnostics** – Revisit the diagnostic pipeline so analyzer and compiler warnings share configuration and reporting. Ensure `DiagnosticOptions` flow into analyzer drivers and add tests for custom suppressions.
 - **Workspace and utility failures** – Audit highlighters and tooling hooks so diagnostics surface consistently; add integration tests for console rendering.
 - **Code generation and sample program loading** – Always emit the `unit` type and populate sample programs to verify end-to-end execution【F:docs/lang/spec/language-specification.md†L40-L45】.
-- **Incremental syntax tree updates** – Repair the text change algorithm and cache invalidation. The language specification does not currently define incremental update semantics, so behavior must be inferred from Roslyn-style trees.
 
 ### Specification ambiguities
 

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -30,11 +30,14 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
         return token;
     }
 
-    public override SyntaxNode? VisitStatement(StatementSyntax node)
+    public override SyntaxNode? VisitStatement(StatementSyntax? node)
     {
+        if (node is null)
+            return null;
+
         var statement = base.VisitStatement(node)!;
 
-        if (node is BlockStatementSyntax && node?.Parent is IfStatementSyntax)
+        if (node is BlockStatementSyntax && node.Parent is IfStatementSyntax)
         {
             return statement;
         }

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxRewriter.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxRewriter.cs
@@ -46,34 +46,34 @@ public abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode?>
         return default;
     }
 
-    public virtual SyntaxNode? VisitStatement(StatementSyntax node)
+    public virtual SyntaxNode? VisitStatement(StatementSyntax? node)
     {
-        return node.Accept(this);
+        return node?.Accept(this);
     }
 
-    public virtual SyntaxNode? VisitExpression(ExpressionSyntax node)
+    public virtual SyntaxNode? VisitExpression(ExpressionSyntax? node)
     {
-        return node.Accept(this);
+        return node?.Accept(this);
     }
 
-    public virtual SyntaxNode? VisitType(TypeSyntax node)
+    public virtual SyntaxNode? VisitType(TypeSyntax? node)
     {
-        return node.Accept(this);
+        return node?.Accept(this);
     }
 
-    public virtual SyntaxNode? VisitName(NameSyntax node)
+    public virtual SyntaxNode? VisitName(NameSyntax? node)
     {
-        return node.Accept(this);
+        return node?.Accept(this);
     }
 
-    public virtual SyntaxNode? VisitUnqualifiedName(UnqualifiedNameSyntax node)
+    public virtual SyntaxNode? VisitUnqualifiedName(UnqualifiedNameSyntax? node)
     {
-        return node.Accept(this);
+        return node?.Accept(this);
     }
 
-    public virtual SyntaxNode? VisitSimpleName(SimpleNameSyntax node)
+    public virtual SyntaxNode? VisitSimpleName(SimpleNameSyntax? node)
     {
-        return node.Accept(this);
+        return node?.Accept(this);
     }
 
     public virtual SyntaxList<TElement>? VisitList<TElement>(SyntaxList<TElement>? list0)
@@ -85,7 +85,12 @@ public abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode?>
 
         foreach (var item in list)
         {
-            newList.Add((TElement)item.Accept(this));
+            if (item is null)
+                continue;
+
+            var visited = (TElement?)item.Accept(this);
+            if (visited is not null)
+                newList.Add(visited);
         }
         return SyntaxFactory.List<TElement>(newList);
     }
@@ -97,7 +102,12 @@ public abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode?>
 
         foreach (var item in list)
         {
-            newList.Add((TElement)item.Accept(this));
+            if (item is null)
+                continue;
+
+            var visited = (TElement?)item.Accept(this);
+            if (visited is not null)
+                newList.Add(visited);
         }
         return SyntaxFactory.List<TElement>(newList);
     }
@@ -135,8 +145,12 @@ public abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode?>
         {
             if (item.TryGetNode(out var node))
             {
-                newList.Add(
-                    new SyntaxNodeOrToken(node.Accept(this)!));
+                if (node is null)
+                    continue;
+
+                var visited = node.Accept(this);
+                if (visited is not null)
+                    newList.Add(new SyntaxNodeOrToken(visited));
             }
             else if (item.TryGetToken(out var token))
             {
@@ -155,8 +169,12 @@ public abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode?>
         {
             if (item.TryGetNode(out var node))
             {
-                newList.Add(
-                    new SyntaxNodeOrToken(node.Accept(this)!));
+                if (node is null)
+                    continue;
+
+                var visited = node.Accept(this);
+                if (visited is not null)
+                    newList.Add(new SyntaxNodeOrToken(visited));
             }
             else if (item.TryGetToken(out var token))
             {


### PR DESCRIPTION
## Summary
- guard `SyntaxRewriter` visitor methods against null nodes to prevent crashes during incremental parsing
- normalize optional statements safely in `SyntaxNormalizer`
- remove resolved incremental syntax tree bug from BUGS.md

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~IncrementalSyntaxTreeUpdatesTest`


------
https://chatgpt.com/codex/tasks/task_e_68c583ec8c54832f876ef0baeeea529b