### PR TITLE
test: enable array spread collection test

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -21,10 +21,10 @@ None.
 - `FileScopedCodeDiagnosticsTests.FileScopedCode_AfterDeclaration_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.Library_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.
 - `FileScopedCodeDiagnosticsTests.MultipleFiles_WithFileScopedCode_ProducesDiagnostic` – requires reference assemblies.
-- `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – spread enumeration for arrays not implemented.
 
 ## Recently fixed
 
+- `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – array spreads now enumerate elements correctly.
 - `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – `if` expressions now preserve literal types when inferring unions.
 - Literal arguments now convert to their underlying primitive types before overload resolution, fixing tests such as `StringInterpolationTests.InterpolatedString_FormatsCorrectly`, `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics`, `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable`, `Issue84_MemberResolutionBug.CanResolveMember`, `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload`, and `TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType`.
 - Analyzer configuration flags are respected so analyzer diagnostics can be suppressed; the `MissingReturnTypeAnnotationAnalyzerTests.*` suite now passes.

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CollectionExpressionTests.cs
@@ -47,7 +47,7 @@ class Foo {
         Assert.Equal(0, (int)emptyCountProp!.GetValue(instance)!);
     }
 
-    [Fact(Skip = "Spread enumeration for array collection expressions is not implemented")]
+    [Fact]
     public void ArrayCollectionExpressions_SpreadEnumerates()
     {
         var code = """


### PR DESCRIPTION
## Summary
- enable `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates`
- update BUGS.md to remove resolved test

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName=Raven.CodeAnalysis.Tests.CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpression_GlobalInitializer_ProducesDiagnostics, ExplicitReturnInIfExpressionTests.ExplicitReturnInIfExpressionInitializerProducesDiagnostics)*

------
https://chatgpt.com/codex/tasks/task_e_68c711d9918c832fae98f397f0ccbfd4