### PR TITLE
test: cover bool and char literal types

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
@@ -153,6 +153,42 @@ public class LiteralTypeFlowTests : DiagnosticTestBase
     }
 
     [Fact]
+    public void LiteralType_Bool_UsesUnderlyingBoolean()
+    {
+        var code = "let x: true = true";
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+        var literalType = Assert.IsType<LiteralTypeSymbol>(local.Type);
+
+        Assert.True((bool)literalType.ConstantValue);
+        Assert.Equal(SpecialType.System_Boolean, literalType.UnderlyingType.SpecialType);
+    }
+
+    [Fact]
+    public void LiteralType_Char_UsesUnderlyingChar()
+    {
+        var code = "let x: 'a' = 'a'";
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(declarator)!;
+        var literalType = Assert.IsType<LiteralTypeSymbol>(local.Type);
+
+        Assert.Equal('a', literalType.ConstantValue);
+        Assert.Equal(SpecialType.System_Char, literalType.UnderlyingType.SpecialType);
+    }
+
+    [Fact]
     public void IfExpression_InferredLiteralUnion()
     {
         var code = """


### PR DESCRIPTION
## Summary
- add unit tests ensuring boolean and char literals are typed as their underlying primitive types

## Testing
- `dotnet format Raven.sln --no-restore --include test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs` *(fails: The server disconnected unexpectedly)*
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Assert.Contains() Failure in LiteralTypeFlowTests.IfExpression_InferredLiteralUnion and others)*
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "LiteralType_Bool_UsesUnderlyingBoolean|LiteralType_Char_UsesUnderlyingChar"`


------
https://chatgpt.com/codex/tasks/task_e_68c7cd643b84832f95a06d2c0941b67f