### PR TITLE
fix: display unit keyword in diagnostics

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
@@ -22,7 +22,8 @@ public static partial class SymbolExtensions
         ["System.Double"] = "double",
         ["System.Decimal"] = "decimal",
         ["System.Char"] = "char",
-        ["System.Void"] = "void"
+        ["System.Void"] = "void",
+        ["System.Unit"] = "unit"
     };
 
     public static string ToDisplayStringKeywordAware(this ITypeSymbol typeSymbol, SymbolDisplayFormat format)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UnionConversionTests.cs
@@ -120,6 +120,25 @@ class Baz {
     }
 
     [Fact]
+    public void UnitType_UsesKeywordInDiagnostic()
+    {
+        var code = """
+func test(flag: bool) {
+    let value: int = if flag {
+        ()
+    } else {
+        1
+    }
+}
+""";
+
+        var verifier = CreateVerifier(code, [
+            new DiagnosticResult("RAV1504").WithAnySpan().WithArguments("unit | int", "int")
+        ]);
+        verifier.Verify();
+    }
+
+    [Fact]
     public void NumericLiteralNotInUnion_ProducesDiagnostic()
     {
         var code = "let x: \"true\" | 1 = 2";


### PR DESCRIPTION
## Summary
- display the unit type using the language keyword when formatting types for diagnostics
- add a regression test covering the unit/int union assignment diagnostic

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Assignment_NullLiteral_To_NullableReference_PreservesConvertedType currently fails prior to these changes)*
- dotnet test test/Raven.CodeAnalysis.Tests --no-build --filter UnitType_UsesKeywordInDiagnostic

------
https://chatgpt.com/codex/tasks/task_e_68cbede34700832faa4c42d2aa2e28bf