### PR TITLE
fix: allow identity conversion for nullable types

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -493,11 +493,9 @@ public class Compilation
         if (destination is LiteralTypeSymbol)
             return Conversion.None;
 
-        if (SymbolEqualityComparer.Default.Equals(source, destination) &&
-            source is not NullableTypeSymbol &&
-            destination is not NullableTypeSymbol)
+        if (SymbolEqualityComparer.Default.Equals(source, destination))
         {
-            // Identity conversion
+            // Identity conversion (including nullable references)
             return Finalize(new Conversion(isImplicit: true, isIdentity: true));
         }
 


### PR DESCRIPTION
## Summary
- treat identical type symbols as identity conversions so nullable references no longer fail classification

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue"


------
https://chatgpt.com/codex/tasks/task_e_68ca75563dc4832f9b8f212f2bfb2d6d