### PR TITLE
fix: align sample programs test parameters

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -68,11 +68,10 @@
    Failing tests:
    - `Syntax.Tests.Sandbox.Test`
 
-9. **Code generation and sample program loading**  \
-   Emitted assemblies omit the mandatory `unit` type and sample `.rav` programs do not load into the compilation. The spec treats `unit` as the implicit return type for functions without annotations【F:docs/lang/spec/language-specification.md†L40-L45】.  \
+9. **Code generation**  \
+   Emitted assemblies omit the mandatory `unit` type. The spec treats `unit` as the implicit return type for functions without annotations【F:docs/lang/spec/language-specification.md†L40-L45】.  \
    Failing tests:
    - `CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType`
-   - `SampleProgramsTests.Sample_should_load_into_compilation` (all sample `.rav` files)
 
 
 ## Conclusion

--- a/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs
@@ -7,16 +7,16 @@ public class SampleProgramsTests
 {
     public static IEnumerable<object[]> SamplePrograms =>
     [
-        ["arrays.rav", Array.Empty<string>()],
-        ["enums.rav", Array.Empty<string>()],
-        ["general.rav", Array.Empty<string>()],
-        ["generics.rav", Array.Empty<string>()],
-        ["io.rav", new[] {"."}],
-        ["test2.rav", Array.Empty<string>()],
-        ["type-unions.rav", Array.Empty<string>()],
-        ["tuples.rav", Array.Empty<string>()],
-        ["main.rav", Array.Empty<string>()],
-        ["classes.rav", Array.Empty<string>()],
+        ["arrays.rav"],
+        ["enums.rav"],
+        ["general.rav"],
+        ["generics.rav"],
+        ["io.rav"],
+        ["test2.rav"],
+        ["type-unions.rav"],
+        ["tuples.rav"],
+        ["main.rav"],
+        ["classes.rav"],
     ];
 
     [Theory]


### PR DESCRIPTION
## Summary
- fix `SampleProgramsTests` data to provide file names only
- update BUGS.md to remove resolved sample loading failures

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/Samples/SampleProgramsTests.cs`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~SampleProgramsTests.Sample_should_load_into_compilation" -c Debug`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests`

------
https://chatgpt.com/codex/tasks/task_e_68c5938a46fc832fb85bdafcdaa73bba