### PR TITLE
Fix match diagnostics to report each missing union case

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -981,11 +981,14 @@ partial class BlockBinder : Binder
         if (remaining.Count == 0)
             return;
 
-        var missing = remaining.First();
-
-        _diagnostics.ReportMatchExpressionNotExhaustive(
-            missing.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-            matchExpression.GetLocation());
+        foreach (var missing in remaining
+            .Select(member => member.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat))
+            .OrderBy(name => name, StringComparer.Ordinal))
+        {
+            _diagnostics.ReportMatchExpressionNotExhaustive(
+                missing,
+                matchExpression.GetLocation());
+        }
     }
 
     private bool HasDefaultArm(ITypeSymbol scrutineeType, ImmutableArray<BoundMatchArm> arms)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -200,6 +200,27 @@ let result = match state {
     }
 
     [Fact]
+    public void MatchExpression_WithUnionScrutinee_MultipleMissingArmsReportDiagnostics()
+    {
+        const string code = """
+let state: "on" | "off" | "unknown" = "on"
+
+let result = match state {
+    "on" => 1
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            [
+                new DiagnosticResult("RAV2100").WithAnySpan().WithArguments("\"off\""),
+                new DiagnosticResult("RAV2100").WithAnySpan().WithArguments("\"unknown\""),
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void MatchExpression_WithIncompatiblePattern_ReportsDiagnostic()
     {
         const string code = """


### PR DESCRIPTION
## Summary
- report a diagnostic for every uncovered union member when a match expression is not exhaustive
- add a regression test that expects diagnostics for multiple missing union arms

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: CodeGeneratorTests emit failures in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced9c41e2c832faf5eb977451ca8f4