### PR TITLE
Handle conversions from unions with value destinations

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -563,13 +563,13 @@ public class Compilation
             if (conversions.All(c => c.Exists))
             {
                 var isImplicit = conversions.All(c => c.IsImplicit);
-                var isReference = conversions.Any(c => c.IsReference);
-                var isBoxing = conversions.Any(c => c.IsBoxing);
                 var isAlias = conversions.Any(c => c.IsAlias);
+                var destinationIsValueType = destination.IsValueType;
+
                 return Finalize(new Conversion(
                     isImplicit: isImplicit,
-                    isReference: isReference,
-                    isBoxing: isBoxing,
+                    isReference: !destinationIsValueType,
+                    isUnboxing: destinationIsValueType,
                     isAlias: isAlias));
             }
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
@@ -221,4 +221,21 @@ public sealed class ClassifyConversionTests : CompilationTestBase
         Assert.True(conversion.IsImplicit);
         Assert.False(conversion.IsBoxing);
     }
+
+    [Fact]
+    public void UnionOfLiteralInts_ConvertsToInt()
+    {
+        var compilation = CreateCompilation();
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var fortyTwo = new LiteralTypeSymbol(intType, 42, compilation);
+        var thirteen = new LiteralTypeSymbol(intType, 13, compilation);
+        var union = new UnionTypeSymbol(new[] { fortyTwo, thirteen }, compilation.Assembly, null, null, []);
+
+        var conversion = compilation.ClassifyConversion(union, intType);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.True(conversion.IsUnboxing);
+        Assert.False(conversion.IsReference);
+    }
 }


### PR DESCRIPTION
## Summary
- mark conversions originating from union types as unboxing or reference casts based on the destination so value destinations can be materialized correctly
- add a regression test that verifies a union of literal integers converts implicitly to `int`

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --no-build --logger "console;verbosity=normal"` *(fails: ConversionsTests.Assignment_NullLiteral_To_NullableReference_PreservesConvertedType)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe9185fcc832fa7397a3c166d5284