### PR TITLE
Align conditional access syntax with Roslyn

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -391,7 +391,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
             }
             else if (token.IsKind(SyntaxKind.QuestionToken)) // Conditional access
             {
-                var question = ReadToken();
+                var operatorToken = ReadToken();
                 ExpressionSyntax whenNotNull;
                 var next = PeekToken();
                 if (next.IsKind(SyntaxKind.DotToken))
@@ -426,7 +426,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
                     whenNotNull = MemberBindingExpression(missingDot, missingName);
                 }
 
-                expr = ConditionalAccessExpression(expr, question, whenNotNull);
+                expr = ConditionalAccessExpression(expr, operatorToken, whenNotNull);
             }
             else
             {

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -313,7 +313,7 @@
   </Node>
   <Node Name="ConditionalAccessExpression" Inherits="Expression">
     <Slot Name="Expression" Type="Expression" />
-    <Slot Name="QuestionToken" Type="Token" />
+    <Slot Name="OperatorToken" Type="Token" />
     <Slot Name="WhenNotNull" Type="Expression" />
   </Node>
   <Node Name="NameColon" Inherits="Node">


### PR DESCRIPTION
## Summary
- rename the ConditionalAccessExpression slot to OperatorToken so the syntax tree matches Roslyn's shape
- update the parser to use the renamed operator token when constructing conditional access expressions

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: ConversionsTests.Assignment_NullLiteral_To_NullableReference_PreservesConvertedType)*

------
https://chatgpt.com/codex/tasks/task_e_68cabdf53bd8832fa423b0c95b0e02fc