### PR TITLE
fix: clarify match pattern diagnostic

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -871,7 +871,7 @@ partial class BlockBinder : Binder
         => patternType switch
         {
             LiteralTypeSymbol literal => literal.Name,
-            _ => $"'{patternType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat)}'"
+            _ => $"for type '{patternType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat)}'"
         };
 
     private bool PatternCanMatch(ITypeSymbol scrutineeType, ITypeSymbol patternType)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -213,7 +213,7 @@ let result = match value {
 
         var verifier = CreateVerifier(
             code,
-            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("'string'", "int")]);
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("for type 'string'", "int")]);
 
         verifier.Verify();
     }
@@ -232,7 +232,7 @@ let result = match value {
 
         var verifier = CreateVerifier(
             code,
-            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("'bool'", "\"on\" | \"off\"")]);
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("for type 'bool'", "\"on\" | \"off\"")]);
 
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- update type pattern display text so match arm diagnostics mention "for type"

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: ConversionsTests.Assignment_NullLiteral_To_NullableReference_PreservesConvertedType due to Assert.IsType mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ced1301f80832f96730163940d6848