### PR TITLE
docs: document failing and skipped tests

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -8,33 +8,43 @@
 1. **Import and symbol resolution failures**  \\
    Import directives and member lookups mis-handle ordering and aliasing. The spec requires all imports to precede alias or member declarations within a scope【F:docs/lang/spec/language-specification.md†L392-L394】.
 
-2. **Union features incomplete**  \
+2. **Literal type conversions missing**  \\
+   Literal arguments retain their literal types instead of converting to their underlying primitives before overload resolution, contrary to the specification【F:docs/lang/type-system.md†L76-L78】.  \\
+   Failing tests:
+   - `StringInterpolationTests.InterpolatedString_FormatsCorrectly`
+   - `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics`
+   - `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable`
+   - `Issue84_MemberResolutionBug.CanResolveMember`
+   - `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload`
+   - `TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType`
+
+3. **Union features incomplete**  \
    Assigning or emitting unions is partially implemented. The spec states that converting a union to a target succeeds only if every member converts to the target type【F:docs/lang/spec/language-specification.md†L199-L201】.  \
    Failing tests:
    - `UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable`
 
-3. **Analyzer diagnostics ignored**  \
+4. **Analyzer diagnostics ignored**  \
    Analyzer configuration flags are ignored, so analyzer diagnostics either fail to run or cannot be suppressed.  \
    Failing tests:
    - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_SuggestsInferredReturnType`
    - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithoutAnnotation_WithMultipleReturnTypes_SuggestsUnion`
-    - `MissingReturnTypeAnnotationAnalyzerTests.FunctionStatementWithoutAnnotation_SuggestsInferredReturnType`
+   - `MissingReturnTypeAnnotationAnalyzerTests.FunctionStatementWithoutAnnotation_SuggestsInferredReturnType`
 
 ## Current failing tests
 
-- `StringInterpolationTests.InterpolatedString_FormatsCorrectly` – binder cannot resolve a string concatenation method, raising `InvalidOperationException`.
-- `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics` – `Console.WriteLine` reports `RAV1501` despite correct usage.
+- `StringInterpolationTests.InterpolatedString_FormatsCorrectly` – binder cannot resolve string concatenation because literal segments keep their literal types.
+- `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics` – `Console.WriteLine` with a string literal reports `RAV1501` because the literal fails to convert to `string`.
 - `AliasResolutionTest.AliasDirective_UsesAlias_Tuple_TypeMismatch_ReportsDiagnostic` – expected `RAV1503` diagnostic is missing for tuple element mismatch.
-- `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable` – wildcard import of `System.Console` still triggers `RAV1501` when invoking `WriteLine`.
+- `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable` – wildcard import of `System.Console` still triggers `RAV1501` when a string literal is passed to `WriteLine`.
 - `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – literal branches of an `if` expression lose their literal types and are inferred as `String | Int32`.
-- `Issue84_MemberResolutionBug.CanResolveMember` – `DateTime.Parse` call fails with `RAV1501`.
+- `Issue84_MemberResolutionBug.CanResolveMember` – `DateTime.Parse` with a string literal fails with `RAV1501`.
 - `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – spread operator in array collection expressions fails to emit bytecode.
 - `GreenTreeTest.FullWidth_Equals_Source_Length` – parsed tree reports a full width one character larger than the source text.
 - `UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable` – emitting a union type with `null` does not succeed.
 - `ExpressionSemanticTest.WriteLine_WithUnitVariable_ShouldNot_ProduceDiagnostics` – writing a `unit` value to `Console.WriteLine` triggers `RAV1501`.
 - `UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic` – assigning a union of classes to `object` still reports `RAV1503` diagnostics.
-- `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload` – invocation symbol is null, causing a `NullReferenceException`.
-- `TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType` – target-typed `.Parse("42")` call fails with `RAV1501`.
+- `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload` – invocation symbol is null because the string literal fails to convert to `string`.
+- `TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType` – target-typed `.Parse("42")` call fails with `RAV1501` when the string literal keeps its literal type.
 
 ## Skipped tests
 


### PR DESCRIPTION
## Summary
- record 13 failing tests and 8 skipped tests from the test suite in BUGS.md
- note string interpolation, WriteLine overload resolution, alias, union, and other test failures
- document skipped tests requiring interface support or reference assemblies

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --logger "console;verbosity=detailed"` (fails: 13, skipped: 8)


------
https://chatgpt.com/codex/tasks/task_e_68c6a6062c0c832fac785991f09700c3