### PR TITLE
fix: forbid returns inside expression blocks

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,41 +1,35 @@
 # BUGS
 
 ## Overview
-`dotnet build` succeeds but `dotnet test test/Raven.CodeAnalysis.Tests` currently reports 20 failing tests. The failures cluster into the categories below based on shared root causes.
+`dotnet build` succeeds but `dotnet test test/Raven.CodeAnalysis.Tests` currently reports 18 failing tests. The failures cluster into the categories below based on shared root causes.
 
 ## Prioritized failing test categories
 
-1. **Return type inference and unit diagnostics**  \
-   Early-return analysis miscomputes union return types and fails to warn about missing or mismatched returns. Functions without explicit return types should fall back to `unit` according to the spec【F:docs/lang/spec/language-specification.md†L40-L45】.  \
-   Failing tests:
-   - `ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics`
-   - `ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics`
-
-2. **Import and symbol resolution failures**  \
+1. **Import and symbol resolution failures**  \
    Import directives and member lookups mis-handle ordering and aliasing. The spec requires all imports to precede alias or member declarations within a scope【F:docs/lang/spec/language-specification.md†L392-L394】.  \
    Failing tests:
    - `ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic`
    - `ImportResolutionTest.ImportNonNamespaceOrType_Should_ProduceDiagnostic`
    - `SemanticClassifierTests.ClassifiesTokensBySymbol`
 
-3. **Union features incomplete**  \
+2. **Union features incomplete**  \
    Assigning or emitting unions is partially implemented. The spec states that converting a union to a target succeeds only if every member converts to the target type【F:docs/lang/spec/language-specification.md†L199-L201】.  \
    Failing tests:
    - `UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable`
 
-4. **Analyzer diagnostics ignored**  \
+3. **Analyzer diagnostics ignored**  \
    Analyzer configuration flags are ignored, so analyzer diagnostics either fail to run or cannot be suppressed.  \
    Failing tests:
    - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType`
    - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion`
    - `MissingReturnTypeAnnotationAnalyzerTests.FunctionStatementWithoutAnnotation_SuggestsInferredReturnType`
 
-5. **Workspace and utility failures**  \
+4. **Workspace and utility failures**  \
    Tooling hooks do not load sample code correctly.  \
    Failing tests:
    - `Syntax.Tests.Sandbox.Test`
 
-6. **Code generation**  \
+5. **Code generation**  \
    Emitted assemblies omit the mandatory `unit` type. The spec treats `unit` as the implicit return type for functions without annotations【F:docs/lang/spec/language-specification.md†L40-L45】.  \
    Failing tests:
  - `CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType`
@@ -51,12 +45,13 @@
 - Parser newline handling now treats line continuations as trivia and correctly skips tokens to end-of-file, so newline-related parser tests pass.
 - Literal type flow defaults integers and floating-point literals to their expected primitive types, restoring correct type inference for numeric literals.
 
+- `ExplicitReturnInIfExpressionTests.*` – return statements in expression contexts now report `RAV1900` and their surrounding blocks infer union member types correctly.
+
 ## Conclusion
 The failing tests point to regressions across parsing, binding, diagnostics, and tooling. Each category above groups tests sharing the same underlying issue, guiding future investigation.
 
 ## Fix strategy and specification notes
 
-- **Return type inference and unit diagnostics** – Align type inference with union semantics and the `unit` return rules in the specification【F:docs/lang/spec/language-specification.md†L40-L45】.
 - **Import and symbol resolution** – Enforce ordering and wildcard rules for `import` directives and alias resolution as described in the specification【F:docs/lang/spec/language-specification.md†L392-L394】.
 - **Union features** – Implement missing union conversion checks and metadata emission following the rule that every member must convert to the target type【F:docs/lang/spec/language-specification.md†L199-L201】.
 - **Analyzer diagnostics** – Revisit the diagnostic pipeline so analyzer and compiler warnings share configuration and reporting. Ensure `DiagnosticOptions` flow into analyzer drivers and add tests for custom suppressions.

--- a/src/Raven.CodeAnalysis/BoundTree/BoundIfExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIfExpression.cs
@@ -19,11 +19,15 @@ internal partial class BoundIfExpression : BoundExpression
 
     private static ITypeSymbol Handle(BoundExpression thenBranch, BoundExpression? elseBranch)
     {
-        if (!elseBranch?.Type?.Equals(thenBranch.Type, SymbolEqualityComparer.Default) ?? false)
-        {
-            return new UnionTypeSymbol([thenBranch.Type, elseBranch.Type], null, null, null, []);
-        }
+        var thenType = UnwrapLiteral(thenBranch.Type);
+        var elseType = elseBranch is null ? null : UnwrapLiteral(elseBranch.Type);
 
-        return thenBranch.Type;
+        if (elseType is not null && !elseType.Equals(thenType, SymbolEqualityComparer.Default))
+            return new UnionTypeSymbol([thenType, elseType], null, null, null, []);
+
+        return thenType;
+
+        static ITypeSymbol UnwrapLiteral(ITypeSymbol type)
+            => type is LiteralTypeSymbol literal ? literal.UnderlyingType : type;
     }
 }


### PR DESCRIPTION
## Summary
- fix union inference for return statements embedded in expressions
- suppress return-type checking when returns are disallowed
- update bug tracking for resolved return-in-expression diagnostics

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics -c Release`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68c65da91dd8832fb698c1277fce4f05