### PR TITLE
fix: ensure as casts yield nullable types

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -10,7 +10,6 @@
 
 ## Current failing tests
 
-- `AsExpressionTests.AsCast_ReferenceType_ProducesNullableType` – `as` casts on reference types yield `null` instead of a nullable target type (bug).
 - `SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav")` – `BoundIsPatternExpression` throws `NullReferenceException` while binding patterns (bug; pattern matching not defined in the spec).
 - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic` – same `BoundIsPatternExpression` null reference during semantic analysis (bug; spec gap).
 - `PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully` – pattern binding null reference prevents emission (bug; spec gap).
@@ -26,11 +25,11 @@
 
 ## Recently fixed
 
+- `AsExpressionTests.AsCast_ReferenceType_ProducesNullableType` – semantic model now returns a nullable target type for reference-type `as` casts.
 - `CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic` – built-in numeric casts now resolve primitive types correctly.
 - `MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken` – multi-line comments are now treated as trivia rather than block statements.
 - `CastExpressionTests.ExplicitCast_Invalid_ProducesDiagnostic` and `AsExpressionDiagnosticTests.AsCast_Invalid_ProducesDiagnostic` – invalid cast diagnostics now report source and target types instead of literal values.
 - `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – array spreads now enumerate elements correctly.
-- `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – `if` expressions now preserve literal types when inferring unions.
 - Literal arguments now convert to their underlying primitive types before overload resolution, fixing tests such as `StringInterpolationTests.InterpolatedString_FormatsCorrectly`, `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics`, `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable`, `Issue84_MemberResolutionBug.CanResolveMember`, `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload`, and `TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType`.
 - Analyzer configuration flags are respected so analyzer diagnostics can be suppressed; the `MissingReturnTypeAnnotationAnalyzerTests.*` suite now passes.
 - `AnalyzerInfrastructureTests.GetDiagnostics_IncludesCompilerAndAnalyzerDiagnostics` – parser now buffers the requested position before rewinding, preventing `Position outside of buffer bounds` exceptions.


### PR DESCRIPTION
## Summary
- bind global statements when collecting diagnostics to keep locals in scope
- return bound types for `as` expressions even when errors occur
- document fix for `AsCast_ReferenceType_ProducesNullableType` in BUGS.md

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter AsCast_ReferenceType_ProducesNullableType`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully, NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload, LiteralTypeFlowTests.IfExpression_InferredLiteralUnion, TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType, ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable, Bugs.Issue84_MemberResolutionBug.CanResolveMember, AliasResolutionTest.AliasDirective_UsesMemberAlias_Method, UnionConversionTests.UnionAssignedToObject_ReturnsNoDiagnostic, SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav"), StringInterpolationTests.InterpolatedString_FormatsCorrectly, MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic, CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates, ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue, NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics, TypeSymbolInterfacesTests.Class_WithOnlyInterfaces_HasObjectBaseType)`

------
https://chatgpt.com/codex/tasks/task_e_68c7ee30779c832fbcf87c5a36e2c9a6