### PR TITLE
fix: preserve literal unions inferred from conditionals

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -13,7 +13,6 @@
 - `SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav")` – `BoundIsPatternExpression` throws `NullReferenceException` while binding patterns (bug; pattern matching not defined in the spec).
 - `MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic` – same `BoundIsPatternExpression` null reference during semantic analysis (bug; spec gap).
 - `PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully` – pattern binding null reference prevents emission (bug; spec gap).
-- `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – literal unions are not inferred through `if` expressions, contradicting literal type and union rules (bug).
 - `ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue` – code generation throws `NotSupportedException` for nullable conditional access (bug).
 
 ## Skipped tests
@@ -28,6 +27,7 @@
 - `AsExpressionTests.AsCast_ReferenceType_ProducesNullableType` – semantic model now returns a nullable target type for reference-type `as` casts.
 - `CastExpressionTests.ExplicitCast_Numeric_NoDiagnostic` – built-in numeric casts now resolve primitive types correctly.
 - `MultiLineCommentTriviaTest.MultiLineCommentTrivia_IsLeadingTriviaOfToken` – multi-line comments are now treated as trivia rather than block statements.
+- `LiteralTypeFlowTests.IfExpression_InferredLiteralUnion` – type inference now preserves literal union members produced by conditional expressions.
 - `CastExpressionTests.ExplicitCast_Invalid_ProducesDiagnostic` and `AsExpressionDiagnosticTests.AsCast_Invalid_ProducesDiagnostic` – invalid cast diagnostics now report source and target types instead of literal values.
 - `CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates` – array spreads now enumerate elements correctly.
 - Literal arguments now convert to their underlying primitive types before overload resolution, fixing tests such as `StringInterpolationTests.InterpolatedString_FormatsCorrectly`, `NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics`, `ImportResolutionTest.WildcardTypeImport_MakesStaticMembersAvailable`, `Issue84_MemberResolutionBug.CanResolveMember`, `NullableTypeTests.ConsoleWriteLine_WithStringLiteral_Chooses_StringOverload`, and `TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType`.

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -159,7 +159,10 @@ let pet = if flag { Dog() } else { Cat() }
 ```
 
 Literal expressions infer the underlying primitive type when used to initialize
-`let` or `var` bindings. To retain a literal's singleton type, an explicit
+`let` or `var` bindings. When multiple literal values flow into an inferred
+union—such as the branches of an `if` expression—the resulting union keeps each
+literal member so the type reflects the precise set of constants that may be
+produced. To retain a literal's singleton type for a single value, an explicit
 annotation is required. Literal types are subset types of their underlying
 primitive, so a literal like `1` can be used wherever an `int` is expected.
 

--- a/docs/lang/spec/type-system.md
+++ b/docs/lang/spec/type-system.md
@@ -50,8 +50,11 @@ normal conversion rules of that type. This allows `1` to widen to `double` or
 
 When a literal is assigned to a target whose type is inferred—such as a
 variable declaration without an explicit type annotation—the literal widens to
-its underlying primitive type. This keeps type inference in line with other
-languages that treat `let x = 1` as `int` rather than the literal type `1`.
+its underlying primitive type. When inference gathers multiple literal values
+into a union (for example, via conditional branches), those literal members are
+preserved so the inferred union reports the exact set of constants that may
+flow to that location. This keeps single-literal inference in line with other
+languages that treat `let x = 1` as `int` while still modeling literal unions.
 
 ```raven
 let yes: "yes" = "yes"


### PR DESCRIPTION
## Summary
- keep literal members when normalizing inferred union types so conditional expressions produce literal unions
- document the literal-union inference rule in the language specification and type system overview
- update BUGS.md to record the LiteralTypeFlowTests.IfExpression_InferredLiteralUnion fix

## Testing
- dotnet build -v minimal
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Known BoundIsPatternExpression null-reference in pattern binder)*
- dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.LiteralTypeFlowTests.IfExpression_InferredLiteralUnion"

------
https://chatgpt.com/codex/tasks/task_e_68c86609fe3c832fb93d0150694cbf9c