### PR TITLE
fix: ensure named constructors supply implicit receivers

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -16,11 +16,19 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             yield return (T)node.Accept(this)!;
     }
 
-    public virtual IEnumerable<T> VisitSymbolList<T>(IEnumerable<ISymbol> symbols)
+    public virtual IEnumerable<T> VisitSymbolList<T>(IEnumerable<ISymbol?> symbols)
         where T : ISymbol
     {
         foreach (var symbol in symbols)
+        {
+            if (symbol is null)
+            {
+                yield return (T)symbol!;
+                continue;
+            }
+
             yield return (T)VisitSymbol(symbol)!;
+        }
     }
 
     public virtual BoundStatement VisitStatement(BoundStatement statement)
@@ -69,10 +77,11 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
         return @namespace;
     }
 
-    public virtual ISymbol VisitSymbol(ISymbol symbol)
+    public virtual ISymbol? VisitSymbol(ISymbol? symbol)
     {
         return symbol switch
         {
+            null => null,
             INamespaceSymbol ns => VisitNamespace(ns),
             ITypeSymbol type => VisitType(type),
             IMethodSymbol method => VisitMethod(method),


### PR DESCRIPTION
## Summary
- ensure `NamedConstructorRewriter` injects the implicit `self` receiver for member accesses, assignments, and invocations and preserves the original block expression unit type
- add a code generation regression test that exercises a named constructor using implicit receivers to verify emission succeeds and the resulting factory method works at runtime

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing failure in ConversionsTests and MSBuild TerminalLogger error)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc11df474832faf06b3dd37395256