### PR TITLE
fix: diagnose missing let keyword in fields

### DIFF
--- a/docs/compiler/diagnostics.md
+++ b/docs/compiler/diagnostics.md
@@ -276,6 +276,15 @@ type C {}
 alias x = int // RAV1006
 ```
 
+## RAV1007: Field declaration requires 'let' or 'var'
+Fields must specify `let` or `var` when declaring storage in a type.
+
+```raven
+class Foo {
+    name: string = "" // RAV1007
+}
+```
+
 ## RAV1009: Unrecognized escape sequence
 String or character literal contains an invalid escape.
 

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -40,6 +40,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _duplicateModifier;
     private static DiagnosticDescriptor? _importDirectiveOutOfOrder;
     private static DiagnosticDescriptor? _aliasDirectiveOutOfOrder;
+    private static DiagnosticDescriptor? _fieldDeclarationRequiresLetOrVar;
     private static DiagnosticDescriptor? _unrecognizedEscapeSequence;
     private static DiagnosticDescriptor? _newlineInConstant;
     private static DiagnosticDescriptor? _fileScopedCodeOutOfOrder;
@@ -507,6 +508,19 @@ internal static partial class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
+    /// RAV1007: Field declarations must start with 'let' or 'var'
+    /// </summary>
+    public static DiagnosticDescriptor FieldDeclarationRequiresLetOrVar => _fieldDeclarationRequiresLetOrVar ??= DiagnosticDescriptor.Create(
+        id: "RAV1007",
+        title: "Field declaration requires 'let' or 'var'",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Field declarations must start with 'let' or 'var'",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// RAV1009: Unrecognized escape sequence
     /// </summary>
     public static DiagnosticDescriptor UnrecognizedEscapeSequence => _unrecognizedEscapeSequence ??= DiagnosticDescriptor.Create(
@@ -841,6 +855,7 @@ internal static partial class CompilerDiagnostics
         DuplicateModifier,
         ImportDirectiveOutOfOrder,
         AliasDirectiveOutOfOrder,
+        FieldDeclarationRequiresLetOrVar,
         UnrecognizedEscapeSequence,
         NewlineInConstant,
         FileScopedCodeOutOfOrder,
@@ -902,6 +917,7 @@ internal static partial class CompilerDiagnostics
         "RAV1004" => DuplicateModifier,
         "RAV1005" => ImportDirectiveOutOfOrder,
         "RAV1006" => AliasDirectiveOutOfOrder,
+        "RAV1007" => FieldDeclarationRequiresLetOrVar,
         "RAV1009" => UnrecognizedEscapeSequence,
         "RAV1010" => NewlineInConstant,
         "RAV1011" => FileScopedCodeOutOfOrder,

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -107,6 +107,9 @@ public static partial class DiagnosticBagExtensions
     public static void ReportAliasDirectiveOutOfOrder(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.AliasDirectiveOutOfOrder, location));
 
+    public static void ReportFieldDeclarationRequiresLetOrVar(this DiagnosticBag diagnostics, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.FieldDeclarationRequiresLetOrVar, location));
+
     public static void ReportUnrecognizedEscapeSequence(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.UnrecognizedEscapeSequence, location));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -120,6 +120,10 @@
     Title="Alias directive out of order"
     Message="Alias directives must appear before member declarations" Category="compiler"
     Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV1007" Identifier="FieldDeclarationRequiresLetOrVar"
+    Title="Field declaration requires 'let' or 'var'"
+    Message="Field declarations must start with 'let' or 'var'" Category="compiler"
+    Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV1009" Identifier="UnrecognizedEscapeSequence"
     Title="Unrecognized escape sequence" Message="Unrecognized escape sequence"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -137,6 +137,30 @@ internal class TypeDeclarationParser : SyntaxParser
         }
         else
         {
+            if (keywordOrIdentifier.IsKind(SyntaxKind.IdentifierToken) && PeekToken(1).Kind == SyntaxKind.ColonToken)
+            {
+                using var checkpoint = CreateCheckpoint();
+                ReadToken();
+                _ = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
+
+                var nextToken = PeekToken();
+
+                bool looksLikeField = nextToken.Kind is SyntaxKind.EqualsToken
+                    or SyntaxKind.CommaToken
+                    or SyntaxKind.SemicolonToken
+                    or SyntaxKind.CloseBraceToken
+                    or SyntaxKind.EndOfFileToken
+                    or SyntaxKind.LineFeedToken
+                    or SyntaxKind.CarriageReturnToken
+                    or SyntaxKind.CarriageReturnLineFeedToken
+                    or SyntaxKind.NewLineToken;
+
+                if (looksLikeField)
+                {
+                    return ParseFieldDeclarationSyntax(modifiers);
+                }
+            }
+
             if (keywordOrIdentifier.IsKind(SyntaxKind.InitKeyword))
             {
                 return ParseConstructorDeclaration(modifiers, keywordOrIdentifier);
@@ -470,16 +494,46 @@ internal class TypeDeclarationParser : SyntaxParser
 
     private VariableDeclarationSyntax? ParseVariableDeclarationSyntax()
     {
-        var letOrVarKeyword = ReadToken();
+        var firstToken = ReadToken();
 
+        SyntaxToken letOrVarKeyword;
         SyntaxToken identifier;
-        if (CanTokenBeIdentifier(PeekToken()))
+
+        if (firstToken.Kind is SyntaxKind.LetKeyword or SyntaxKind.VarKeyword)
         {
-            identifier = ReadIdentifierToken();
+            letOrVarKeyword = firstToken;
+
+            if (CanTokenBeIdentifier(PeekToken()))
+            {
+                identifier = ReadIdentifierToken();
+            }
+            else
+            {
+                identifier = ExpectToken(SyntaxKind.IdentifierToken);
+            }
         }
         else
         {
-            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+            AddDiagnostic(
+                DiagnosticInfo.Create(
+                    CompilerDiagnostics.FieldDeclarationRequiresLetOrVar,
+                    GetSpanOfLastToken()));
+
+            letOrVarKeyword = MissingToken(SyntaxKind.LetKeyword);
+
+            if (CanTokenBeIdentifier(firstToken))
+            {
+                identifier = ToIdentifierToken(firstToken);
+                UpdateLastToken(identifier);
+            }
+            else if (CanTokenBeIdentifier(PeekToken()))
+            {
+                identifier = ReadIdentifierToken();
+            }
+            else
+            {
+                identifier = ExpectToken(SyntaxKind.IdentifierToken);
+            }
         }
 
         EqualsValueClauseSyntax? initializer = null;

--- a/test/Raven.CodeAnalysis.Tests/Bugs/FieldDeclarationMissingLetOrVarTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/FieldDeclarationMissingLetOrVarTests.cs
@@ -1,0 +1,22 @@
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class FieldDeclarationMissingLetOrVarTests : DiagnosticTestBase
+{
+    [Fact]
+    public void FieldWithoutLetOrVar_ReportsDiagnostic()
+    {
+        const string code = """
+        class Foo {
+            name: string = ""
+        }
+        """;
+
+        var verifier = CreateVerifier(code, [
+            new DiagnosticResult("RAV1007").WithAnySpan(),
+        ]);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- ensure field declarations fall back to a missing `let` token and report RAV1007
- update generated diagnostic metadata and documentation for the new error
- add a regression test covering a field without `let`/`var`

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Emit_ShouldAlwaysIncludeUnitType – Method 'main' does not have a method body)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd2957a10832f825c941f88494cf7