### PR TITLE
fix: normalize literal types in return inference

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -25,8 +25,6 @@
 3. **Return type inference and unit diagnostics**  \
    Early-return analysis miscomputes union return types and fails to warn about missing or mismatched returns. Functions without explicit return types should fall back to `unit` according to the spec【F:docs/lang/spec/language-specification.md†L40-L45】.  \
    Failing tests:
-   - `EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromImplicitFinalExpression`
-   - `EarlyReturnTypeInferenceTests.ReturnTypeCollector_InfersUnionFromEarlyReturns`
    - `ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics`
    - `ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics`
 

--- a/src/Raven.CodeAnalysis/Binder/ReturnTypeCollector.cs
+++ b/src/Raven.CodeAnalysis/Binder/ReturnTypeCollector.cs
@@ -80,10 +80,15 @@ internal static class ReturnTypeCollector
 
         private void AddType(ITypeSymbol type)
         {
+            // Collapse literal types to their underlying primitive types so return
+            // type inference doesn't treat each distinct literal as its own type.
+            if (type is LiteralTypeSymbol literal)
+                type = literal.UnderlyingType;
+
             if (type is IUnionTypeSymbol union)
             {
                 foreach (var t in union.Types)
-                    _types.Add(t);
+                    AddType(t);
             }
             else
             {


### PR DESCRIPTION
## Summary
- collapse literal literal types to their underlying primitives during return type inference
- update bug list to remove resolved tests

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "EarlyReturnTypeInferenceTests"`


------
https://chatgpt.com/codex/tasks/task_e_68c5b3852f64832fa044b5a03a26a1fa