### PR TITLE
fix: classify qualified name segments

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
 
 namespace Raven.CodeAnalysis;
 
@@ -15,6 +16,14 @@ class NamespaceBinder : Binder
     }
 
     public override INamespaceSymbol? CurrentNamespace => _namespaceSymbol;
+
+    public override ISymbol? BindDeclaredSymbol(SyntaxNode node)
+    {
+        if (node is NamespaceDeclarationSyntax)
+            return _namespaceSymbol;
+
+        return base.BindDeclaredSymbol(node);
+    }
 
     public void DeclareType(SourceNamedTypeSymbol type)
     {


### PR DESCRIPTION
## Summary
- resolve identifiers within qualified names using binder-based name resolution
- avoid merging qualified names in semantic classifier
- cover alias directives with a classification test

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter SemanticClassifierTests`


------
https://chatgpt.com/codex/tasks/task_e_68c67651f730832f88cc1f1ab56a5d3c