### PR TITLE
Clarify literal and union typing in docs

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -117,6 +117,24 @@ returning `unit`. If the returned expression's type is not assignable to the
 declared return type, the compiler emits a conversion diagnostic.
 
 ```raven
+func DoOperation(a: int, b: int) -> int {
+    if a > b {
+        return -1
+    }
+    return a + b
+}
+
+func DoOperation2(a: int, b: int) -> int | false {
+    if a > b {
+        return false
+    }
+    return a + b
+}
+```
+
+Property accessors follow the same rule: each explicit `return` must produce a value compatible with the property's declared type.
+
+```raven
 func choose(flag: bool) -> int | () {
     if flag {
         42            // implicit return
@@ -171,6 +189,19 @@ var i = 0       // i : int
 let j = 0       // j : int
 var k: 1 = 1    // k : 1
 ```
+
+Control-flow expressions participate in the same inference. An `if` expression whose branches produce different types infers a union of those results:
+
+```raven
+let result = if a > b { false } else { 42 }
+// result : false | 42
+
+let x = 42        // x : int
+let result2 = if a > b { false } else { x }
+// result2 : false | int
+```
+
+Here each branch contributes its inferred type to the union. Because the `else` branch is the literal `42`, the union preserves that literal member. When the branch expression flows through a variable such as `x : int`, the union widens accordingly.
 
 Numeric literals choose an underlying primitive type. Integer literals default
 to `int` but upgrade to `long` when the value exceeds the `int` range.

--- a/docs/lang/spec/type-system.md
+++ b/docs/lang/spec/type-system.md
@@ -30,6 +30,8 @@ let value: "yes" | "no" = "yes"
 
 alias Switch = "yes" | "no"
 let value: Switch = "yes"
+
+let literalInt: int = 2      // literal widens to its underlying type
 ```
 
 Supported literal types are:
@@ -84,6 +86,11 @@ Appending `?` creates a nullable type. Value types are emitted as `System.Nullab
 
 The compiler flattens nested unions, unwraps aliases, and then walks each member's inheritance chain to select the most-derived type shared by every non-`null` branch. Member lookup on a union delegates to that type so methods defined on a shared base class remain available. If no tighter relationship exists the union falls back to `object`, and including `null` makes that base behave as nullable (e.g. `object?`).
 
+```raven
+let union: int | string = "foo"
+Console.WriteLine(union.ToString()) // members from the common base type are available
+```
+
 Common use cases include mixing unrelated primitives, modeling optional values, or constraining a value to specific literals:
 
 ```raven
@@ -92,7 +99,7 @@ let b: string | null = null // optional string (equivalent to string?)
 let c: "yes" | "no" = "yes" // constrained to specific constants
 ```
 
-When assigning to a union, the expression must convert to at least one branch. Literal branches are matched by value rather than by type:
+A value is assignable to a union when it can convert to at least one member. Literal branches are matched by value rather than by type:
 
 ```raven
 let d: "true" | 1 = 1   // ok
@@ -150,6 +157,10 @@ User-defined conversions are considered last. An argument of a literal type is a
 exact match for a parameter of the same literal type; otherwise the literal is
 converted to its underlying primitive type before the ranking is applied. If no
 candidate is strictly better, the call is reported as ambiguous.
+
+```raven
+let parsed = int.Parse("42") // string literal selects the overload taking string
+```
 
 Arguments with union types participate using the union's base type. The compiler
 does not test each branch individually; instead, it ranks conversions from the


### PR DESCRIPTION
## Summary
- clarify how literal types widen to their underlying primitives and participate in overload resolution
- expand the union type documentation with assignability and base-type member access examples
- document return-type validation and refine the control-flow union inference example in the language specification

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68c943aa1e30832fae4c431db8499103