### PR TITLE
test: cover math wildcard import and repeated alias

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -148,6 +148,21 @@ public class ImportResolutionTest : DiagnosticTestBase
     }
 
     [Fact]
+    public void WildcardImport_MakesSystemMathMembersAvailable()
+    {
+        string testCode =
+            """
+            import System.Math.*
+
+            let pi = PI
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void NamespaceImportWithoutWildcard_Should_ProduceDiagnostic()
     {
         string testCode =


### PR DESCRIPTION
## Summary
- add a semantic test covering `import System.Math.*` to ensure static members like `PI` are available without diagnostics
- add a semantic alias test that repeats the same member alias declaration to ensure duplicate directives still expose the alias symbol

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~ImportResolutionTest.WildcardImport_MakesSystemMathMembersAvailable"`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~AliasResolutionTest.AliasDirective_RepeatedMethodAlias_FormsOverloadSet"`


------
https://chatgpt.com/codex/tasks/task_e_68c99c10735c832f805d6869e6e66a2d