### PR TITLE
fix: make general sample compile

### DIFF
--- a/src/Raven.Compiler/samples/general.rav
+++ b/src/Raven.Compiler/samples/general.rav
@@ -3,21 +3,28 @@
  * * * */
 
 import System.*
+import System.Collections.Generic.List<>
 import System.Text.*
 
-let list = [1, 42, 3]
+let list = List<int>()
+list.Add(1)
+list.Add(42)
+list.Add(3)
 var i = 0
 
 let stringBuilder = StringBuilder()
 
-while i < list.Length {
+while i < list.Count {
     let x = list[i]
     stringBuilder.AppendLine(x.ToString())
     if x > 3 {
         Console.WriteLine("Hello, World!")
         list[i] = 42
     }
-    i = { i + 1; }
+    i = {
+        let next = i + 1
+        next
+    }
 }
 
 Console.WriteLine(stringBuilder.ToString())


### PR DESCRIPTION
## Summary
- switch the general sample to use `List<int>` so the mutation example type-checks
- keep the increment as a block expression that now produces the next index value

## Testing
- dotnet run --project src/Raven.Compiler --no-build -- src/Raven.Compiler/samples/general.rav
- dotnet test test/Raven.CodeAnalysis.Tests --filter Sample_should_load_into_compilation
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68cb16171ee0832f8378d5474970fda9