### PR TITLE
fix: support discard patterns in match

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -823,6 +823,8 @@ partial class BlockBinder : Binder
     {
         switch (pattern)
         {
+            case BoundDiscardPattern:
+                return true;
             case BoundDeclarationPattern { Designator: BoundDiscardDesignator } declaration:
             {
                 var declaredType = UnwrapAlias(declaration.DeclaredType);
@@ -844,6 +846,9 @@ partial class BlockBinder : Binder
     {
         switch (pattern)
         {
+            case BoundDiscardPattern:
+                remaining.Clear();
+                break;
             case BoundDeclarationPattern declaration:
                 RemoveMembersAssignableToPattern(remaining, declaration.DeclaredType);
                 break;

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -481,6 +481,13 @@ internal class ExpressionGenerator : Generator
     {
         scope ??= this;
 
+        if (pattern is BoundDiscardPattern)
+        {
+            ILGenerator.Emit(OpCodes.Pop);
+            ILGenerator.Emit(OpCodes.Ldc_I4_1);
+            return;
+        }
+
         if (pattern is BoundDeclarationPattern declarationPattern)
         {
             var typeSymbol = declarationPattern.Type;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -41,6 +41,24 @@ let result = match value {
     }
 
     [Fact]
+    public void MatchExpression_WithDiscardArm_BindsDesignation()
+    {
+        const string code = """
+let value: object = "hello"
+
+let result = match value {
+    string text => text
+    object obj => obj.ToString()
+    _ => ""
+}
+""";
+
+        var verifier = CreateVerifier(code);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void MatchExpression_WithGuard_UsesDesignation()
     {
         const string code = """


### PR DESCRIPTION
## Summary
- add a dedicated `BoundDiscardPattern` and bind `_` patterns to it
- treat discard arms as catch-alls during exhaustiveness checks and code generation
- cover the scenario with a semantic test that ensures `_` arms allow bindings

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "Assignment_NullLiteral_To_NullableReference_PreservesConvertedType"` *(fails: existing assertion expects BoundAssignmentStatement, actual BoundExpressionStatement)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9508d0a4832faf507498038a1a4b