### PR TITLE
Add char literal conversion coverage

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ConversionsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ConversionsTests.cs
@@ -40,6 +40,21 @@ public class ConversionsTests : CompilationTestBase
     }
 
     [Fact]
+    public void LiteralChar_To_Char_IsIdentity()
+    {
+        var compilation = CreateCompilation();
+        var charType = compilation.GetSpecialType(SpecialType.System_Char);
+        var literal = new LiteralTypeSymbol(charType, 'a', compilation);
+
+        var conversion = compilation.ClassifyConversion(literal, charType);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.True(conversion.IsIdentity);
+        Assert.False(conversion.IsAlias);
+    }
+
+    [Fact]
     public void LiteralInt_To_Long_IsImplicitNumeric()
     {
         var compilation = CreateCompilation();


### PR DESCRIPTION
## Summary
- add a conversion classification test that verifies char literals convert implicitly and identically to System.Char

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing failing tests Raven.CodeAnalysis.Tests.CollectionExpressionTests.ArrayCollectionExpressions_SpreadEnumerates and Raven.CodeAnalysis.Tests.Bugs.Issue84_MemberResolutionBug.CanResolveMember)*

------
https://chatgpt.com/codex/tasks/task_e_68c96e50a7b0832f81ce871e50d6be05