### PR TITLE
fix: report missing type arguments for open generic imports

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -8,7 +8,6 @@
 1. **Import and symbol resolution failures**  \
    Import directives and member lookups mis-handle ordering and aliasing. The spec requires all imports to precede alias or member declarations within a scope【F:docs/lang/spec/language-specification.md†L392-L394】.  \
    Failing tests:
-    - `ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic`
     - `SemanticClassifierTests.ClassifiesTokensBySymbol`
 
 2. **Union features incomplete**  \
@@ -47,6 +46,7 @@
 - `ExplicitReturnInIfExpressionTests.*` – return statements in expression contexts now report `RAV1900` and their surrounding blocks infer union member types correctly.
 
 - `ImportResolutionTest.ImportNonNamespaceOrType_Should_ProduceDiagnostic` – diagnostic span now excludes the wildcard, highlighting only the invalid target.
+- `ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic` – open generic type references without type arguments now report `RAV0305`.
 
 ## Conclusion
 The failing tests point to regressions across parsing, binding, diagnostics, and tooling. Each category above groups tests sharing the same underlying issue, guiding future investigation.

--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -259,8 +259,9 @@ internal abstract class Binder
             if (type is INamedTypeSymbol named)
             {
                 // Allow constructed generic types (e.g., from aliases) to be used without
-                // specifying additional type arguments.
-                if (named.Arity > 0 && named.ConstructedFrom is null)
+                // specifying additional type arguments. Only report an error for unbound
+                // generic type definitions referenced without type arguments.
+                if (named.Arity > 0 && named.IsUnboundGenericType)
                 {
                     _diagnostics.ReportTypeRequiresTypeArguments(named.Name, named.Arity, ident.Identifier.GetLocation());
                     return Compilation.ErrorTypeSymbol;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -105,7 +105,7 @@ public class ImportResolutionTest : DiagnosticTestBase
             """
             import System.Collections.Generic.*
 
-            let x: List
+            var x: List = null
             """;
 
         var verifier = CreateVerifier(


### PR DESCRIPTION
## Summary
- ensure unbound generic imports report RAV0305
- cover open generic import scenario in tests
- document fix in BUGS.md

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic`


------
https://chatgpt.com/codex/tasks/task_e_68c66553cac8832fb502289cedbad6ba