### PR TITLE
fix: treat primitive special types as equal

### DIFF
--- a/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
+++ b/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
@@ -32,6 +32,16 @@ public sealed class SymbolEqualityComparer : IEqualityComparer<ISymbol>
         if (x.Kind != y.Kind)
             return false;
 
+        if (x is ITypeSymbol typeX && y is ITypeSymbol typeY)
+        {
+            if (typeX.SpecialType != SpecialType.None &&
+                typeX.SpecialType == typeY.SpecialType &&
+                IsSimpleSpecialType(typeX.SpecialType))
+            {
+                return true;
+            }
+        }
+
         if (x is IParameterSymbol px && y is IParameterSymbol py)
         {
             if (px.RefKind != py.RefKind)
@@ -67,6 +77,19 @@ public sealed class SymbolEqualityComparer : IEqualityComparer<ISymbol>
         }
 
         return true;
+    }
+
+    private static bool IsSimpleSpecialType(SpecialType specialType)
+    {
+        return specialType is SpecialType.System_Boolean
+            or SpecialType.System_Char
+            or SpecialType.System_Double
+            or SpecialType.System_Int32
+            or SpecialType.System_Int64
+            or SpecialType.System_Object
+            or SpecialType.System_Single
+            or SpecialType.System_String
+            or SpecialType.System_Unit;
     }
 
     public int GetHashCode(ISymbol obj)


### PR DESCRIPTION
## Summary
- ensure SymbolEqualityComparer treats primitive special types from different assemblies as identical
- add helper to recognize built-in special types during equality checks

## Testing
- dotnet build
- dotnet test *(fails: Raven.Editor.Tests.ProgramTests.ShowCompletion_NoItems_DoesNotShowWindow)*

------
https://chatgpt.com/codex/tasks/task_e_68caa2b51c30832f8d7c144b73fdd59d