### PR TITLE
Update pattern matching and diagnostics documentation

### DIFF
--- a/docs/compiler/diagnostics.md
+++ b/docs/compiler/diagnostics.md
@@ -224,6 +224,13 @@ func log() {}
 let x = log() // RAV0815
 ```
 
+## RAV1000: Expression expected
+Parser expected an expression but encountered the end of a statement or block.
+
+```raven
+let value = // RAV1000
+```
+
 ## RAV1001: Identifier expected
 Parser expected an identifier but none was provided.
 
@@ -308,6 +315,14 @@ Multiple files contain top-level statements.
 print("hi") // RAV1013
 ```
 
+## RAV1014: Console application requires entry point
+Console applications must define a `func main` entry point.
+
+```raven
+// Console project without a main function
+// RAV1014: Program.Main entry point not found
+```
+
 ## RAV1501: No overload for method takes argument
 Called a method with a wrong number of arguments.
 
@@ -354,6 +369,13 @@ log().ToString() // RAV1526
 let x = if flag { return 1 } else { 2 } // RAV1900
 ```
 
+## RAV1901: If expression requires an else clause
+`if` expressions used for their value must include an `else` branch.
+
+```raven
+let value = if flag { 1 } // RAV1901
+```
+
 ## RAV1955: Non-invocable member cannot be used like a method
 Attempted to invoke a member that is not a method.
 
@@ -397,6 +419,32 @@ Alias directive targets an unsupported symbol.
 alias Bad = notatype // RAV2020
 ```
 
+## RAV2021: Invalid import target
+`use` directives can only import namespaces or types.
+
+```raven
+use System.Console.WriteLine // RAV2021
+```
+
+## RAV2022: Spread source must be enumerable
+Spread segments require an enumerable input.
+
+```raven
+let value = 42
+let items = [..value] // RAV2022
+```
+
+## RAV2100: Match expression is not exhaustive
+`match` expressions must cover every possible scrutinee value.
+
+```raven
+let state: "on" | "off" = "on"
+
+match state {
+    "on" => 1
+} // RAV2100 (missing "off")
+```
+
 ## RAV2101: Match arm is unreachable
 An earlier guardless catch-all arm prevents later arms from matching.
 
@@ -414,7 +462,7 @@ The pattern's type cannot match the scrutinee's type.
 let number: int = 0
 
 match number {
-    text: string => text // RAV2102
+    string text => text // RAV2102
     _ => ""
 }
 ```

--- a/docs/lang/proposals/patterns.md
+++ b/docs/lang/proposals/patterns.md
@@ -6,25 +6,20 @@ Raven supports pattern matching to destructure values and test for specific shap
 
 ## Pattern syntax
 
-Patterns align with Raven's style by placing the type after the bound identifier.
+Patterns align with Raven's type annotation style by placing the type before the
+bound identifier.
 
 ### Variable and type patterns
 
 ```raven
-if expr is x: int {      // bind only if expr is int
+if expr is int x {      // bind only if expr is int
     Console.WriteLine(x + 1)
 }
 ```
 
-The variable name precedes its optional type annotation.
-
-**Optional:**
-
-```raven
-if expr is x {           // bind with inferred type
-    Console.WriteLine(x)
-}
-```
+The type precedes the variable name. Future work may allow the type to be
+inferred (`if expr is value { ... }`), but the current implementation requires an
+explicit type annotation.
 
 ### Constant patterns
 
@@ -38,35 +33,35 @@ if expr is "yes" {
 }
 ```
 
-### Assignment statement
+### Typed discards
 
 ```raven
-if expr is x: 0 {
-    // matches only if expr == 0, binds x = 0
+if expr is int _ {
+    // matches any int while ignoring the value
 }
 ```
 
 ### Tuple patterns
 
 ```raven
-if expr is (x: int, y, 0) {
+if expr is (int x, y, 0) {
     // first element must be int (bound as x)
     // second element bound as y
     // third must equal literal 0
 }
 ```
 
-Each element follows the `name: type` convention.
+Each element follows the standard `type name` convention.
 
 ### Property patterns
 
 ```raven
-if expr is { name as n: string, age } {
+if expr is { name as string n, age } {
     Console.WriteLine("Name = ${n}, Age = ${age}")
 }
 ```
 
-Nested bindings use the same `name: type` layout. Use `as` to rename a field while binding its value.
+Nested bindings use the same `type name` layout. Use `as` to rename a field while binding its value.
 
 ## `match` expression
 
@@ -75,7 +70,7 @@ The `match` expression evaluates an input value against a sequence of patterns a
 ```raven
 let result = match value {
     0        => "zero"
-    x: int   => "an int ${x}"
+    int x    => "an int ${x}"
     _        => "other"
 }
 ```
@@ -89,7 +84,7 @@ Combine alternatives for a single arm using `or`, and add an expression guard wi
 ```raven
 match value {
     0 or 1            => "zero or one"
-    x: int when x > 0 => "positive int"
+    int x when x > 0  => "positive int"
     _                 => "other"
 }
 ```


### PR DESCRIPTION
## Summary
- align the language specification and pattern proposal with the type-first pattern syntax and `or` alternatives
- document match exhaustiveness requirements and refresh examples that use pattern bindings
- add coverage for missing diagnostics (RAV1000, RAV1014, RAV1901, RAV2021, RAV2022) and update match diagnostic samples

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ced6c3b2a4832f94dfc576838f7c34