### PR TITLE
fix: handle multi-line comment trivia inside if blocks

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -8,7 +8,6 @@
 - Pattern matching and `is`/`as` expressions can produce null references or missing diagnostics.
 - Cast expressions mis-handle primitive types and report incorrect conversion diagnostics.
 - Conditional access emission is incomplete.
-- Parser misclassifies multi-line comments as block statements.
 
 ## Current failing tests
 
@@ -18,7 +17,6 @@
 - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic` – same `BoundIsPatternExpression` null reference during semantic analysis (bug; spec gap).
 - `PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully` – pattern binding null reference prevents emission (bug; spec gap).
 - `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – literal unions are not inferred through `if` expressions, contradicting literal type and union rules (bug).
-- `MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken` – parser casts `EmptyStatementSyntax` to `BlockStatementSyntax` when handling comments (bug).
 - `ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue` – code generation throws `NotSupportedException` for nullable conditional access (bug).
 
 ## Skipped tests
@@ -30,6 +28,7 @@
 
 ## Recently fixed
 
+- `MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken` – multi-line comments are now treated as trivia rather than block statements.
 - `CastExpressionTests.ExplicitCast_Invalid_ProducesDiagnostic` and `AsExpressionDiagnosticTests.AsCast_Invalid_ProducesDiagnostic` – invalid cast diagnostics now report source and target types instead of literal values.
 - `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – array spreads now enumerate elements correctly.
 - `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – `if` expressions now preserve literal types when inferring unions.

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -694,7 +694,8 @@ internal class ExpressionSyntaxParser : SyntaxParser
             if (!next.IsKind(SyntaxKind.CommaToken) &&
                 !next.IsKind(SyntaxKind.CloseParenToken) &&
                 !next.IsKind(SyntaxKind.SemicolonToken) &&
-                !next.IsKind(SyntaxKind.EndOfFileToken))
+                !next.IsKind(SyntaxKind.EndOfFileToken) &&
+                !next.IsKind(SyntaxKind.OpenBraceToken))
             {
                 var expression = ParseFactorExpression();
                 return CastExpression(openParenToken, typeName, closeParen, expression);


### PR DESCRIPTION
## Summary
- avoid treating `{` after a parenthesized expression as part of a cast
- note resolved multi-line comment parsing issue in `BUGS.md`

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests -c Release --filter "FullyQualifiedName~MultiLineCommentTrivia_IsLeadingTriviaOfToken"`
- `dotnet test test/Raven.CodeAnalysis.Tests -c Release` *(fails: AsExpressionTests.AsCast_ReferenceType_ProducesNullableType, UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, StringInterpolationTests.InterpolatedString_FormatsCorrectly, LiteralTypeFlowTests.IfExpression_InferredLiteralUnion, ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable, CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates, Issue84_MemberResolutionBug.CanResolveMember, NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue, TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic, PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully, SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav"), CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic)`

------
https://chatgpt.com/codex/tasks/task_e_68c7e332c8dc832fba6a98ad8e97922c