### PR TITLE
Align static call diagnostic span with member highlight

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -33,7 +33,6 @@
    Failing tests:
    - `ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic`
    - `ImportResolutionTest.ImportNonNamespaceOrType_Should_ProduceDiagnostic`
-   - `SymbolQueryTests.CallingInstanceMethodAsStatic_ProducesDiagnostic`
    - `SemanticClassifierTests.ClassifiesTokensBySymbol`
 
 5. **Union features incomplete**  \
@@ -65,6 +64,7 @@
 - `SemanticClassifierTests.ClassifiesTokensBySymbol` – parser now tolerates missing namespace terminators, eliminating `ArgumentNullException` crashes.
 - `TypeSymbolInterfacesTests.Interfaces_ExcludeInheritedInterfaces` – class symbols now track only direct interfaces, excluding inherited ones.
 - `NamespaceResolutionTest.ConsoleDoesNotContainWriteLine2_Should_ProduceDiagnostics` – diagnostic span now targets the undefined member name rather than the entire expression.
+- `SymbolQueryTests.CallingInstanceMethodAsStatic_ProducesDiagnostic` – test now expects the diagnostic to highlight only the undefined member name.
 
 ## Conclusion
 The failing tests point to regressions across parsing, binding, diagnostics, and tooling. Each category above groups tests sharing the same underlying issue, guiding future investigation.

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs
@@ -17,7 +17,7 @@ public class SymbolQueryTests : DiagnosticTestBase
             """;
 
         var verifier = CreateVerifier(testCode,
-            [new DiagnosticResult("RAV0117").WithSpan(5, 1, 5, 6).WithArguments("Foo", "M")]);
+            [new DiagnosticResult("RAV0117").WithSpan(5, 5, 5, 6).WithArguments("Foo", "M")]);
 
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- expect static-call error RAV0117 to flag only the undefined member
- update BUGS.md to remove the resolved SymbolQueryTests failure and list it under recently fixed

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/Semantics/SymbolQueryTests.cs`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests -v n` *(fails: UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic, ImportResolutionTest.ImportNonNamespaceOrType_Should_ProduceDiagnostic, Syntax.Tests.Sandbox.Test, AliasResolutionTest.AliasDirective_UsesAlias_Tuple_TypeMismatch_ReportsDiagnostic, ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics, GreenTreeTest.FullWidth_Equals_Source_Length, SemanticClassifierTests.ClassifiesTokensBySymbol)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c54e9420832f969b9b51afc252e2