### PR TITLE
fix: include namespace aliases in member completions

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -42,7 +42,6 @@
    - `ImportResolutionTest.ImportNonNamespaceOrType_Should_ProduceDiagnostic`
    - `NamespaceResolutionTest.ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics`
    - `SymbolQueryTests.CallingInstanceMethodAsStatic_ProducesDiagnostic`
-   - `CompletionServiceTests.GetCompletions_OnNamespaceAlias_ReturnsMembers`
    - `SemanticClassifierTests.ClassifiesTokensBySymbol`
 
 6. **Union features incomplete**  \

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -65,17 +65,11 @@ partial class BlockBinder : Binder
 
     public override ISymbol? LookupSymbol(string name)
     {
-        if (_locals.TryGetValue(name, out var sym))
-            return sym.Symbol;
-
-        if (_functions.TryGetValue(name, out var func))
-            return func;
-
-        var parentSymbol = ParentBinder?.LookupSymbol(name);
-        if (parentSymbol != null)
-            return parentSymbol;
-
-        return Compilation.GlobalNamespace.GetMembers(name).FirstOrDefault();
+        // Forward to LookupSymbols so import directives and alias mappings are considered
+        // when binding identifier references. Previously this method bypassed the import
+        // binder, causing namespace or type aliases to be ignored and resulting in missing
+        // completions for alias-qualified names.
+        return LookupSymbols(name).FirstOrDefault();
     }
 
     private SymbolInfo BindCompilationUnit(CompilationUnitSyntax compilationUnit)

--- a/src/Raven.CodeAnalysis/CompletionProvider.cs
+++ b/src/Raven.CodeAnalysis/CompletionProvider.cs
@@ -284,7 +284,14 @@ public static class CompletionProvider
                 var type = typeInfo?.UnderlyingSymbol as ITypeSymbol;
                 IEnumerable<ISymbol>? members = null;
 
-                if (symbol is INamedTypeSymbol typeSymbol && SymbolEqualityComparer.Default.Equals(symbol, type))
+                if (symbol is INamespaceSymbol ns)
+                {
+                    // Namespace or namespace alias: list its public members
+                    members = ns.GetMembers().Where(m =>
+                        m.DeclaredAccessibility == Accessibility.NotApplicable ||
+                        m.DeclaredAccessibility == Accessibility.Public);
+                }
+                else if (symbol is INamedTypeSymbol typeSymbol && SymbolEqualityComparer.Default.Equals(symbol, type))
                 {
                     // Accessing a type name: show static members
                     members = typeSymbol.GetMembers().Where(m => m.IsStatic && m.DeclaredAccessibility == Accessibility.Public);


### PR DESCRIPTION
## Summary
- allow `LookupSymbol` to consult import aliases
- support namespace and alias member access in completion provider
- update BUGS.md fixed list

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~CompletionServiceTests.GetCompletions_OnNamespaceAlias_ReturnsMembers" -v n`
- `dotnet test test/Raven.CodeAnalysis.Tests -v minimal` *(fails: Raven.CodeAnalysis.Syntax.InternalSyntax.Tests.GreenTreeTest.FullWidth_Equals_Source_Length)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a7f79a54832f8a1d9a84c0e4f959