### PR TITLE
feat: validate match arm patterns

### DIFF
--- a/docs/compiler/diagnostics.md
+++ b/docs/compiler/diagnostics.md
@@ -406,3 +406,15 @@ match value {
     1 => 1 // RAV2101
 }
 ```
+
+## RAV2102: Match arm pattern is not valid
+The pattern's type cannot match the scrutinee's type.
+
+```raven
+let number: int = 0
+
+match number {
+    text: string => text // RAV2102
+    _ => ""
+}
+```

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -62,6 +62,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _spreadSourceMustBeEnumerable;
     private static DiagnosticDescriptor? _matchExpressionNotExhaustive;
     private static DiagnosticDescriptor? _matchExpressionArmUnreachable;
+    private static DiagnosticDescriptor? _matchExpressionArmPatternInvalid;
 
     /// <summary>
     /// RAV0021: Cannot apply indexing with [] to an expression of type '{0}'
@@ -791,6 +792,19 @@ internal static partial class CompilerDiagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// RAV2102: Pattern of type '{0}' is not valid for scrutinee of type '{1}'
+    /// </summary>
+    public static DiagnosticDescriptor MatchExpressionArmPatternInvalid => _matchExpressionArmPatternInvalid ??= DiagnosticDescriptor.Create(
+        id: "RAV2102",
+        title: "Match arm pattern is not valid",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Pattern of type '{0}' is not valid for scrutinee of type '{1}'",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public static DiagnosticDescriptor[] AllDescriptors => _allDescriptors ??=
     [
         CannotApplyIndexingWithToAnExpressionOfType,
@@ -849,6 +863,7 @@ internal static partial class CompilerDiagnostics
         SpreadSourceMustBeEnumerable,
         MatchExpressionNotExhaustive,
         MatchExpressionArmUnreachable,
+        MatchExpressionArmPatternInvalid,
     ];
 
     public static DiagnosticDescriptor? GetDescriptor(string diagnosticId) => diagnosticId switch
@@ -909,6 +924,7 @@ internal static partial class CompilerDiagnostics
         "RAV2022" => SpreadSourceMustBeEnumerable,
         "RAV2100" => MatchExpressionNotExhaustive,
         "RAV2101" => MatchExpressionArmUnreachable,
+        "RAV2102" => MatchExpressionArmPatternInvalid,
         _ => null
     };
 }

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -173,4 +173,7 @@ public static partial class DiagnosticBagExtensions
     public static void ReportMatchExpressionArmUnreachable(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.MatchExpressionArmUnreachable, location));
 
+    public static void ReportMatchExpressionArmPatternInvalid(this DiagnosticBag diagnostics, object? patternType, object? scrutineeType, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.MatchExpressionArmPatternInvalid, location, patternType, scrutineeType));
+
 }

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -198,4 +198,7 @@
   <Descriptor Id="RAV2101" Identifier="MatchExpressionArmUnreachable" Title="Match arm is unreachable"
     Message="Match expression arm is unreachable because a previous arm matches all cases"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV2102" Identifier="MatchExpressionArmPatternInvalid" Title="Match arm pattern is not valid"
+    Message="Pattern of type '{patternType}' is not valid for scrutinee of type '{scrutineeType}'"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
 </Diagnostics>

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
@@ -17,7 +17,6 @@ class Program {
     Run() -> string {
         let value = 42
         let result = match value {
-            string str => str
             int i => i.ToString()
             _ => "None"
         }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -198,5 +198,43 @@ let result = match state {
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void MatchExpression_WithIncompatiblePattern_ReportsDiagnostic()
+    {
+        const string code = """
+let value: int = 0
+
+let result = match value {
+    string text => text
+    _ => ""
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("string", "int")]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MatchExpression_WithUnionScrutineeAndIncompatiblePattern_ReportsDiagnostic()
+    {
+        const string code = """
+let value: "on" | "off" = "on"
+
+let result = match value {
+    bool flag => 1
+    _ => 0
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("bool", "\"on\" | \"off\"")]);
+
+        verifier.Verify();
+    }
 }
 


### PR DESCRIPTION
## Summary
- validate match expression patterns against the scrutinee type and surface a diagnostic when they can never match
- add semantic coverage for incompatible match arms and adjust the value-type codegen scenario
- document the new RAV2102 diagnostic and regenerate descriptors/extensions

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs,src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs,test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs,test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --filter MatchExpression_WithIncompatiblePattern_ReportsDiagnostic
- dotnet test test/Raven.CodeAnalysis.Tests *(fails in this environment because the runtime reference assemblies are unavailable for the code-generation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cec033b9fc832f80c4547c25e77eb7