### PR TITLE
fix: surface ambiguous overload resolution

### DIFF
--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.cs
@@ -1,7 +1,45 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+
 namespace Raven.CodeAnalysis;
 
 // The methods in this partial class are generated from DiagnosticDescriptors.xml
 // using tools/DiagnosticsGenerator.
 public static partial class DiagnosticBagExtensions
 {
+    public static void ReportCallIsAmbiguous(
+        this DiagnosticBag diagnostics,
+        string methodName,
+        ImmutableArray<IMethodSymbol> candidates,
+        Location location)
+    {
+        var printableCandidates = candidates
+            .Where(static c => c is not null)
+            .Take(2)
+            .Select(c => c.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat))
+            .ToArray();
+
+        string first;
+        string second;
+
+        if (printableCandidates.Length >= 2)
+        {
+            first = printableCandidates[0];
+            second = printableCandidates[1];
+        }
+        else if (printableCandidates.Length == 1)
+        {
+            first = printableCandidates[0];
+            second = printableCandidates[0];
+        }
+        else
+        {
+            first = methodName;
+            second = methodName;
+        }
+
+        diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.CallIsAmbiguous, location, first, second));
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
@@ -30,7 +30,8 @@ public sealed class OverloadResolverTests : CompilationTestBase
 
         var result = OverloadResolver.ResolveOverload([identity, numeric], arguments, compilation);
 
-        Assert.Same(identity, result);
+        Assert.True(result.Success);
+        Assert.Same(identity, result.Method);
     }
 
     [Fact]
@@ -48,7 +49,8 @@ public sealed class OverloadResolverTests : CompilationTestBase
 
         var result = OverloadResolver.ResolveOverload([numeric, boxing], arguments, compilation);
 
-        Assert.Same(numeric, result);
+        Assert.True(result.Success);
+        Assert.Same(numeric, result.Method);
     }
 
     [Fact]
@@ -68,7 +70,8 @@ public sealed class OverloadResolverTests : CompilationTestBase
 
         var result = OverloadResolver.ResolveOverload([stream, obj], arguments, compilation);
 
-        Assert.Same(stream, result);
+        Assert.True(result.Success);
+        Assert.Same(stream, result.Method);
     }
 
     [Fact]
@@ -87,7 +90,8 @@ public sealed class OverloadResolverTests : CompilationTestBase
 
         var result = OverloadResolver.ResolveOverload([identity, numeric], arguments, compilation);
 
-        Assert.Same(identity, result);
+        Assert.True(result.Success);
+        Assert.Same(identity, result.Method);
     }
 
     [Fact]
@@ -117,7 +121,8 @@ public sealed class OverloadResolverTests : CompilationTestBase
 
         var result = OverloadResolver.ResolveOverload([nonNullable, nullable], arguments, compilation);
 
-        Assert.Same(nullable, result);
+        Assert.True(result.Success);
+        Assert.Same(nullable, result.Method);
     }
 
     [Fact]
@@ -135,7 +140,10 @@ public sealed class OverloadResolverTests : CompilationTestBase
 
         var result = OverloadResolver.ResolveOverload([toLong, toDouble], arguments, compilation);
 
-        Assert.Null(result);
+        Assert.True(result.IsAmbiguous);
+        Assert.False(result.Success);
+        Assert.Contains(toLong, result.AmbiguousCandidates, SymbolEqualityComparer.Default);
+        Assert.Contains(toDouble, result.AmbiguousCandidates, SymbolEqualityComparer.Default);
     }
 
     protected override MetadataReference[] GetMetadataReferences()


### PR DESCRIPTION
## Summary
- replace `OverloadResolver.ResolveOverload` to return an `OverloadResolutionResult` that tracks success versus ambiguity and keeps the tied candidates
- teach `BlockBinder` to surface `CallIsAmbiguous` diagnostics and create `BoundErrorExpression` nodes when overload resolution fails with ties
- add a diagnostic helper and refresh overload-resolution unit tests, including the nullable `Console.WriteLine(null)` scenario

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing ConversionsTests.Assignment_NullLiteral_To_NullableReference_PreservesConvertedType assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68cba9774130832f923f8eca3beccabf