### PR TITLE
Allow constructors to assign getter-only auto properties

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs
@@ -42,4 +42,80 @@ public class PropertyBindingTests : DiagnosticTestBase
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void GetterOnlyAutoProperty_AssignableInConstructor()
+    {
+        string testCode =
+            """
+            class Person {
+                public Name: string { get; }
+                init (name: string) {
+                    Name = name;
+                }
+            }
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void GetterOnlyAutoProperty_AssignableInNamedConstructor()
+    {
+        string testCode =
+            """
+            class Person {
+                public Name: string { get; }
+                public init WithName(name: string) {
+                    self.Name = name;
+                }
+            }
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void GetterOnlyAutoProperty_AssignmentOutsideConstructor_ProducesDiagnostic()
+    {
+        string testCode =
+            """
+            class Person {
+                public Name: string { get; }
+                public SetName(name: string) -> unit {
+                    Name = name;
+                }
+            }
+            """;
+
+        var verifier = CreateVerifier(testCode,
+            [new DiagnosticResult("RAV0200").WithSpan(6, 9, 6, 13).WithArguments("Name")]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void GetterOnlyPropertyWithAccessorBody_AssignmentInConstructor_ProducesDiagnostic()
+    {
+        string testCode =
+            """
+            class Person {
+                public Name: string {
+                    get => ""
+                }
+                init (name: string) {
+                    Name = name;
+                }
+            }
+            """;
+
+        var verifier = CreateVerifier(testCode,
+            [new DiagnosticResult("RAV0200").WithSpan(8, 9, 8, 13).WithArguments("Name")]);
+
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- allow constructor contexts to assign getter-only auto-properties by redirecting writes to their backing fields and emitting diagnostics elsewhere
- add tests covering constructor, named constructor, and accessor-body scenarios for getter-only auto-properties

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Raven.CodeAnalysis.Tests.CodeGeneratorTests.Emit_ShouldAlwaysIncludeUnitType due to `Method 'main' does not have a method body`)*

------
https://chatgpt.com/codex/tasks/task_e_68d0474ca59c832f999679622574d79b