### PR TITLE
Fix pattern matching tests with discard designators

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
@@ -46,10 +46,14 @@ internal class PatternSyntaxParser : SyntaxParser
         var type = new NameSyntaxParser(this).ParseTypeName();
 
         // Optionally consume a variable designation
-        VariableDesignationSyntax? designation = null;
+        VariableDesignationSyntax designation;
         if (CanTokenBeIdentifier(PeekToken()))
         {
             designation = ParseDesignation();
+        }
+        else
+        {
+            designation = SingleVariableDesignation(MissingToken(SyntaxKind.IdentifierToken));
         }
 
         return DeclarationPattern(type, designation);


### PR DESCRIPTION
## Summary
- allow the pattern parser to synthesize a missing designation when no identifier is supplied
- bind declaration patterns without a variable to a discard designator and skip it in code generation
- ensure pattern emission tolerates arms that do not introduce locals

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter FullyQualifiedName~MatchExpressionTests -v minimal
- dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj -v minimal *(fails: ReturnStatementUnitTests expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4d7dc0dc832f9f07a80c2ed621f9