### PR TITLE
Fix boolean type resolution for pattern expressions

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
@@ -6,10 +6,16 @@ internal partial class BoundIsPatternExpression : BoundExpression
 {
     public BoundExpression Expression { get; }
     public BoundPattern Pattern { get; }
+    public ITypeSymbol BooleanType { get; }
 
-    public BoundIsPatternExpression(BoundExpression expression, BoundPattern pattern, BoundExpressionReason reason = BoundExpressionReason.None)
-        : base(expression.Type.ContainingAssembly.GetTypeByMetadataName("System.Boolean")!, null, reason)
+    public BoundIsPatternExpression(
+        BoundExpression expression,
+        BoundPattern pattern,
+        ITypeSymbol booleanType,
+        BoundExpressionReason reason = BoundExpressionReason.None)
+        : base(booleanType, null, reason)
     {
+        BooleanType = booleanType;
         Expression = expression;
         Pattern = pattern;
     }
@@ -181,7 +187,9 @@ internal partial class BlockBinder
         var expression = BindExpression(syntax.Expression);
         var pattern = BindPattern(syntax.Pattern);
 
-        return new BoundIsPatternExpression(expression, pattern);
+        var booleanType = Compilation.GetSpecialType(SpecialType.System_Boolean);
+
+        return new BoundIsPatternExpression(expression, pattern, booleanType);
     }
 
     private BoundSingleVariableDesignator? BindSingleVariableDesignation(SingleVariableDesignationSyntax singleVariableDesignation)


### PR DESCRIPTION
## Summary
- add an explicit BooleanType on BoundIsPatternExpression and accept it as a constructor argument
- obtain the boolean special type from the compilation when binding `is` pattern expressions so union operands no longer crash

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing NotSupportedException in ConditionalAccess code generation)*

------
https://chatgpt.com/codex/tasks/task_e_68c91544c2f0832fa89bad6dcc7d0e4b