### PR TITLE
test: make VersionStamp same-tick test deterministic

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -18,7 +18,6 @@ None.
 
 - `UnionEmissionTests.CommonBaseClass_WithNull_UsesBaseTypeAndNullable` – union emission with `null` not implemented.
 - `EntryPointDiagnosticsTests.ConsoleApp_WithoutMain_ProducesDiagnostic` – requires reference assemblies.
-- `VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal` – same-tick version increments are unreliable across environments.
 - `FileScopedCodeDiagnosticsTests.FileScopedCode_AfterDeclaration_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.Library_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.MultipleFiles_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.
@@ -47,6 +46,7 @@ None.
 - `CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType` – emitted assemblies now define `System.Unit`, enabling successful emission when functions return `unit` implicitly.
 - Diagnostic verifier now safely formats expected diagnostic messages, preventing `FormatException` crashes when argument counts mismatch.
 - `AliasResolutionTest.AliasDirective_UsesAlias_Tuple_TypeMismatch_ReportsDiagnostic` – tuple alias assignments now emit `RAV1503` when element types mismatch.
+- `VersionStampTests.GetNewerVersion_InSameTick_IncrementsLocal` – deterministic timestamp seeding validates same-tick local increments reliably.
 
 ## Conclusion
 Union emission with `null` remains unimplemented and is tracked by a skipped test. Addressing this will bring the test suite closer to green.


### PR DESCRIPTION
## Summary
- replace probabilistic same-tick VersionStamp test with deterministic constructor seeding
- update BUGS.md to remove skipped VersionStamp test and mark it fixed

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/Workspaces/VersionStampTests.cs --no-restore` *(fails: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(failed: Raven.CodeAnalysis.Semantics.Tests.UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, Raven.CodeAnalysis.Semantics.Tests.NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, Raven.CodeAnalysis.Tests.Bugs.ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, Raven.CodeAnalysis.Tests.Bugs.ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics, Raven.CodeAnalysis.Tests.StringInterpolationTests.InterpolatedString_FormatsCorrectly, Raven.CodeAnalysis.Semantics.Tests.TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, Raven.CodeAnalysis.Semantics.Tests.ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable, Raven.CodeAnalysis.Tests.Bugs.Issue84_MemberResolutionBug.CanResolveMember, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c70df920f8832f999cc3d88e8944ef