### PR TITLE
Fix nullable conversion scoring during overload resolution

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
@@ -123,6 +123,39 @@ public class NullableTypeTests : CompilationTestBase
     }
 
     [Fact]
+    public void ConsoleWriteLine_WithNullLiteral_Chooses_StringOverload()
+    {
+        var (compilation, tree) = CreateCompilation("System.Console.WriteLine(null)");
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var symbol = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;
+
+        var param = Assert.IsType<NullableTypeSymbol>(symbol.Parameters[0].Type);
+        Assert.Equal(SpecialType.System_String, param.UnderlyingType.SpecialType);
+
+        Assert.Empty(compilation.GetDiagnostics());
+    }
+
+    [Fact]
+    public void ConsoleWriteLine_WithNullableLocal_Chooses_StringOverload()
+    {
+        const string source = """
+            let value: string? = null
+            System.Console.WriteLine(value)
+            """;
+
+        var (compilation, tree) = CreateCompilation(source);
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var symbol = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;
+
+        var param = Assert.IsType<NullableTypeSymbol>(symbol.Parameters[0].Type);
+        Assert.Equal(SpecialType.System_String, param.UnderlyingType.SpecialType);
+
+        Assert.Empty(compilation.GetDiagnostics());
+    }
+
+    [Fact]
     public void UnionWithNull_ImplicitlyConvertsToNullable()
     {
         var compilation = CreateCompilation();


### PR DESCRIPTION
## Summary
- guard overload scoring against null argument types when evaluating candidates
- score lifted conversions using their underlying conversion so nullable parameters are preferred over broader overloads
- add regression coverage that exercises Console.WriteLine overload binding for null literals and nullable locals

## Testing
- dotnet build -v minimal
- dotnet test test/Raven.CodeAnalysis.Tests -v minimal --no-build --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.NamespaceResolutionTest.ConsoleDoesContainWriteLine_ShouldNot_ProduceDiagnostics"
- dotnet test test/Raven.CodeAnalysis.Tests -v minimal --no-build --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.TargetTypedExpressionTests.TargetTypedMethodBinding_UsesAssignmentType"
- dotnet test test/Raven.CodeAnalysis.Tests -v minimal --no-build --filter "FullyQualifiedName~NullableTypeTests"

------
https://chatgpt.com/codex/tasks/task_e_68c98a997cb0832faf8feab008145308