### PR TITLE
feat: support interfaces in class base lists

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -51,11 +51,10 @@ EnumDeclaration          ::= TypeModifiers?
 EnumMembers              ::= EnumMember {',' EnumMember} ;
 EnumMember               ::= Identifier ['=' Expression] ;
 
-ClassDeclaration         ::= TypeModifiers? 'class' Identifier BaseTypeClause? ClassBody ;
-BaseTypeClause           ::= ':' Type ;
+ClassDeclaration         ::= TypeModifiers? 'class' Identifier BaseList? ClassBody ;
 StructDeclaration        ::= TypeModifiers? 'struct' Identifier ClassBody ;
-InterfaceDeclaration     ::= TypeModifiers? 'interface' Identifier InterfaceBaseList? ClassBody ;
-InterfaceBaseList        ::= ':' Type {',' Type} ;
+InterfaceDeclaration     ::= TypeModifiers? 'interface' Identifier BaseList? ClassBody ;
+BaseList                 ::= ':' Type {',' Type} ;
 ClassBody                ::= '{' {ClassMember} '}' ;
 
 ClassMember              ::= FieldDeclaration

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -28,17 +28,7 @@ internal class TypeDeclarationParser : SyntaxParser
             identifier = ExpectToken(SyntaxKind.IdentifierToken);
         }
 
-        TypeAnnotationClauseSyntax? baseType = null;
-        InterfaceBaseListSyntax? baseList = null;
-
-        if (typeKeyword.IsKind(SyntaxKind.InterfaceKeyword))
-        {
-            baseList = ParseInterfaceBaseList();
-        }
-        else
-        {
-            baseType = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
-        }
+        BaseListSyntax? baseList = ParseBaseList();
 
         List<GreenNode> memberList = new List<GreenNode>();
 
@@ -75,10 +65,10 @@ internal class TypeDeclarationParser : SyntaxParser
             return InterfaceDeclaration(modifiers, typeKeyword, identifier, baseList, null, openBraceToken, List(memberList), closeBraceToken, terminatorToken);
         }
 
-        return ClassDeclaration(modifiers, typeKeyword, identifier, baseType, null, openBraceToken, List(memberList), closeBraceToken, terminatorToken);
+        return ClassDeclaration(modifiers, typeKeyword, identifier, baseList, null, openBraceToken, List(memberList), closeBraceToken, terminatorToken);
     }
 
-    private InterfaceBaseListSyntax? ParseInterfaceBaseList()
+    private BaseListSyntax? ParseBaseList()
     {
         if (ConsumeToken(SyntaxKind.ColonToken, out var colonToken))
         {
@@ -100,7 +90,7 @@ internal class TypeDeclarationParser : SyntaxParser
                 }
             }
 
-            return InterfaceBaseList(colonToken, List(types));
+            return BaseList(colonToken, List(types));
         }
 
         return null;

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -74,14 +74,14 @@
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Keyword" Type="Token" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
-    <Slot Name="BaseType" Type="TypeAnnotationClause" IsNullable="true" />
+    <Slot Name="BaseList" Type="BaseList" IsNullable="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsNullable="true" IsInherited="true" />
     <Slot Name="OpenBraceToken" Type="Token" IsInherited="true" />
     <Slot Name="Members" Type="List" ElementType="MemberDeclaration" IsInherited="true" />
     <Slot Name="CloseBraceToken" Type="Token" IsInherited="true" />
     <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
-  <Node Name="InterfaceBaseList" Inherits="Node">
+  <Node Name="BaseList" Inherits="Node">
     <Slot Name="ColonToken" Type="Token" />
     <Slot Name="Types" Type="SeparatedList" ElementType="Type" />
   </Node>
@@ -89,7 +89,7 @@
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Keyword" Type="Token" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
-    <Slot Name="BaseList" Type="InterfaceBaseList" IsNullable="true" />
+    <Slot Name="BaseList" Type="BaseList" IsNullable="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsNullable="true" IsInherited="true" />
     <Slot Name="OpenBraceToken" Type="Token" IsInherited="true" />
     <Slot Name="Members" Type="List" ElementType="MemberDeclaration" IsInherited="true" />

--- a/test/Raven.CodeAnalysis.Tests/Symbols/TypeSymbolInterfacesTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/TypeSymbolInterfacesTests.cs
@@ -35,4 +35,39 @@ public class TypeSymbolInterfacesTests
         Assert.DoesNotContain(c.Interfaces, i => SymbolEqualityComparer.Default.Equals(i, ia));
         Assert.Contains(c.AllInterfaces, i => SymbolEqualityComparer.Default.Equals(i, ia));
     }
+
+    [Fact]
+    public void Class_WithBaseTypeAndMultipleInterfaces()
+    {
+        var source = @"interface IA {} interface IB {} class Base {} class C : Base, IA, IB {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var c = (INamedTypeSymbol)compilation.GetTypeByMetadataName("C")!;
+        var ia = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IA")!;
+        var ib = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IB")!;
+        var baseType = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Base")!;
+
+        Assert.Equal(baseType, c.BaseType);
+        Assert.Contains(c.Interfaces, i => SymbolEqualityComparer.Default.Equals(i, ia));
+        Assert.Contains(c.Interfaces, i => SymbolEqualityComparer.Default.Equals(i, ib));
+    }
+
+    [Fact]
+    public void Class_WithOnlyInterfaces_HasObjectBaseType()
+    {
+        var source = @"interface IA {} interface IB {} class C : IA, IB {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var c = (INamedTypeSymbol)compilation.GetTypeByMetadataName("C")!;
+        var ia = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IA")!;
+        var ib = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IB")!;
+
+        var objectType = compilation.GetSpecialType(SpecialType.System_Object);
+
+        Assert.Equal(objectType, c.BaseType);
+        Assert.Contains(c.Interfaces, i => SymbolEqualityComparer.Default.Equals(i, ia));
+        Assert.Contains(c.Interfaces, i => SymbolEqualityComparer.Default.Equals(i, ib));
+    }
 }


### PR DESCRIPTION
## Summary
- allow classes to specify multiple base types and interfaces
- parse and bind class/interface base lists with Roslyn-style semantics
- add tests for class base types with interfaces and docs update

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs,src/Raven.CodeAnalysis/SemanticModel.cs,test/Raven.CodeAnalysis.Tests/Symbols/TypeSymbolInterfacesTests.cs`
- `dotnet build` (fails: Generator.Tests failed)
- `dotnet build src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj`
- `dotnet test test/Raven.CodeAnalysis.Tests` (fails: ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics)`

------
https://chatgpt.com/codex/tasks/task_e_68c7082f84f4832f889fc3edb29b459a