### PR TITLE
fix: restore lexer position when rewinding

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -15,7 +15,6 @@
 2. **Imperative context and control-flow forms**  \
    `if`, `while`, and `for` have both expression and statement forms. `return` is allowed only when the construct is in statement position with no enclosing expression, but the compiler conflates these modes. The spec notes that control-flow constructs are expressions yet also have statement forms, and that `return` inside value contexts is invalid【F:docs/lang/spec/language-specification.md†L81-L83】【F:docs/lang/spec/language-specification.md†L103-L104】【F:docs/lang/spec/language-specification.md†L108-L115】.  \
    Failing tests:
-   - `ImperativeContextTests.IfStatement_BranchesCanBeStatements`
    - `ImperativeContextTests.IfStatement_BranchesCanBeExpressions`
 
 3. **Literal type flow broken**  \

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/BaseParseContext.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/BaseParseContext.cs
@@ -96,6 +96,7 @@ internal class BaseParseContext : ParseContext
     {
         _lookaheadTokens.Clear(); // Invalidate lookahead because context changed
         _lexer.ResetToPosition(position);
+        _position = position;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- ensure `RewindToPosition` updates parser position so lookahead resets correctly
- update BUGS.md to drop fixed `IfStatement_BranchesCanBeStatements` test

## Testing
- `dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/BaseParseContext.cs --verbosity minimal`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~ImperativeContextTests.IfStatement_BranchesCanBeStatements"`


------
https://chatgpt.com/codex/tasks/task_e_68c59aee14c4832fada26e6228c348b9