### PR TITLE
feat: normalize union inference for control flow

### DIFF
--- a/docs/compiler/architecture/semantic-binding.md
+++ b/docs/compiler/architecture/semantic-binding.md
@@ -60,9 +60,12 @@ tree.
 ### Return type inference
 
 `ReturnTypeCollector` is a specialized `BoundTreeWalker` used by the binder to infer
-return types for blocks and lambdas when no explicit return type is declared.  It
+return types for blocks and lambdas when no explicit return type is declared. It
 collects the types from all `return` statements and, if a block ends with a final
-expression, includes that expression's type as an implicit return.  When multiple
-distinct types are observed, the collector produces a union type; otherwise the single
-type is returned.  The inferred union is used as the default type when assigning the
-result to a declaration without an explicit annotation.
+expression, includes that expression's type as an implicit return. The collected
+types are normalized before inference completes: nested unions flatten, literal
+members collapse into their underlying type when a broader branch is present, and a
+`null` branch paired with a single non-nullable type becomes that type's nullable
+form. When multiple distinct types remain, the collector produces a union; otherwise
+the single type is returned. The inferred (and normalized) result is used as the
+default type when assigning the result to a declaration without an explicit annotation.

--- a/docs/lang/spec/type-system.md
+++ b/docs/lang/spec/type-system.md
@@ -66,11 +66,12 @@ introduced.
 
 When a literal is assigned to a target whose type is inferred—such as a
 variable declaration without an explicit type annotation—the literal widens to
