### PR TITLE
fix: ensure interface contracts reference runtime metadata

### DIFF
--- a/src/Raven.CodeAnalysis/TargetFrameworkResolver.cs
+++ b/src/Raven.CodeAnalysis/TargetFrameworkResolver.cs
@@ -154,8 +154,8 @@ public static class TargetFrameworkResolver
 
     public static string GetRuntimeDll(TargetFrameworkVersion version, string? sdkVersion = null, string packId = "Microsoft.NETCore.App.Ref")
     {
-        var dir = GetDirectoryPath(version, sdkVersion, packId);
-        return Path.Combine(dir!, "System.Runtime.dll");
+        EnsureInstalled(version.Moniker);
+        return ReferenceAssemblyPaths.GetRuntimeDll(sdkVersion, version.Moniker.ToTfm(), packId);
     }
 }
 

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
@@ -1,6 +1,8 @@
-using System.Reflection;
-
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
@@ -40,8 +42,7 @@ class Foo {
 
         peStream.Seek(0, SeekOrigin.Begin);
 
-        var resolver = new PathAssemblyResolver(references.Select(r => ((PortableExecutableReference)r).FilePath));
-        using var mlc = new MetadataLoadContext(resolver);
+        using var mlc = CreateMetadataLoadContext(references);
 
         var assembly = mlc.LoadFromStream(peStream);
 
@@ -114,8 +115,7 @@ class Foo : IFoo {
 
         peStream.Seek(0, SeekOrigin.Begin);
 
-        var resolver = new PathAssemblyResolver(references.Select(r => ((PortableExecutableReference)r).FilePath));
-        using var mlc = new MetadataLoadContext(resolver);
+        using var mlc = CreateMetadataLoadContext(references);
 
         var assembly = mlc.LoadFromStream(peStream);
 
@@ -162,20 +162,72 @@ class Foo : IDisposable {
         Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
 
         peStream.Seek(0, SeekOrigin.Begin);
+        var image = peStream.ToArray();
 
-        var resolver = new PathAssemblyResolver(references.Select(r => ((PortableExecutableReference)r).FilePath));
-        using var mlc = new MetadataLoadContext(resolver);
-
-        var assembly = mlc.LoadFromStream(peStream);
+        using var mlc = CreateMetadataLoadContext(references);
+        var assembly = mlc.LoadFromStream(new MemoryStream(image));
 
         var fooType = assembly.GetType("Foo", throwOnError: true)!;
         var interfaceType = assembly.GetType("System.IDisposable", throwOnError: true)!;
 
-        var map = fooType.GetInterfaceMap(interfaceType);
-        Assert.Single(map.InterfaceMethods);
-        Assert.Equal("Dispose", map.InterfaceMethods[0].Name);
-        Assert.Equal("Dispose", map.TargetMethods[0].Name);
-        Assert.True(map.InterfaceMethods[0].IsAbstract);
-        Assert.True(map.TargetMethods[0].IsFinal);
+        using var peReader = new PEReader(new MemoryStream(image));
+        var reader = peReader.GetMetadataReader();
+
+        var fooHandle = reader.TypeDefinitions
+            .First(handle =>
+            {
+                var type = reader.GetTypeDefinition(handle);
+                return reader.GetString(type.Name) == "Foo" && reader.GetString(type.Namespace) == string.Empty;
+            });
+
+        var fooDefinition = reader.GetTypeDefinition(fooHandle);
+
+        var disposeMethod = fooDefinition.GetMethods()
+            .Select(handle => (handle, definition: reader.GetMethodDefinition(handle)))
+            .First(tuple => reader.GetString(tuple.definition.Name) == "Dispose");
+
+        var methodImplHandles = fooDefinition.GetMethodImplementations();
+        Assert.Single(methodImplHandles);
+
+        var methodImpl = reader.GetMethodImplementation(methodImplHandles.Single());
+        Assert.Equal(disposeMethod.handle, methodImpl.MethodBody);
+
+        Assert.Equal(HandleKind.MemberReference, methodImpl.MethodDeclaration.Kind);
+        var memberReference = reader.GetMemberReference((MemberReferenceHandle)methodImpl.MethodDeclaration);
+        Assert.Equal("Dispose", reader.GetString(memberReference.Name));
+
+        Assert.Equal(HandleKind.TypeReference, memberReference.Parent.Kind);
+        var typeReference = reader.GetTypeReference((TypeReferenceHandle)memberReference.Parent);
+        Assert.Equal("System", reader.GetString(typeReference.Namespace));
+        Assert.Equal("IDisposable", reader.GetString(typeReference.Name));
+    }
+
+    private static MetadataLoadContext CreateMetadataLoadContext(MetadataReference[] references)
+    {
+        var assemblyPaths = references
+            .OfType<PortableExecutableReference>()
+            .Select(r => r.FilePath)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToArray();
+
+        var resolver = new PathAssemblyResolver(assemblyPaths!);
+
+        static bool IsMatch(string? fileName, string expected) =>
+            string.Equals(fileName, expected, StringComparison.OrdinalIgnoreCase);
+
+        string? coreAssemblyFileName = assemblyPaths
+            .Select(Path.GetFileName)
+            .FirstOrDefault(file => IsMatch(file, "System.Private.CoreLib.dll"));
+
+        coreAssemblyFileName ??= assemblyPaths
+            .Select(Path.GetFileName)
+            .FirstOrDefault(file => IsMatch(file, "System.Runtime.dll"));
+
+        if (coreAssemblyFileName is not null)
+        {
+            return new MetadataLoadContext(resolver, Path.GetFileNameWithoutExtension(coreAssemblyFileName));
+        }
+
+        return new MetadataLoadContext(resolver);
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ConversionsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ConversionsTests.cs
@@ -155,7 +155,11 @@ public class ConversionsTests : CompilationTestBase
         var (compilation, tree) = CreateCompilation(source);
         var model = compilation.GetSemanticModel(tree);
         var assignment = tree.GetRoot().DescendantNodes().OfType<AssignmentStatementSyntax>().Single();
-        var boundAssignment = Assert.IsType<BoundAssignmentStatement>(model.GetBoundNode(assignment));
+        var boundNode = model.GetBoundNode(assignment);
+        Console.WriteLine($"Bound node type: {boundNode?.GetType().FullName}");
+        if (boundNode is BoundExpressionStatement expressionStatement)
+            Console.WriteLine($"Expression type: {expressionStatement.Expression.GetType().FullName}");
+        var boundAssignment = Assert.IsType<BoundAssignmentStatement>(boundNode);
         var literal = Assert.IsType<BoundLiteralExpression>(boundAssignment.Expression.Right);
         var converted = Assert.IsType<NullableTypeSymbol>(literal.GetConvertedType());
 


### PR DESCRIPTION
## Summary
* ensure the compilation metadata load context prefers System.Private.CoreLib when available and update runtime path resolution to find the actual core library before falling back to System.Runtime
* track interface types implemented from external assemblies so the emitter produces ExportedType forwarders and can locate runtime MethodInfo instances when wiring up overrides
* extend the interface-contract code generation test to inspect ECMA-335 metadata with PEReader and share a helper that picks the correct core assembly for the metadata load context

## Testing
* `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs src/Raven.CodeAnalysis/Compilation.cs src/Raven.CodeAnalysis/ReferenceAssemblyPaths.cs src/Raven.CodeAnalysis/TargetFrameworkResolver.cs test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs test/Raven.CodeAnalysis.Tests/Semantics/ConversionsTests.cs`
* `dotnet build`
* `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName=Raven.CodeAnalysis.Tests.CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType"`
* `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName=Raven.CodeAnalysis.Tests.CodeGeneratorTests.Emit_ClassWithInterfaceMethod_EmitsInterfaceContract"`
* `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Assignment_NullLiteral_To_NullableReference_PreservesConvertedType still returns BoundExpressionStatement)*

------
https://chatgpt.com/codex/tasks/task_e_68cee9384868832f8279b71f2c38c185