### PR TITLE
test: open base class in conversion test

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ConversionsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ConversionsTests.cs
@@ -125,7 +125,7 @@ public class ConversionsTests : CompilationTestBase
     public void DerivedType_To_BaseType_IsImplicitReferenceConversion()
     {
         var source = """
-        class Base {}
+        open class Base {}
         class Derived : Base {}
         """;
 


### PR DESCRIPTION
## Summary
- mark the base class as `open` in the implicit reference conversion test so derived types can inherit successfully

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter DerivedType_To_BaseType_IsImplicitReferenceConversion

------
https://chatgpt.com/codex/tasks/task_e_68ca59b00628832fb7d0d919a3bf244c