### PR TITLE
docs: move type system spec and describe literal types

### DIFF
--- a/docs/lang/README.md
+++ b/docs/lang/README.md
@@ -3,7 +3,7 @@
 ### Sub sections
 
 * [Language specification](spec/language-specification.md)
-* [Type system](type-system.md)
+* [Type system](spec/type-system.md)
 * [Proposals](proposals)
 
 ### Vision

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -4,6 +4,8 @@
 
 Implementation details describing how Raven constructs project to .NET are documented in [dotnet-implementation.md](dotnet-implementation.md).
 
+An overview of available types, literal semantics, and conversions can be found in the [type system](type-system.md).
+
 ## Code samples
 
 You find them [here](../../../src/Raven.Compiler/samples/).

--- a/docs/lang/spec/type-system.md
+++ b/docs/lang/spec/type-system.md
@@ -14,6 +14,24 @@ Raven is a statically typed language whose types correspond directly to CLR type
 | `unit` | `System.Unit` | single value `()` representing "no result" |
 | `null` | *(null literal)* | inhabits any nullable reference type |
 
+## Literal types
+
+Numeric and string literals may appear as their own types. A literal type
+represents exactly that value and carries an underlying primitive type—`1`
+has underlying type `int` while `"hi"` has underlying type `string`. Literal
+expressions are given these singleton types.
+
+Literal types implicitly convert to their underlying type and then follow the
+normal conversion rules of that type. This allows `1` to widen to `double` or
+`"hi"` to be used wherever a `string` is expected.
+
+```raven
+let yes: "yes" = "yes"
+let one: 1 = 1
+let two: int = one      // implicit conversion to int
+let d: double = one     // underlying int widens to double
+```
+
 ## Composite and derived types
 
 ### Arrays
@@ -59,7 +77,14 @@ Console.WriteLine(ids[0])
 
 ## Conversions
 
-Values may convert to other types according to .NET rules. Implicit conversions include identity, `null` to any nullable type, lifting value types to their nullable counterpart, widening numeric conversions, reference conversions to base types or interfaces, boxing of value types, and conversions to a matching branch of a union. Narrowing or otherwise unsafe conversions require an explicit cast. See [type compatibility](proposals/type-compatibility.md) for a detailed list of conversion forms.
+Values may convert to other types according to .NET rules. Implicit conversions
+include identity, literal types to their underlying primitive type, `null` to any
+nullable type, lifting value types to their nullable counterpart, widening numeric
+conversions, reference conversions to base types or interfaces, boxing of value
+types, and conversions to a matching branch of a union. Narrowing or otherwise
+unsafe conversions require an explicit cast. See
+[type compatibility](../proposals/type-compatibility.md) for a detailed list of
+conversion forms.
 
 ### Explicit casts
 
@@ -75,5 +100,11 @@ let s = obj as string
 
 ## Overload resolution
 
-When multiple function overloads are available, Raven selects the candidate whose parameters require the best implicit conversions. Identity matches are preferred over numeric widening, which outrank reference or boxing conversions. User-defined conversions are considered last. Literal arguments convert to their underlying primitive type before the ranking is applied. If no candidate is strictly better, the call is reported as ambiguous.
+When multiple function overloads are available, Raven selects the candidate whose
+parameters require the best implicit conversions. Identity matches are preferred
+over numeric widening, which outrank reference or boxing conversions.
+User-defined conversions are considered last. An argument of a literal type is an
+exact match for a parameter of the same literal type; otherwise the literal is
+converted to its underlying primitive type before the ranking is applied. If no
+candidate is strictly better, the call is reported as ambiguous.
 

--- a/docs/lang/spec/type-system.md
+++ b/docs/lang/spec/type-system.md
@@ -19,17 +19,25 @@ Raven is a statically typed language whose types correspond directly to CLR type
 Numeric and string literals may appear as their own types. A literal type
 represents exactly that value and carries an underlying primitive type—`1`
 has underlying type `int` while `"hi"` has underlying type `string`. Literal
-expressions are given these singleton types.
+expressions are given these singleton types. These singleton types act as
+value-level constraints, most often used as branches in union types or other
+constructs that restrict a value to specific constants.
 
 Literal types implicitly convert to their underlying type and then follow the
 normal conversion rules of that type. This allows `1` to widen to `double` or
 `"hi"` to be used wherever a `string` is expected.
+
+When a literal is assigned to a target whose type is inferred—such as a
+variable declaration without an explicit type annotation—the literal widens to
+its underlying primitive type. This keeps type inference in line with other
+languages that treat `let x = 1` as `int` rather than the literal type `1`.
 
 ```raven
 let yes: "yes" = "yes"
 let one: 1 = 1
 let two: int = one      // implicit conversion to int
 let d: double = one     // underlying int widens to double
+let inferred = 1        // inferred int, literal type is widened
 ```
 
 ## Composite and derived types

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,7 +1,7 @@
 - name: Language
   href: lang/spec/language-specification.html
 - name: Type System
-  href: lang/type-system.md
+  href: lang/spec/type-system.md
 - name: Compiler
   href: compiler/
 - name: API


### PR DESCRIPTION
## Summary
- move type system doc under `docs/lang/spec`
- document literal types including conversions and overload resolution
- link type system from language specification and update references

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c6a70b46a8832f874671307b24b8b2