### PR TITLE
fix: clarify match pattern diagnostic for literals

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -801,6 +801,7 @@ partial class BlockBinder : Binder
                 if (PatternCanMatch(scrutineeType, patternType))
                     return;
 
+                var patternDisplay = GetMatchPatternDisplay(patternType);
                 var location = patternSyntax switch
                 {
                     DeclarationPatternSyntax declarationSyntax => declarationSyntax.Type.GetLocation(),
@@ -808,7 +809,7 @@ partial class BlockBinder : Binder
                 };
 
                 _diagnostics.ReportMatchExpressionArmPatternInvalid(
-                    patternType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    patternDisplay,
                     scrutineeType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
                     location);
                 return;
@@ -842,6 +843,13 @@ partial class BlockBinder : Binder
             }
         }
     }
+
+    private static string GetMatchPatternDisplay(ITypeSymbol patternType)
+        => patternType switch
+        {
+            LiteralTypeSymbol literal => literal.Name,
+            _ => $"'{patternType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat)}'"
+        };
 
     private bool PatternCanMatch(ITypeSymbol scrutineeType, ITypeSymbol patternType)
     {

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -793,14 +793,14 @@ internal static partial class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
-    /// RAV2102: Pattern of type '{0}' is not valid for scrutinee of type '{1}'
+    /// RAV2102: Pattern {0} is not valid for scrutinee of type '{1}'
     /// </summary>
     public static DiagnosticDescriptor MatchExpressionArmPatternInvalid => _matchExpressionArmPatternInvalid ??= DiagnosticDescriptor.Create(
         id: "RAV2102",
         title: "Match arm pattern is not valid",
         description: "",
         helpLinkUri: "",
-        messageFormat: "Pattern of type '{0}' is not valid for scrutinee of type '{1}'",
+        messageFormat: "Pattern {0} is not valid for scrutinee of type '{1}'",
         category: "compiler",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -199,6 +199,6 @@
     Message="Match expression arm is unreachable because a previous arm matches all cases"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV2102" Identifier="MatchExpressionArmPatternInvalid" Title="Match arm pattern is not valid"
-    Message="Pattern of type '{patternType}' is not valid for scrutinee of type '{scrutineeType}'"
+    Message="Pattern {patternType} is not valid for scrutinee of type '{scrutineeType}'"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
 </Diagnostics>

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -213,7 +213,7 @@ let result = match value {
 
         var verifier = CreateVerifier(
             code,
-            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("string", "int")]);
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("'string'", "int")]);
 
         verifier.Verify();
     }
@@ -232,7 +232,26 @@ let result = match value {
 
         var verifier = CreateVerifier(
             code,
-            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("bool", "\"on\" | \"off\"")]);
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("'bool'", "\"on\" | \"off\"")]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MatchExpression_WithIncompatibleLiteralPattern_ReportsDiagnostic()
+    {
+        const string code = """
+let value: int = 0
+
+let result = match value {
+    "foo" => 1
+    _ => 0
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("\"foo\"", "int")]);
 
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- adjust the match pattern diagnostic to emit the pattern text directly, handling literal types without redundant wording
- regenerate the compiler diagnostics descriptor to reflect the new message
- update semantic tests to expect the revised wording and cover literal patterns

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --filter MatchExpression --no-build

------
https://chatgpt.com/codex/tasks/task_e_68cec6a8b064832fa3a3cfd343f49092