### PR TITLE
fix: derive common base for union types

### DIFF
--- a/docs/lang/spec/type-system.md
+++ b/docs/lang/spec/type-system.md
@@ -82,6 +82,8 @@ Appending `?` creates a nullable type. Value types are emitted as `System.Nullab
 
 `A | B` represents a value that may be either type. Each branch retains its own CLR representation and the union's base type is inferred from the operands. This common denominator is used whenever a single type is required, such as overload resolution.
 
+The compiler flattens nested unions, unwraps aliases, and then walks each member's inheritance chain to select the most-derived type shared by every non-`null` branch. Member lookup on a union delegates to that type so methods defined on a shared base class remain available. If no tighter relationship exists the union falls back to `object`, and including `null` makes that base behave as nullable (e.g. `object?`).
+
 Common use cases include mixing unrelated primitives, modeling optional values, or constraining a value to specific literals:
 
 ```raven

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/UnionTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/UnionTypeSymbol.cs
@@ -1,20 +1,26 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Raven.CodeAnalysis.Symbols;
 
 internal partial class UnionTypeSymbol : SourceSymbol, IUnionTypeSymbol
 {
+    private readonly ImmutableArray<ITypeSymbol> _types;
+
     public UnionTypeSymbol(IEnumerable<ITypeSymbol> types, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations)
         : base(SymbolKind.Type, string.Empty, containingSymbol, containingType, containingNamespace, locations, [])
     {
-        Types = types;
+        _types = types is ImmutableArray<ITypeSymbol> array ? array : ImmutableArray.CreateRange(types);
+
+        BaseType = ComputeBaseType(_types);
 
         TypeKind = TypeKind.Union;
     }
 
     public override string Name => string.Join(" | ", Types.Select(x => x.ToDisplayStringKeywordAware(SymbolDisplayFormat.FullyQualifiedFormat)));
 
-    public IEnumerable<ITypeSymbol> Types { get; }
+    public IEnumerable<ITypeSymbol> Types => _types;
 
     public SpecialType SpecialType => SpecialType.None;
 
@@ -22,7 +28,7 @@ internal partial class UnionTypeSymbol : SourceSymbol, IUnionTypeSymbol
 
     public bool IsType => true;
 
-    public INamedTypeSymbol? BaseType => null;
+    public INamedTypeSymbol? BaseType { get; }
 
     public TypeKind TypeKind { get; }
 
@@ -30,12 +36,12 @@ internal partial class UnionTypeSymbol : SourceSymbol, IUnionTypeSymbol
 
     public ImmutableArray<ISymbol> GetMembers()
     {
-        return ImmutableArray<ISymbol>.Empty;
+        return BaseType?.GetMembers() ?? ImmutableArray<ISymbol>.Empty;
     }
 
     public ImmutableArray<ISymbol> GetMembers(string name)
     {
-        return ImmutableArray<ISymbol>.Empty;
+        return BaseType?.GetMembers(name) ?? ImmutableArray<ISymbol>.Empty;
     }
 
     public ITypeSymbol? LookupType(string name)
@@ -50,7 +56,116 @@ internal partial class UnionTypeSymbol : SourceSymbol, IUnionTypeSymbol
 
     public bool IsMemberDefined(string name, out ISymbol? symbol)
     {
+        if (BaseType is not null)
+            return BaseType.IsMemberDefined(name, out symbol);
+
         symbol = null;
         return false;
+    }
+
+    private static INamedTypeSymbol? ComputeBaseType(ImmutableArray<ITypeSymbol> types)
+    {
+        var members = FlattenTypes(types)
+            .Select(Normalize)
+            .ToImmutableArray();
+
+        if (members.Length == 0)
+            return null;
+
+        var nonNullMembers = members.Where(t => t.TypeKind != TypeKind.Null).ToImmutableArray();
+        if (nonNullMembers.Length == 0)
+            return TryGetObjectType(members);
+
+        var candidates = EnumerateHierarchy(nonNullMembers[0]).ToList();
+        if (candidates.Count == 0)
+            return TryGetObjectType(nonNullMembers);
+
+        var comparer = SymbolEqualityComparer.Default;
+
+        foreach (var type in nonNullMembers.Skip(1))
+        {
+            var hierarchy = new HashSet<INamedTypeSymbol>(EnumerateHierarchy(type), comparer);
+            candidates.RemoveAll(candidate => !hierarchy.Contains(candidate));
+
+            if (candidates.Count == 0)
+                break;
+        }
+
+        return candidates.FirstOrDefault() ?? TryGetObjectType(nonNullMembers);
+    }
+
+    private static IEnumerable<ITypeSymbol> FlattenTypes(IEnumerable<ITypeSymbol> types)
+    {
+        foreach (var type in types)
+        {
+            if (type is IUnionTypeSymbol union)
+            {
+                foreach (var nested in FlattenTypes(union.Types))
+                    yield return nested;
+            }
+            else
+            {
+                yield return type;
+            }
+        }
+    }
+
+    private static ITypeSymbol Normalize(ITypeSymbol type)
+    {
+        while (true)
+        {
+            if (type.IsAlias && type.UnderlyingSymbol is ITypeSymbol alias)
+            {
+                type = alias;
+                continue;
+            }
+
+            if (type is LiteralTypeSymbol literal)
+            {
+                type = literal.UnderlyingType;
+                continue;
+            }
+
+            break;
+        }
+
+        return type;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateHierarchy(ITypeSymbol type)
+    {
+        var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        for (ITypeSymbol? current = Normalize(type); current is not null; current = GetNext(current))
+        {
+            if (current is INamedTypeSymbol named && seen.Add(named))
+                yield return named;
+        }
+    }
+
+    private static ITypeSymbol? GetNext(ITypeSymbol type)
+    {
+        return type switch
+        {
+            NullableTypeSymbol nullable => Normalize(nullable.UnderlyingType),
+            _ => type.BaseType is { } baseType ? Normalize(baseType) : null
+        };
+    }
+
+    private static INamedTypeSymbol? TryGetObjectType(IEnumerable<ITypeSymbol> types)
+    {
+        foreach (var type in types)
+        {
+            foreach (var candidate in EnumerateHierarchy(type))
+            {
+                if (candidate.SpecialType == SpecialType.System_Object)
+                    return candidate;
+            }
+
+            if (type.ContainingAssembly?.GetTypeByMetadataName("System.Object") is { } objectType)
+                return objectType;
+        }
+
+        return null;
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
@@ -28,6 +28,64 @@ class Baz {
     }
 
     [Fact]
+    public void InstanceMembersFromObjectAreAccessibleOnUnion()
+    {
+        string code = """
+import System.*
+
+class Foo {}
+class Bar {}
+
+class Baz {
+    Test(flag: bool) {
+        let value = if flag {
+            Foo()
+        } else {
+            Bar()
+        }
+
+        value.ToString()
+    }
+}
+""";
+
+        var verifier = CreateVerifier(code);
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void CommonBaseMembersAreAccessibleOnUnion()
+    {
+        string code = """
+import System.*
+
+open class Animal {
+    Speak() -> string {
+        "sound"
+    }
+}
+
+class Dog : Animal {}
+class Cat : Animal {}
+
+class Zoo {
+    Test(flag: bool) {
+        let pet = if flag {
+            Dog()
+        } else {
+            Cat()
+        }
+
+        pet.Speak()
+    }
+}
+""";
+
+        var verifier = CreateVerifier(code);
+        verifier.Verify();
+    }
+
+    [Fact]
     public void UnionNotConvertibleToExplicitType_ProducesDiagnostic()
     {
         string code = """


### PR DESCRIPTION
## Summary
- compute the union base type by flattening members, normalizing aliases/literals, and finding the most-derived shared ancestor so object members and custom base members surface correctly
- extend the union conversion tests with a scenario where a shared base class method remains callable
- document how the compiler determines a union's common denominator and how `null` influences the nullable behavior

## Testing
- dotnet build src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing runtime limitations such as System.NotSupportedException when emitting conditional access and missing BCL overloads)*


------
https://chatgpt.com/codex/tasks/task_e_68c919f53358832f8273bb48d6a44d83