### PR TITLE
Fix ConsoleSyntaxHighlighter to only underline actual diagnostics

### DIFF
--- a/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
+++ b/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
@@ -106,21 +106,11 @@ public static class ConsoleSyntaxHighlighter
 
         if (includeDiagnostics)
         {
-            var diagnostics = compilation.GetDiagnostics()
-                .Where(d => d.Location.SourceTree == node.SyntaxTree)
-                .ToList();
-
-            if (diagnostics.Count == 0)
+            foreach (var diagnostic in compilation.GetDiagnostics()
+                         .Where(d => d.Location.SourceTree == node.SyntaxTree))
             {
-                AddDiagnosticSpan(lineDiagnostics, lines, sourceText, 0, text.Length, DiagnosticSeverity.Error);
-            }
-            else
-            {
-                foreach (var diagnostic in diagnostics)
-                {
-                    AddDiagnosticSpan(lineDiagnostics, lines, sourceText, diagnostic.Location.SourceSpan.Start,
-                        diagnostic.Location.SourceSpan.End, diagnostic.Severity);
-                }
+                AddDiagnosticSpan(lineDiagnostics, lines, sourceText, diagnostic.Location.SourceSpan.Start,
+                    diagnostic.Location.SourceSpan.End, diagnostic.Severity);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure ConsoleSyntaxHighlighter only adds diagnostic underlines when diagnostics exist
- update syntax highlighter tests to cover both diagnostic and clean cases with realistic samples

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --no-build --filter ConsoleSyntaxHighlighter


------
https://chatgpt.com/codex/tasks/task_e_68ce8a268cb4832fad8c3c9ebab13888