### PR TITLE
docs: document failing tests

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,11 +5,23 @@
 
 ## Prioritized failing test categories
 
-None.
+- Pattern matching and `is`/`as` expressions can produce null references or missing diagnostics.
+- Cast expressions mis-handle primitive types and report incorrect conversion diagnostics.
+- Conditional access emission is incomplete.
+- Parser misclassifies multi-line comments as block statements.
 
 ## Current failing tests
 
-None.
+- `CastExpressionTests.ExplicitCast_Invalid_ProducesDiagnostic` – mismatched `RAV1503` diagnostics reference the literal `1` instead of the source and target types (bug per explicit cast rules).
+- `CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic` – emitting `RAV1503` and `RAV0103` for built-in numeric casts shows primitive type resolution failures (bug).
+- `AsExpressionTests.AsCast_ReferenceType_ProducesNullableType` – `as` casts on reference types yield `null` instead of a nullable target type (bug).
+- `AsExpressionDiagnosticTests.AsCast_Invalid_ProducesDiagnostic` – diagnostics for invalid `as` casts report literal values rather than types (bug).
+- `SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav")` – `BoundIsPatternExpression` throws `NullReferenceException` while binding patterns (bug; pattern matching not defined in the spec).
+- `MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic` – same `BoundIsPatternExpression` null reference during semantic analysis (bug; spec gap).
+- `PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully` – pattern binding null reference prevents emission (bug; spec gap).
+- `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – literal unions are not inferred through `if` expressions, contradicting literal type and union rules (bug).
+- `MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken` – parser casts `EmptyStatementSyntax` to `BlockStatementSyntax` when handling comments (bug).
+- `ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue` – code generation throws `NotSupportedException` for nullable conditional access (bug).
 
 ## Skipped tests
 
@@ -59,3 +71,4 @@ Implementing remaining union conversion checks and reference-assembly diagnostic
 - Line-continuation versus newline-as-terminator rules could be elaborated to avoid parser ambiguity.
 - Import resolution for generic types and namespace/member precedence needs explicit wording.
 - The specification defines `if` expressions for expression positions and `if` statements for statement positions, but the term *imperative context* (no ancestor expression) could be made more explicit.
+- Pattern matching and conditional access semantics are not yet covered, so the expected behavior of related constructs is unclear.


### PR DESCRIPTION
## Summary
- document current failing tests and categorize root causes
- note missing specification coverage for pattern matching and conditional access

## Testing
- `dotnet build`
- `dotnet test --no-build test/Raven.CodeAnalysis.Tests --filter ConditionalAccessTests` *(fails: ConditionalAccess_NullableValue_ReturnsValue)*
- `dotnet test --no-build test/Raven.CodeAnalysis.Tests` *(fails: CastExpressionTests, AsExpressionTests, SampleProgramsTests, MissingReturnTypeAnnotationAnalyzerTests, LiteralTypeFlowTests, MultiLineCommentTriviaTest, PatternVariableTests)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dcfc5be0832f9b18a112c2f6502d