### PR TITLE
fix: handle diagnostic format mismatch

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -38,6 +38,7 @@
 - `Syntax.Tests.Sandbox.Test` – disabled excessive output that caused logger failures during test execution.
 - `SemanticClassifierTests.ClassifiesTokensBySymbol` – import binder now surfaces static members from wildcard type imports, allowing classifiers to resolve symbols correctly.
 - `CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType` – emitted assemblies now define `System.Unit`, enabling successful emission when functions return `unit` implicitly.
+- Diagnostic verifier now safely formats expected diagnostic messages, preventing `FormatException` crashes when argument counts mismatch.
 
 ## Conclusion
 The failing tests point to regressions across parsing, binding, diagnostics, and tooling. Each category above groups tests sharing the same underlying issue, guiding future investigation.

--- a/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
+++ b/src/Raven.CodeAnalysis.Testing/DiagnosticVerifier.cs
@@ -146,7 +146,16 @@ public class DiagnosticVerifier
             foreach (var expected in missing)
             {
                 var descriptor = CompilerDiagnostics.GetDescriptor(expected.Id);
-                var m = string.Format(descriptor!.MessageFormat, expected.Arguments);
+                var format = descriptor?.MessageFormat.ToString() ?? string.Empty;
+                string m;
+                try
+                {
+                    m = string.Format(format, expected.Arguments);
+                }
+                catch (FormatException)
+                {
+                    m = format;
+                }
 
                 var start = expected.Location.Span.StartLinePosition;
                 var end = expected.Location.Span.EndLinePosition;


### PR DESCRIPTION
## Summary
- avoid FormatException when expected diagnostic message arguments don't match the descriptor
- note diagnostic verifier fix in BUGS.md

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build -nologo`
- `MSBUILDTERMINALLOGGER=false dotnet test test/Raven.CodeAnalysis.Tests --no-build -nologo` *(fails: GreenTreeTest.FullWidth_Equals_Source_Length, AliasDirective_UsesAlias_Tuple_TypeMismatch_ReportsDiagnostic, LiteralTypeFlowTests.IfExpression_InferredLiteralUnion, UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable)*

------
https://chatgpt.com/codex/tasks/task_e_68c68f5bb2c0832fa99fec43b58cda95