### PR TITLE
fix: report proper types in cast diagnostics

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -12,10 +12,8 @@
 
 ## Current failing tests
 
-- `CastExpressionTests.ExplicitCast_Invalid_ProducesDiagnostic` – mismatched `RAV1503` diagnostics reference the literal `1` instead of the source and target types (bug per explicit cast rules).
 - `CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic` – emitting `RAV1503` and `RAV0103` for built-in numeric casts shows primitive type resolution failures (bug).
 - `AsExpressionTests.AsCast_ReferenceType_ProducesNullableType` – `as` casts on reference types yield `null` instead of a nullable target type (bug).
-- `AsExpressionDiagnosticTests.AsCast_Invalid_ProducesDiagnostic` – diagnostics for invalid `as` casts report literal values rather than types (bug).
 - `SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav")` – `BoundIsPatternExpression` throws `NullReferenceException` while binding patterns (bug; pattern matching not defined in the spec).
 - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic` – same `BoundIsPatternExpression` null reference during semantic analysis (bug; spec gap).
 - `PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully` – pattern binding null reference prevents emission (bug; spec gap).
@@ -32,6 +30,7 @@
 
 ## Recently fixed
 
+- `CastExpressionTests.ExplicitCast_Invalid_ProducesDiagnostic` and `AsExpressionDiagnosticTests.AsCast_Invalid_ProducesDiagnostic` – invalid cast diagnostics now report source and target types instead of literal values.
 - `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – array spreads now enumerate elements correctly.
 - `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – `if` expressions now preserve literal types when inferring unions.
 - Literal arguments now convert to their underlying primitive types before overload resolution, fixing tests such as `StringInterpolationTests.InterpolatedString_FormatsCorrectly`, `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics`, `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable`, `Issue84_MemberResolutionBug.CanResolveMember`, `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload`, and `TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType`.

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -665,8 +665,8 @@ partial class BlockBinder : Binder
         if (!conversion.Exists)
         {
             _diagnostics.ReportCannotConvertFromTypeToType(
-                expression.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                targetType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                expression.Type!.ToDisplayStringForDiagnostics(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                targetType.ToDisplayStringForDiagnostics(SymbolDisplayFormat.MinimallyQualifiedFormat),
                 castExpression.GetLocation());
             return new BoundErrorExpression(targetType, null, BoundExpressionReason.TypeMismatch);
         }
@@ -685,8 +685,8 @@ partial class BlockBinder : Binder
         if (expression.Type!.IsValueType || targetType.IsValueType)
         {
             _diagnostics.ReportCannotConvertFromTypeToType(
-                expression.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                targetType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                expression.Type!.ToDisplayStringForDiagnostics(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                targetType.ToDisplayStringForDiagnostics(SymbolDisplayFormat.MinimallyQualifiedFormat),
                 asExpression.GetLocation());
             var errorType = new NullableTypeSymbol(targetType, null, null, null, []);
             return new BoundErrorExpression(errorType, null, BoundExpressionReason.TypeMismatch);
@@ -696,8 +696,8 @@ partial class BlockBinder : Binder
         if (!conversion.Exists || conversion.IsNumeric || conversion.IsUserDefined)
         {
             _diagnostics.ReportCannotConvertFromTypeToType(
-                expression.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                targetType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                expression.Type!.ToDisplayStringForDiagnostics(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                targetType.ToDisplayStringForDiagnostics(SymbolDisplayFormat.MinimallyQualifiedFormat),
                 asExpression.GetLocation());
             var errorType = new NullableTypeSymbol(targetType, null, null, null, []);
             return new BoundErrorExpression(errorType, null, BoundExpressionReason.TypeMismatch);

--- a/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis;
 
@@ -52,6 +53,14 @@ public static partial class SymbolExtensions
         }
 
         return typeSymbol.ToDisplayString(format);
+    }
+
+    public static string ToDisplayStringForDiagnostics(this ITypeSymbol typeSymbol, SymbolDisplayFormat format)
+    {
+        if (typeSymbol is LiteralTypeSymbol literal)
+            typeSymbol = literal.UnderlyingType;
+
+        return typeSymbol.ToDisplayStringKeywordAware(format);
     }
 
     public static string ToDisplayString(this ISymbol symbol, SymbolDisplayFormat? format = default!)


### PR DESCRIPTION
## Summary
- unwrap literal types when formatting diagnostics
- use underlying types for explicit and `as` cast diagnostics
- update BUGS list

## Testing
- `dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --include src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs` *(fails: The server disconnected unexpectedly.)*
- `dotnet build src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj -v minimal`
- `dotnet test test/Raven.CodeAnalysis.Tests --no-build` *(fails: "dotnet" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c7df923ac8832f8c07b103790b3cc7