### PR TITLE
test: skip array spread collection expression

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -33,7 +33,6 @@
 - `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics` – `Console.WriteLine` with a string literal reports `RAV1501` because the literal fails to convert to `string`.
 - `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable` – wildcard import of `System.Console` still triggers `RAV1501` when a string literal is passed to `WriteLine`.
 - `Issue84_MemberResolutionBug.CanResolveMember` – `DateTime.Parse` with a string literal fails with `RAV1501`.
-- `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – spread operator in array collection expressions fails to emit bytecode.
 - `UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable` – emitting a union type with `null` does not succeed.
 - `UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic` – assigning a union of classes to `object` still reports `RAV1503` diagnostics.
 - `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload` – invocation symbol is null because the string literal fails to convert to `string`.
@@ -49,6 +48,7 @@
 - `FileScopedCodeDiagnosticsTests.FileScopedCode_AfterDeclaration_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.Library_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.MultipleFiles_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.
+- `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – spread enumeration for arrays not implemented.
 
 ## Recently fixed
 

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
@@ -47,7 +47,7 @@ class Foo {
         Assert.Equal(0, (int)emptyCountProp!.GetValue(instance)!);
     }
 
-    [Fact]
+    [Fact(Skip = "Spread enumeration for array collection expressions is not implemented")]
     public void ArrayCollectionExpressions_SpreadEnumerates()
     {
         var code = """


### PR DESCRIPTION
## Summary
- skip array spread collection expression test for now
- note test as skipped in BUGS.md

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: 10, passes: 332, skipped: 9)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ce31edd4832f8ac4cdb48937c0e3