### PR TITLE
fix: emit default for null value-type targets

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1172,7 +1172,17 @@ partial class BlockBinder : Binder
     {
         if (syntax.Kind == SyntaxKind.NullLiteralExpression)
         {
-            return new BoundLiteralExpression(BoundLiteralExpressionKind.NullLiteral, null!, Compilation.NullTypeSymbol);
+            ITypeSymbol? convertedType = null;
+            var targetType = GetTargetType(syntax);
+
+            if (targetType is not null)
+            {
+                var conversion = Compilation.ClassifyConversion(Compilation.NullTypeSymbol, targetType);
+                if (conversion.Exists)
+                    convertedType = targetType;
+            }
+
+            return new BoundLiteralExpression(BoundLiteralExpressionKind.NullLiteral, null!, Compilation.NullTypeSymbol, convertedType);
         }
 
         var value = syntax.Token.Value ?? syntax.Token.Text!;

--- a/src/Raven.CodeAnalysis/BoundTree/BoundExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundExpression.cs
@@ -15,7 +15,7 @@ abstract class BoundExpression : BoundNode
         Reason = reason;
     }
 
-    public ITypeSymbol? GetConvertedType()
+    public virtual ITypeSymbol? GetConvertedType()
     {
         return null;
     }

--- a/src/Raven.CodeAnalysis/BoundTree/BoundLiteralExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundLiteralExpression.cs
@@ -4,12 +4,17 @@ internal partial class BoundLiteralExpression : BoundExpression
 {
     public object Value { get; }
 
-    public BoundLiteralExpression(BoundLiteralExpressionKind kind, object value, ITypeSymbol type)
+    public ITypeSymbol? ConvertedType { get; }
+
+    public BoundLiteralExpression(BoundLiteralExpressionKind kind, object value, ITypeSymbol type, ITypeSymbol? convertedType = null)
         : base(type, null, BoundExpressionReason.None)
     {
         Kind = kind;
         Value = value;
+        ConvertedType = convertedType;
     }
+
+    public override ITypeSymbol? GetConvertedType() => ConvertedType;
 
     public BoundLiteralExpressionKind Kind { get; }
 }

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1513,7 +1513,15 @@ internal class ExpressionGenerator : Generator
 
             case BoundLiteralExpressionKind.NullLiteral:
                 {
-                    ILGenerator.Emit(OpCodes.Ldnull);
+                    var convertedType = literalExpression.GetConvertedType();
+                    if (convertedType is not null && convertedType.IsValueType)
+                    {
+                        EmitDefaultValue(convertedType);
+                    }
+                    else
+                    {
+                        ILGenerator.Emit(OpCodes.Ldnull);
+                    }
                     break;
                 }
 

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -503,7 +503,10 @@ public class Compilation
 
         if (source.TypeKind == TypeKind.Null)
         {
-            if (destination.TypeKind == TypeKind.Nullable || destination.TypeKind == TypeKind.Union)
+            if (destination.TypeKind == TypeKind.Nullable)
+                return Finalize(new Conversion(isImplicit: true, isReference: true));
+
+            if (destination is IUnionTypeSymbol unionDest && unionDest.Types.Any(t => t.TypeKind == TypeKind.Null))
                 return Finalize(new Conversion(isImplicit: true, isReference: true));
 
             return Conversion.None;

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/NullLiteralEmissionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/NullLiteralEmissionTests.cs
@@ -1,0 +1,213 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class NullLiteralEmissionTests
+{
+    private static readonly OpCode[] SingleByteOpCodes;
+    private static readonly OpCode[] MultiByteOpCodes;
+
+    static NullLiteralEmissionTests()
+    {
+        SingleByteOpCodes = new OpCode[0x100];
+        MultiByteOpCodes = new OpCode[0x100];
+
+        foreach (var field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetValue(null) is OpCode opcode)
+            {
+                var value = (ushort)opcode.Value;
+                if (value < 0x100)
+                {
+                    SingleByteOpCodes[value] = opcode;
+                }
+                else if ((value & 0xFF00) == 0xFE00)
+                {
+                    MultiByteOpCodes[value & 0xFF] = opcode;
+                }
+            }
+        }
+    }
+
+    private static IReadOnlyList<OpCode> GetOpCodes(MethodInfo method)
+    {
+        var body = method.GetMethodBody() ?? throw new InvalidOperationException("Method has no body.");
+        var il = body.GetILAsByteArray() ?? throw new InvalidOperationException("Method body has no IL.");
+        var opcodes = new List<OpCode>();
+
+        for (var i = 0; i < il.Length;)
+        {
+            OpCode opcode;
+            var code = il[i++];
+            if (code == 0xFE)
+            {
+                if (i >= il.Length)
+                    throw new InvalidOperationException("Unexpected end of IL stream when decoding multi-byte opcode.");
+
+                var second = il[i++];
+                opcode = MultiByteOpCodes[second];
+            }
+            else
+            {
+                opcode = SingleByteOpCodes[code];
+            }
+
+            if (opcode.Value == 0 && opcode != OpCodes.Nop)
+                throw new InvalidOperationException($"Unknown opcode: 0x{code:X2}");
+
+            opcodes.Add(opcode);
+
+            switch (opcode.OperandType)
+            {
+                case OperandType.InlineNone:
+                    break;
+                case OperandType.ShortInlineBrTarget:
+                case OperandType.ShortInlineI:
+                case OperandType.ShortInlineVar:
+                    i += 1;
+                    break;
+                case OperandType.InlineVar:
+                    i += 2;
+                    break;
+                case OperandType.InlineI:
+                case OperandType.InlineBrTarget:
+                case OperandType.InlineField:
+                case OperandType.InlineMethod:
+                case OperandType.InlineSig:
+                case OperandType.InlineString:
+                case OperandType.InlineTok:
+                case OperandType.InlineType:
+                    i += 4;
+                    break;
+                case OperandType.InlineI8:
+                case OperandType.InlineR:
+                    i += 8;
+                    break;
+                case OperandType.ShortInlineR:
+                    i += 4;
+                    break;
+                case OperandType.InlineSwitch:
+                    var count = BitConverter.ToInt32(il, i);
+                    i += 4 + (count * 4);
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported operand type: {opcode.OperandType}");
+            }
+        }
+
+        return opcodes;
+    }
+
+    [Fact]
+    public void NullableReference_ReturningNull_EmitsNull()
+    {
+        const string code = """
+class C {
+    Run() -> string? {
+        return null
+    }
+}
+""";
+
+        var tree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddSyntaxTrees(tree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("C", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+
+        var value = method.Invoke(instance, Array.Empty<object?>());
+
+        Assert.Null(value);
+
+        var opcodes = GetOpCodes(method);
+        Assert.Contains(OpCodes.Ldnull, opcodes);
+    }
+
+    [Fact]
+    public void NullableValue_ReturningNull_EmitsDefault()
+    {
+        const string code = """
+class C {
+    Run() -> int? {
+        return null
+    }
+}
+""";
+
+        var tree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddSyntaxTrees(tree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("C", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+
+        var value = method.Invoke(instance, Array.Empty<object?>());
+
+        Assert.Null(value);
+
+        var opcodes = GetOpCodes(method);
+        Assert.Contains(OpCodes.Initobj, opcodes);
+        Assert.DoesNotContain(OpCodes.Ldnull, opcodes);
+    }
+
+    [Fact]
+    public void NullableValue_LocalInitializedWithNull_ReturnsDefault()
+    {
+        const string code = """
+class C {
+    Run() -> int? {
+        let value: int? = null
+        return value
+    }
+}
+""";
+
+        var tree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddSyntaxTrees(tree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("C", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+
+        var value = method.Invoke(instance, Array.Empty<object?>());
+
+        Assert.Null(value);
+
+        var opcodes = GetOpCodes(method);
+        Assert.Contains(OpCodes.Initobj, opcodes);
+        Assert.DoesNotContain(OpCodes.Ldnull, opcodes);
+    }
+}


### PR DESCRIPTION
## Summary
- capture the target type when binding null literals so code generation can see implicit conversions
- allow bound literals to expose their converted type and emit default values for value-type null targets
- extend null literal emission tests to decode IL and ensure initobj is used for nullable value scenarios

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter NullLiteralEmissionTests`


------
https://chatgpt.com/codex/tasks/task_e_68c9b2fd2458832f9c2e784239c0422d