### PR TITLE
fix: use value equality for literal patterns

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
@@ -49,4 +49,49 @@ class Program {
         var value = (string)method.Invoke(instance, Array.Empty<object>())!;
         Assert.Equal("42", value);
     }
+
+    [Fact]
+    public void MatchExpression_WithStringLiteralPattern_MatchesExactValue()
+    {
+        const string code = """
+class Program {
+    Run() -> string {
+        let foo = match "foo" {
+            "foo" => "str"
+            _ => "None"
+        }
+
+        let empty = match "" {
+            "foo" => "str"
+            _ => "None"
+        }
+
+        return foo + "," + empty
+    }
+
+    Main() -> unit {
+        return
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Program", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+        var value = (string)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal("str,None", value);
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `BoundConstantPattern` node and bind literal-only patterns to it
- validate constant patterns against the scrutinee type and account for them when tracking match exhaustiveness
- emit literal-pattern checks via boxed value equality and box value types for `is` pattern evaluation
- add a regression codegen test ensuring string literal match arms do not match unrelated inputs

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: `Assignment_NullLiteral_To_NullableReference_PreservesConvertedType` also fails on main)*

------
https://chatgpt.com/codex/tasks/task_e_68cec96a1d98832f83300b0d81c8d16e