-its underlying primitive type. When inference gathers multiple literal values
-into a union (for example, via conditional branches), those literal members are
-preserved so the inferred union reports the exact set of constants that may
-flow to that location. This keeps single-literal inference in line with other
-languages that treat `let x = 1` as `int` while still modeling literal unions.
+its underlying primitive type. When inference gathers multiple results into a
+union (for example, via conditional branches), it normalizes the members so the
+union only reports distinct possibilities. Literal members collapse into their
+underlying type when a non-literal of that type also flows to the location,
+while disjoint literal values remain literal to preserve the precise set of
+constants.
 
 ```raven
 let yes: "yes" = "yes"

--- a/src/Raven.CodeAnalysis/Binder/ReturnTypeCollector.cs
+++ b/src/Raven.CodeAnalysis/Binder/ReturnTypeCollector.cs
@@ -100,9 +100,11 @@ internal static class ReturnTypeCollector
         {
             if (_types.Count == 0)
                 return null;
+
             if (_types.Count == 1)
-                return _types.First();
-            return new UnionTypeSymbol(_types, null, null, null, []);
+                return TypeSymbolNormalization.NormalizeForInference(_types.First());
+
+            return TypeSymbolNormalization.NormalizeUnion(_types);
         }
     }
 }

--- a/src/Raven.CodeAnalysis/BoundTree/BoundIfExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIfExpression.cs
@@ -1,4 +1,4 @@
-
+using System;
 using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis;
@@ -22,9 +22,12 @@ internal partial class BoundIfExpression : BoundExpression
         var thenType = thenBranch.Type;
         var elseType = elseBranch?.Type;
 
-        if (elseType is not null && !SymbolEqualityComparer.Default.Equals(elseType, thenType))
-            return new UnionTypeSymbol([thenType, elseType], null, null, null, []);
+        if (thenType is null)
+            return elseType ?? throw new InvalidOperationException("If expression must have a type.");
 
-        return thenType!;
+        if (elseType is null || SymbolEqualityComparer.Default.Equals(elseType, thenType))
+            return thenType;
+
+        return TypeSymbolNormalization.NormalizeUnion(new[] { thenType, elseType });
     }
 }

--- a/src/Raven.CodeAnalysis/TypeSymbolNormalization.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolNormalization.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal static class TypeSymbolNormalization
+{
+    public static ITypeSymbol NormalizeForInference(ITypeSymbol type)
+    {
+        if (type is IUnionTypeSymbol union)
+            return NormalizeUnion(union.Types);
+
+        if (type is LiteralTypeSymbol literal)
+            return literal.UnderlyingType;
+
+        return type;
+    }
+
+    public static ITypeSymbol NormalizeUnion(IEnumerable<ITypeSymbol> types)
+    {
+        var members = ImmutableArray.CreateBuilder<ITypeSymbol>();
+
+        foreach (var member in types)
+            AddNormalizedUnionMember(members, member);
+
+        var filtered = RemoveRedundantUnionMembers(members.ToImmutable());
+
+        if (TryCollapseToNullable(filtered, out var collapsed))
+            return NormalizeForInference(collapsed);
+
+        if (filtered.Length == 1)
+            return NormalizeForInference(filtered[0]);
+
+        return new UnionTypeSymbol(filtered, null, null, null, []);
+    }
+
+    private static void AddNormalizedUnionMember(ImmutableArray<ITypeSymbol>.Builder builder, ITypeSymbol member)
+    {
+        switch (member)
+        {
+            case IUnionTypeSymbol nested:
+                foreach (var nestedMember in nested.Types)
+                    AddNormalizedUnionMember(builder, nestedMember);
+                break;
+            case LiteralTypeSymbol literal:
+                builder.Add(literal);
+                break;
+            default:
+                builder.Add(NormalizeForInference(member));
+                break;
+        }
+    }
+
+    private static ImmutableArray<ITypeSymbol> RemoveRedundantUnionMembers(ImmutableArray<ITypeSymbol> members)
+    {
+        var filtered = ImmutableArray.CreateBuilder<ITypeSymbol>();
+        var hasNonLiteral = members.Any(member => member is not LiteralTypeSymbol);
+
+        foreach (var member in members)
+        {
+            var candidate = member;
+
+            if (member is LiteralTypeSymbol literal)
+            {
+                if (hasNonLiteral)
+                    candidate = NormalizeForInference(literal.UnderlyingType);
+
+                if (members.Any(other => !ReferenceEquals(other, member) &&
+                                         SymbolEqualityComparer.Default.Equals(other, literal.UnderlyingType)))
+                {
+                    continue;
+                }
+            }
+
+            if (candidate.TypeKind == TypeKind.Null &&
+                members.Any(other => !ReferenceEquals(other, member) && other is NullableTypeSymbol))
+            {
+                continue;
+            }
+
+            if (candidate is not NullableTypeSymbol &&
+                members.Any(other => !ReferenceEquals(other, member) &&
+                                     other is NullableTypeSymbol nullable &&
+                                     SymbolEqualityComparer.Default.Equals(nullable.UnderlyingType, candidate)))
+            {
+                continue;
+            }
+
+            if (!filtered.Any(existing => SymbolEqualityComparer.Default.Equals(existing, candidate)))
+                filtered.Add(candidate);
+        }
+
+        return filtered.ToImmutable();
+    }
+
+    private static bool TryCollapseToNullable(ImmutableArray<ITypeSymbol> members, out ITypeSymbol? result)
+    {
+        result = null;
+
+        if (members.Length != 2)
+            return false;
+
+        ITypeSymbol? nullMember = null;
+        ITypeSymbol? other = null;
+
+        foreach (var member in members)
+        {
+            if (member.TypeKind == TypeKind.Null)
+            {
+                if (nullMember is not null)
+                    return false;
+
+                nullMember = member;
+                continue;
+            }
+
+            if (other is not null)
+                return false;
+
+            other = member;
+        }
+
+        if (nullMember is null || other is null)
+            return false;
+
+        if (other is NullableTypeSymbol nullable)
+        {
+            result = nullable;
+            return true;
+        }
+
+        if (other.TypeKind == TypeKind.Error)
+            return false;
+
+        result = new NullableTypeSymbol(other, null, null, null, []);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared TypeSymbolNormalization helper that collapses redundant union members
- use the normalization when binding if expressions and return type inference
- extend literal flow tests and docs to cover nullable and mixed branch inference, including branch union collapsing rules

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,src/Raven.CodeAnalysis/BoundTree/BoundIfExpression.cs,src/Raven.CodeAnalysis/TypeSymbolNormalization.cs,src/Raven.CodeAnalysis/Binder/ReturnTypeCollector.cs,test/Raven.CodeAnalysis.Tests/Semantics/LiteralTypeFlowTests.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests (fails: missing method body / reference assemblies)
- dotnet test test/Raven.CodeAnalysis.Tests --filter LiteralTypeFlowTests

------
https://chatgpt.com/codex/tasks/task_e_68cbb83a1524832fbdb4e50097b497ef