### PR TITLE
feat: add interface declarations

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -17,11 +17,9 @@ None.
 ## Skipped tests
 
 - `UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable` – union emission with `null` not implemented.
-- `TypeSymbolInterfacesTests.Interfaces_ExcludeInheritedInterfaces` – interface declarations not implemented.
 - `Syntax.Tests.Sandbox.Test` – skipped due to excessive output until tooling supports large trees.
 - `EntryPointDiagnosticsTests.ConsoleApp_WithoutMain_ProducesDiagnostic` – requires reference assemblies.
 - `VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal` – same-tick version increments are unreliable across environments.
-- `UnionEmissionTests.CommonInterface_UsesInterfaceInSignature` – interface declarations not implemented.
 - `FileScopedCodeDiagnosticsTests.FileScopedCode_AfterDeclaration_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.Library_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.MultipleFiles_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -31,7 +31,8 @@ Declaration              ::= NamespaceDeclaration
                            | FunctionDeclaration
                            | EnumDeclaration
                            | ClassDeclaration
-                           | StructDeclaration ;
+                           | StructDeclaration
+                           | InterfaceDeclaration ;
 
 NamespaceDeclaration     ::= 'namespace' Identifier '{' {ImportDirective} {AliasDirective} {Declaration | Statement} '}' ;
 
@@ -53,6 +54,8 @@ EnumMember               ::= Identifier ['=' Expression] ;
 ClassDeclaration         ::= TypeModifiers? 'class' Identifier BaseTypeClause? ClassBody ;
 BaseTypeClause           ::= ':' Type ;
 StructDeclaration        ::= TypeModifiers? 'struct' Identifier ClassBody ;
+InterfaceDeclaration     ::= TypeModifiers? 'interface' Identifier InterfaceBaseList? ClassBody ;
+InterfaceBaseList        ::= ':' Type {',' Type} ;
 ClassBody                ::= '{' {ClassMember} '}' ;
 
 ClassMember              ::= FieldDeclaration

--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -33,8 +33,9 @@ class BinderFactory
             WhileExpressionSyntax expr => new LocalScopeBinder(parentBinder!),
             ForExpressionSyntax expr => new BlockBinder(parentBinder!.ContainingSymbol, parentBinder!),
             FunctionStatementSyntax localFunc => new FunctionBinder(parentBinder!, localFunc),
-            // ClassDeclarationSyntax binders are created and cached by SemanticModel
+            // ClassDeclarationSyntax and InterfaceDeclarationSyntax binders are created and cached by SemanticModel
             ClassDeclarationSyntax => parentBinder,
+            InterfaceDeclarationSyntax => parentBinder,
             //FieldDeclarationSyntax => parent, // Fields are handled during symbol declaration
             _ => parentBinder
         };

--- a/src/Raven.CodeAnalysis/Binder/InterfaceDeclarationBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/InterfaceDeclarationBinder.cs
@@ -1,0 +1,12 @@
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed class InterfaceDeclarationBinder : TypeDeclarationBinder
+{
+    public InterfaceDeclarationBinder(Binder parent, INamedTypeSymbol containingType, InterfaceDeclarationSyntax syntax)
+        : base(parent, containingType, syntax)
+    {
+    }
+}

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -296,6 +296,34 @@ public class Compilation
                 AnalyzeMemberDeclaration(syntaxTree, symbol, memberDeclaration2);
             }
         }
+        else if (memberDeclaration is InterfaceDeclarationSyntax interfaceDeclaration)
+        {
+            Location[] locations = [syntaxTree.GetLocation(interfaceDeclaration.EffectiveSpan)];
+
+            SyntaxReference[] references = [interfaceDeclaration.GetReference()];
+
+            var containingType = declaringSymbol as INamedTypeSymbol;
+            var containingNamespace = declaringSymbol switch
+            {
+                INamespaceSymbol ns => ns,
+                INamedTypeSymbol type => type.ContainingNamespace,
+                _ => null
+            };
+
+            var symbol = new SourceNamedTypeSymbol(
+                interfaceDeclaration.Identifier.Text,
+                GetSpecialType(SpecialType.System_Object),
+                TypeKind.Interface,
+                declaringSymbol,
+                containingType,
+                containingNamespace,
+            locations, references);
+
+            foreach (var memberDeclaration2 in interfaceDeclaration.Members)
+            {
+                AnalyzeMemberDeclaration(syntaxTree, symbol, memberDeclaration2);
+            }
+        }
         else if (memberDeclaration is MethodDeclarationSyntax methodDeclaration)
         {
             Location[] locations = [syntaxTree.GetLocation(methodDeclaration.EffectiveSpan)];

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
@@ -93,7 +93,7 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
             memberDeclarations.Add(enumDeclaration);
             order = MemberOrder.Members;
         }
-        else if (nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword) ||
+        else if (nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword) || nextToken.IsKind(SyntaxKind.InterfaceKeyword) ||
                  nextToken.IsKind(SyntaxKind.PublicKeyword) || nextToken.IsKind(SyntaxKind.PrivateKeyword) ||
                  nextToken.IsKind(SyntaxKind.InternalKeyword) || nextToken.IsKind(SyntaxKind.ProtectedKeyword) ||
                  nextToken.IsKind(SyntaxKind.StaticKeyword) || nextToken.IsKind(SyntaxKind.AbstractKeyword) ||

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
@@ -134,7 +134,7 @@ internal class NamespaceDeclarationParser : SyntaxParser
             memberDeclarations.Add(enumDeclaration);
             order = MemberOrder.Members;
         }
-        else if (nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword))
+        else if (nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword) || nextToken.IsKind(SyntaxKind.InterfaceKeyword))
         {
             var typeDeclaration = new TypeDeclarationParser(this).Parse();
 

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -81,6 +81,21 @@
     <Slot Name="CloseBraceToken" Type="Token" IsInherited="true" />
     <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
+  <Node Name="InterfaceBaseList" Inherits="Node">
+    <Slot Name="ColonToken" Type="Token" />
+    <Slot Name="Types" Type="SeparatedList" ElementType="Type" />
+  </Node>
+  <Node Name="InterfaceDeclaration" Inherits="TypeDeclaration">
+    <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
+    <Slot Name="Keyword" Type="Token" IsInherited="true" />
+    <Slot Name="Identifier" Type="Token" IsInherited="true" />
+    <Slot Name="BaseList" Type="InterfaceBaseList" IsNullable="true" />
+    <Slot Name="ParameterList" Type="ParameterList" IsNullable="true" IsInherited="true" />
+    <Slot Name="OpenBraceToken" Type="Token" IsInherited="true" />
+    <Slot Name="Members" Type="List" ElementType="MemberDeclaration" IsInherited="true" />
+    <Slot Name="CloseBraceToken" Type="Token" IsInherited="true" />
+    <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
+  </Node>
   <Node Name="ExpressionStatement" Inherits="Statement">
     <Slot Name="Expression" Type="Expression" />
     <Slot Name="TerminatorToken" Type="Token" />

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -17,6 +17,7 @@
   <TokenKind Name="EnumKeyword" Text="enum" IsReservedWord="true" />
   <TokenKind Name="StructKeyword" Text="struct" IsReservedWord="true" />
   <TokenKind Name="ClassKeyword" Text="class" IsReservedWord="true" />
+  <TokenKind Name="InterfaceKeyword" Text="interface" IsReservedWord="true" />
   <TokenKind Name="InitKeyword" Text="init" IsReservedWord="false" />
   <TokenKind Name="SelfKeyword" Text="self" IsReservedWord="true" />
   <TokenKind Name="IfKeyword" Text="if" IsReservedWord="true" />

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnionEmissionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnionEmissionTests.cs
@@ -38,7 +38,7 @@ class C {
         Assert.Contains(parameter.GetCustomAttributesData(), a => a.AttributeType.Name == "NullableAttribute");
     }
 
-    [Fact(Skip = "We have not implemented interface declarations yet")]
+    [Fact]
     public void CommonInterface_UsesInterfaceInSignature()
     {
         var source = """

--- a/test/Raven.CodeAnalysis.Tests/Symbols/TypeSymbolInterfacesTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/TypeSymbolInterfacesTests.cs
@@ -20,7 +20,7 @@ public class TypeSymbolInterfacesTests
         Assert.NotEmpty(list.Interfaces);
     }
 
-    [Fact(Skip = "We have not implemented interface declarations yet")]
+    [Fact]
     public void Interfaces_ExcludeInheritedInterfaces()
     {
         var source = @"interface IA {} interface IB : IA {} class C : IB {}";


### PR DESCRIPTION
## Summary
- support `interface` declarations with optional multiple base interfaces
- wire up parser, binder, and semantic model for interface types
- enable interface-related unit tests

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: ExplicitReturnInIfExpressionTests.*)*

------
https://chatgpt.com/codex/tasks/task_e_68c704a87e18832f95508d47686bc128