### PR TITLE
Fix nullable value-type codegen for conditional access

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -725,10 +725,15 @@ for both nullable reference types and nullable value types.
 
 ```raven
 var str = x?.ToString()
+
+let number: int? = 42
+let digits = number?.ToString() // "42"
 ```
 
 Here `str` is `string?`, and the call to `ToString` only occurs when `x` is not
-`null`.
+`null`. When the receiver is a nullable value type, the compiler unwraps the
+`System.Nullable<T>` storage, invokes the member on the underlying value, and
+wraps the result back into a nullable type.
 
 ### Enums
 

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs
@@ -23,6 +23,8 @@ internal sealed class NullableTypeSymbol : SourceSymbol, ITypeSymbol
 
     public bool IsType => true;
 
+    public bool IsValueType => UnderlyingType.IsValueType;
+
     public INamedTypeSymbol? BaseType { get; }
 
     public TypeKind TypeKind { get; }


### PR DESCRIPTION
## Summary
- ensure nullable symbols expose value-type identity when wrapping structs and resolve System.Nullable`1 from metadata during emit
- update invocation and local initialization paths to construct Nullable<T> instances and box underlying values before invoking members
- document null-conditional behavior for nullable value types in the language specification

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue --no-build

------
https://chatgpt.com/codex/tasks/task_e_68c974fe72f8832fa4ed5864c945f1e9