### PR TITLE
Add nullable overload resolver test

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
@@ -91,6 +91,36 @@ public sealed class OverloadResolverTests : CompilationTestBase
     }
 
     [Fact]
+    public void ResolveOverload_NullableArgumentPrefersNullableParameter()
+    {
+        var compilation = CreateInitializedCompilation();
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
+        var nullableArgumentType = new NullableTypeSymbol(
+            stringType,
+            compilation.Assembly,
+            null,
+            compilation.Assembly.GlobalNamespace,
+            Array.Empty<Location>());
+
+        var nullableParameterType = new NullableTypeSymbol(
+            stringType,
+            compilation.Assembly,
+            null,
+            compilation.Assembly.GlobalNamespace,
+            Array.Empty<Location>());
+
+        var nonNullable = CreateMethod(compilation, "NonNullable", stringType);
+        var nullable = CreateMethod(compilation, "Nullable", nullableParameterType);
+
+        var arguments = CreateArguments(new TestBoundExpression(nullableArgumentType));
+
+        var result = OverloadResolver.ResolveOverload([nonNullable, nullable], arguments, compilation);
+
+        Assert.Same(nullable, result);
+    }
+
+    [Fact]
     public void ResolveOverload_ReturnsNullWhenAmbiguous()
     {
         var compilation = CreateInitializedCompilation();


### PR DESCRIPTION
## Summary
- add coverage to OverloadResolverTests to ensure nullable arguments select nullable parameters

## Testing
- `dotnet format Raven.sln --include test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs`
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj -c Release` *(fails: Raven.CodeAnalysis.Semantics.Tests.ConversionsTests.Assignment_NullLiteral_To_NullableReference_PreservesConvertedType currently fails in the baseline suite and MSBuild stops due to TerminalLogger ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68ca91a22bc0832fa3f993b491253455