### PR TITLE
fix: support double keyword and numeric casts

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -6,12 +6,10 @@
 ## Prioritized failing test categories
 
 - Pattern matching and `is`/`as` expressions can produce null references or missing diagnostics.
-- Cast expressions mis-handle primitive types and report incorrect conversion diagnostics.
 - Conditional access emission is incomplete.
 
 ## Current failing tests
 
-- `CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic` – emitting `RAV1503` and `RAV0103` for built-in numeric casts shows primitive type resolution failures (bug).
 - `AsExpressionTests.AsCast_ReferenceType_ProducesNullableType` – `as` casts on reference types yield `null` instead of a nullable target type (bug).
 - `SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav")` – `BoundIsPatternExpression` throws `NullReferenceException` while binding patterns (bug; pattern matching not defined in the spec).
 - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic` – same `BoundIsPatternExpression` null reference during semantic analysis (bug; spec gap).
@@ -28,6 +26,7 @@
 
 ## Recently fixed
 
+- `CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic` – built-in numeric casts now resolve primitive types correctly.
 - `MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken` – multi-line comments are now treated as trivia rather than block statements.
 - `CastExpressionTests.ExplicitCast_Invalid_ProducesDiagnostic` and `AsExpressionDiagnosticTests.AsCast_Invalid_ProducesDiagnostic` – invalid cast diagnostics now report source and target types instead of literal values.
 - `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – array spreads now enumerate elements correctly.

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -673,6 +673,7 @@ public class Compilation
         var destType = destination.SpecialType;
 
         return (sourceType is SpecialType.System_Int32 && destType is SpecialType.System_Int64) ||
+               (sourceType is SpecialType.System_Int32 && destType is SpecialType.System_Double) ||
                (sourceType is SpecialType.System_Single && destType is SpecialType.System_Double);
     }
 
@@ -765,7 +766,7 @@ public class Compilation
             //SyntaxKind.ByteKeyword => SpecialType.System_Byte,
             SyntaxKind.CharKeyword => SpecialType.System_Char,
             //SyntaxKind.DecimalKeyword => SpecialType.System_Decimal,
-            //SyntaxKind.DoubleKeyword => SpecialType.System_Double,
+            SyntaxKind.DoubleKeyword => SpecialType.System_Double,
             //SyntaxKind.FloatKeyword => SpecialType.System_Single,
             SyntaxKind.IntKeyword => SpecialType.System_Int32,
             //SyntaxKind.LongKeyword => SpecialType.System_Int64,

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -600,6 +600,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
             case SyntaxKind.BoolKeyword:
             case SyntaxKind.CharKeyword:
             case SyntaxKind.IntKeyword:
+            case SyntaxKind.DoubleKeyword:
             case SyntaxKind.ObjectKeyword:
                 return ParsePredefinedTypeSyntax();
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
@@ -311,6 +311,7 @@ internal class NameSyntaxParser : SyntaxParser
             case SyntaxKind.BoolKeyword:
             case SyntaxKind.CharKeyword:
             case SyntaxKind.IntKeyword:
+            case SyntaxKind.DoubleKeyword:
             case SyntaxKind.ObjectKeyword:
             case SyntaxKind.UnitKeyword:
                 return true;

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -4,6 +4,7 @@
   <TokenKind Name="UnitKeyword" Text="unit" IsReservedWord="false" />
   <TokenKind Name="NullKeyword" Text="null" IsReservedWord="true" />
   <TokenKind Name="IntKeyword" Text="int" IsReservedWord="true" />
+  <TokenKind Name="DoubleKeyword" Text="double" IsReservedWord="true" />
   <TokenKind Name="StringKeyword" Text="string" IsReservedWord="true" />
   <TokenKind Name="BoolKeyword" Text="bool" IsReservedWord="true" />
   <TokenKind Name="CharKeyword" Text="char" IsReservedWord="true" />


### PR DESCRIPTION
## Summary
- recognize `double` as a predefined type and permit casting `int` to `double`
- update parsing and conversion logic for `double`
- remove resolved cast test from BUGS list

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/Tokens.xml,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs,src/Raven.CodeAnalysis/Compilation.cs`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --no-build` *(fails: StringInterpolationTests.InterpolatedString_FormatsCorrectly, SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav"), PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully, Diagnostics.MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic, TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable, NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue, CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates, AliasResolutionTest.AliasDirective_UsesMemberAlias_Method, AsExpressionTests.AsCast_ReferenceType_ProducesNullableType, LiteralTypeFlowTests.IfExpression_InferredLiteralUnion, UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics)*
- `dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic`

------
https://chatgpt.com/codex/tasks/task_e_68c7e87a88f0832f9109a7e0cb304c57