### PR TITLE
docs: clarify literal types as subset of underlying type

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -160,7 +160,8 @@ let pet = if flag { Dog() } else { Cat() }
 
 Literal expressions infer the underlying primitive type when used to initialize
 `let` or `var` bindings. To retain a literal's singleton type, an explicit
-annotation is required.
+annotation is required. Literal types are subset types of their underlying
+primitive, so a literal like `1` can be used wherever an `int` is expected.
 
 ```raven
 var i = 0       // i : int

--- a/docs/lang/spec/type-system.md
+++ b/docs/lang/spec/type-system.md
@@ -19,8 +19,10 @@ Raven is a statically typed language whose types correspond directly to CLR type
 Numeric, string, character, and boolean literals may appear as their own types.
 A literal type represents exactly that value and carries an underlying
 primitive type—`1` has underlying type `int` while `"hi"` has underlying type
-`string`. Literal expressions are given these singleton types. These singleton
-types act as value-level constraints, most often used as branches in union
+`string`. Literal types are considered subset types of their underlying primitive,
+so every value of a literal type is also a value of that primitive type. Literal
+expressions are given these singleton types. These singleton types act as
+value-level constraints, most often used as branches in union
 types or other constructs that restrict a value to specific constants.
 
 ```raven


### PR DESCRIPTION
## Summary
- note in the type system spec that literal types are subset types of their underlying primitive
- mention the same subset relationship in the language specification's type inference section

## Testing
- No tests were run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68c7cc071d4c832fa346596400c49b85