### PR TITLE
fix: correct IL for value-type match patterns

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class MatchExpressionCodeGenTests
+{
+    [Fact]
+    public void MatchExpression_WithValueTypeArm_EmitsAndRuns()
+    {
+        const string code = """
+class Program {
+    Run() -> string {
+        let value = 42
+        let result = match value {
+            string str => str
+            int i => i.ToString()
+            _ => "None"
+        }
+
+        return result
+    }
+
+    Main() -> unit {
+        return
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Program", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+        var value = (string)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal("42", value);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure match expressions box value-type scrutinees before evaluation and unbox via a temporary when checking declaration patterns
- clean up value-type pattern emission so the generated IL no longer leaves extra stack values behind
- add a regression test that exercises a match arm binding a value-type and verifies the result at runtime

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing ConversionsTests.Assignment_NullLiteral_To_NullableReference_PreservesConvertedType assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68ceac02a40c832fa1f564e1965c0202