### PR TITLE
test: re-enable sandbox test

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -17,7 +17,6 @@ None.
 ## Skipped tests
 
 - `UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable` – union emission with `null` not implemented.
-- `Syntax.Tests.Sandbox.Test` – skipped due to excessive output until tooling supports large trees.
 - `EntryPointDiagnosticsTests.ConsoleApp_WithoutMain_ProducesDiagnostic` – requires reference assemblies.
 - `VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal` – same-tick version increments are unreliable across environments.
 - `FileScopedCodeDiagnosticsTests.FileScopedCode_AfterDeclaration_ProducesDiagnostic` – requires reference assemblies.
@@ -43,7 +42,7 @@ None.
 
 - `ImportResolutionTest.ImportNonNamespaceOrType_Should_ProduceDiagnostic` – diagnostic span now excludes the wildcard, highlighting only the invalid target.
 - `ImportResolutionTest.OpenGenericTypeWithoutTypeArguments_Should_ProduceDiagnostic` – open generic type references without type arguments now report `RAV0305`.
-- `Syntax.Tests.Sandbox.Test` – disabled excessive output that caused logger failures during test execution.
+- `Syntax.Tests.Sandbox.Test` – trimmed excessive output and re-enabled to verify successful compilation.
 - `SemanticClassifierTests.ClassifiesTokensBySymbol` – import binder now surfaces static members from wildcard type imports, allowing classifiers to resolve symbols correctly.
 - `CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType` – emitted assemblies now define `System.Unit`, enabling successful emission when functions return `unit` implicitly.
 - Diagnostic verifier now safely formats expected diagnostic messages, preventing `FormatException` crashes when argument counts mismatch.

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs
@@ -3,9 +3,9 @@ using Raven.CodeAnalysis.Testing;
 
 namespace Raven.CodeAnalysis.Syntax.Tests;
 
-public class Sandbox(ITestOutputHelper testOutputHelper)
+public class Sandbox
 {
-    [Fact(Skip = "Sandbox test generates excessive output and is skipped until tooling supports large trees.")]
+    [Fact]
     public void Test()
     {
         var code =
@@ -14,7 +14,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
         import System.Text.*;
 
         let list = [1, 42, 3];
-        var i = 0; 
+        var i = 0;
 
         let stringBuilder = new StringBuilder();
 
@@ -22,7 +22,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
             let x = list[i];
             stringBuilder.AppendLine(x.ToString());
             if x > 3 {
-                Console.WriteLine("Hello, World!");   
+                Console.WriteLine("Hello, World!");
             }
             i = i + 1;
         }
@@ -31,13 +31,6 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
         """;
 
         var syntaxTree = SyntaxTree.ParseText(code);
-
-        var root = syntaxTree.GetRoot();
-
-        // var visitor = new TestSyntaxVisitor();
-        // visitor.Visit(root);
-
-        #region Compilation
 
         var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
         var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
@@ -49,30 +42,7 @@ public class Sandbox(ITestOutputHelper testOutputHelper)
                 MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
             ]);
 
-        var semanticModel = compilation.GetSemanticModel(syntaxTree);
-
-        var methodSymbol = semanticModel.GetDeclaredSymbol(root) as IMethodSymbol;
-        var typeSymbol = methodSymbol?.ContainingType;
-
-        var local = semanticModel.GetDeclaredSymbol(root.DescendantNodes().OfType<VariableDeclaratorSyntax>().First());
-
-        var method = semanticModel.GetSymbolInfo(root.DescendantNodes().OfType<InvocationExpressionSyntax>().First());
-
-        var visitor2 = new TestSymbolVisitor();
-        // visitor2.Visit(compilation.GlobalNamespace);
-
-        testOutputHelper.WriteLine(method.Symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty);
-
-        var diagnostics = semanticModel.GetDiagnostics();
-
-        testOutputHelper.WriteLine("");
-
-        foreach (var diagnostic in compilation.GetDiagnostics())
-        {
-            testOutputHelper.WriteLine(diagnostic.ToString());
-        }
-
-        #endregion
+        Assert.Empty(compilation.GetDiagnostics());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- re-enable sandbox test with minimal diagnostics and assert compilation succeeds
- update BUGS.md to remove skip for sandbox test

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/Syntax/Sandbox.cs --verify-no-changes`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, logger error)*
- `dotnet test test/Raven.CodeAnalysis.Tests --filter Sandbox`


------
https://chatgpt.com/codex/tasks/task_e_68c70a1b7944832fb48908bbcc38bbf0