### PR TITLE
Fix match arm newline retention

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -852,9 +852,9 @@ internal class ExpressionSyntaxParser : SyntaxParser
 
             var expression = new ExpressionSyntaxParser(this).ParseExpression();
 
-            arms.Add(MatchArm(pattern, whenClause, arrowToken, expression));
+            TryConsumeTerminator(out var terminatorToken);
 
-            TryConsumeTerminator(out _);
+            arms.Add(MatchArm(pattern, whenClause, arrowToken, expression, terminatorToken));
         }
         ExitParens();
 

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -304,6 +304,7 @@
     <Slot Name="WhenClause" Type="WhenClause" IsNullable="true" />
     <Slot Name="ArrowToken" Type="Token" />
     <Slot Name="Expression" Type="Expression" />
+    <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="WhenClause" Inherits="Node">
     <Slot Name="WhenKeyword" Type="Token" />


### PR DESCRIPTION
## Summary
- add a terminator token slot to match arm syntax nodes so newline trivia is preserved
- update the match arm parser to carry the consumed terminator token into the constructed node

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: missing reference assemblies in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cea7c2b9e8832fbd85c8dd020dcb4a