### PR TITLE
fix: enforce tuple alias element types

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -34,7 +34,6 @@
 
 - `StringInterpolationTests.InterpolatedString_FormatsCorrectly` – binder cannot resolve string concatenation because literal segments keep their literal types.
 - `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics` – `Console.WriteLine` with a string literal reports `RAV1501` because the literal fails to convert to `string`.
-- `AliasResolutionTest.AliasDirective_UsesAlias_Tuple_TypeMismatch_ReportsDiagnostic` – expected `RAV1503` diagnostic is missing for tuple element mismatch.
 - `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable` – wildcard import of `System.Console` still triggers `RAV1501` when a string literal is passed to `WriteLine`.
 - `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – literal branches of an `if` expression lose their literal types and are inferred as `String | Int32`.
 - `Issue84_MemberResolutionBug.CanResolveMember` – `DateTime.Parse` with a string literal fails with `RAV1501`.
@@ -75,6 +74,7 @@
 - `SemanticClassifierTests.ClassifiesTokensBySymbol` – import binder now surfaces static members from wildcard type imports, allowing classifiers to resolve symbols correctly.
 - `CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType` – emitted assemblies now define `System.Unit`, enabling successful emission when functions return `unit` implicitly.
 - Diagnostic verifier now safely formats expected diagnostic messages, preventing `FormatException` crashes when argument counts mismatch.
+- `AliasResolutionTest.AliasDirective_UsesAlias_Tuple_TypeMismatch_ReportsDiagnostic` – tuple alias assignments now emit `RAV1503` when element types mismatch.
 
 ## Conclusion
 The failing tests point to regressions across parsing, binding, diagnostics, and tooling. Each category above groups tests sharing the same underlying issue, guiding future investigation.

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -444,7 +444,9 @@ partial class BlockBinder : Binder
     {
         var elements = new List<BoundExpression>(tupleExpression.Arguments.Count);
 
-        if (GetTargetType(tupleExpression) is ITupleTypeSymbol target && target.TupleElements.Length == tupleExpression.Arguments.Count)
+        if (GetTargetType(tupleExpression) is INamedTypeSymbol target &&
+            target.TypeKind == TypeKind.Tuple &&
+            target.TupleElements.Length == tupleExpression.Arguments.Count)
         {
             for (int i = 0; i < tupleExpression.Arguments.Count; i++)
             {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AliasResolutionTest.cs
@@ -113,7 +113,8 @@ public class AliasResolutionTest : DiagnosticTestBase
 
         var verifier = CreateVerifier(
             testCode,
-            expectedDiagnostics: [new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id)]);
+            expectedDiagnostics: [new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id)
+                .WithArguments("\"\"", "int")]);
 
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- ensure tuple aliases validate element conversions
- add missing test arguments for tuple alias type mismatch
- update BUGS list

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "AliasDirective_UsesAlias_Tuple_TypeMismatch_ReportsDiagnostic"`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Raven.CodeAnalysis.Semantics.Tests.UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.IfExpression_InferredLiteralUnion, Raven.CodeAnalysis.Semantics.Tests.ExpressionSemanticTest.WriteLine_WithUnitVariable_ShouldNot_ProduceDiagnostics, Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, Raven.CodeAnalysis.Semantics.Tests.NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, Raven.CodeAnalysis.Semantics.Tests.TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, Raven.CodeAnalysis.Tests.Bugs.Issue84_MemberResolutionBug.CanResolveMember, Raven.CodeAnalysis.Semantics.Tests.UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable, Raven.CodeAnalysis.Tests.CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates, Raven.CodeAnalysis.Tests.StringInterpolationTests.InterpolatedString_FormatsCorrectly, Raven.CodeAnalysis.Semantics.Tests.ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable)*


------
https://chatgpt.com/codex/tasks/task_e_68c6b343be58832f9138563547ee48e6