### PR TITLE
refactor: stop emitting match fallback exception

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -476,12 +476,6 @@ internal class ExpressionGenerator : Generator
             ILGenerator.MarkLabel(nextArmLabel);
         }
 
-        var exceptionCtor = Compilation.CoreAssembly.GetType("System.InvalidOperationException", throwOnError: false).GetConstructor([Compilation.CoreAssembly.GetType("System.String")])
-            ?? throw new InvalidOperationException("InvalidOperationException(string) constructor not found.");
-        ILGenerator.Emit(OpCodes.Ldstr, "Non-exhaustive match expression.");
-        ILGenerator.Emit(OpCodes.Newobj, exceptionCtor);
-        ILGenerator.Emit(OpCodes.Throw);
-
         ILGenerator.MarkLabel(endLabel);
         ILGenerator.Emit(OpCodes.Ldloc, resultLocal);
     }


### PR DESCRIPTION
## Summary
- stop emitting an InvalidOperationException for non-exhaustive match expressions since the binder now requires a discard pattern

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: System.InvalidOperationException: Method 'main' does not have a method body.)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb912eefc832faa49cbd6f489b046