### PR TITLE
fix: apply implicit conversions and add coverage

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
@@ -38,7 +38,7 @@ class MethodBodyBinder : BlockBinder
         var unit = Compilation.GetSpecialType(SpecialType.System_Unit);
         if (!SymbolEqualityComparer.Default.Equals(_methodSymbol.ReturnType, unit))
         {
-            if (bound.Statements.LastOrDefault() is BoundExpressionStatement exprStmt && exprStmt.Expression.Type is ITypeSymbol t && !IsAssignable(_methodSymbol.ReturnType, t))
+            if (bound.Statements.LastOrDefault() is BoundExpressionStatement exprStmt && exprStmt.Expression.Type is ITypeSymbol t && !IsAssignable(_methodSymbol.ReturnType, t, out _))
             {
                 _diagnostics.ReportCannotConvertFromTypeToType(
                     t.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),


### PR DESCRIPTION
## Summary
- apply implicit conversions when binding local initializers, assignments, collection elements, and invocation arguments
- add conversion helper logic and teach the emitter to handle nullable value conversions without crashing
- expand conversion tests to cover implicit numeric casts and null assignments to nullable references

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: existing ImportResolutionTest diagnostic expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d081d144832fbe93f285ec575681