### PR TITLE
feat: add basic virtual method support

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -53,6 +53,23 @@ internal class MethodGenerator
         {
             attributes |= MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.NewSlot;
         }
+        else
+        {
+            if (MethodSymbol.IsAbstract)
+            {
+                attributes |= MethodAttributes.Abstract | MethodAttributes.Virtual | MethodAttributes.NewSlot;
+            }
+            else if (MethodSymbol.IsVirtual)
+            {
+                attributes |= MethodAttributes.Virtual;
+
+                if (!MethodSymbol.IsOverride)
+                    attributes |= MethodAttributes.NewSlot;
+            }
+
+            if (MethodSymbol.IsOverride && MethodSymbol.IsSealed)
+                attributes |= MethodAttributes.Final;
+        }
 
         if (MethodSymbol.IsStatic && !isInterfaceMethod)
             attributes |= MethodAttributes.Static;

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -30,6 +30,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _unassignedOutParameter;
     private static DiagnosticDescriptor? _typeRequiresTypeArguments;
     private static DiagnosticDescriptor? _cannotInheritFromSealedType;
+    private static DiagnosticDescriptor? _overrideMemberNotFound;
     private static DiagnosticDescriptor? _nullableTypeInUnion;
     private static DiagnosticDescriptor? _typeNameDoesNotExistInType;
     private static DiagnosticDescriptor? _cannotAssignVoidToAnImplicitlyTypedVariable;
@@ -373,6 +374,19 @@ internal static partial class CompilerDiagnostics
         description: "",
         helpLinkUri: "",
         messageFormat: "Type '{0}' is sealed and cannot be inherited",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// RAV0307: No virtual member named '{0}' was found in the base type to override
+    /// </summary>
+    public static DiagnosticDescriptor OverrideMemberNotFound => _overrideMemberNotFound ??= DiagnosticDescriptor.Create(
+        id: "RAV0307",
+        title: "No virtual member to override",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "No virtual member named '{0}' was found in the base type to override",
         category: "compiler",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -845,6 +859,7 @@ internal static partial class CompilerDiagnostics
         UnassignedOutParameter,
         TypeRequiresTypeArguments,
         CannotInheritFromSealedType,
+        OverrideMemberNotFound,
         NullableTypeInUnion,
         TypeNameDoesNotExistInType,
         CannotAssignVoidToAnImplicitlyTypedVariable,
@@ -907,6 +922,7 @@ internal static partial class CompilerDiagnostics
         "RAV0269" => UnassignedOutParameter,
         "RAV0305" => TypeRequiresTypeArguments,
         "RAV0306" => CannotInheritFromSealedType,
+        "RAV0307" => OverrideMemberNotFound,
         "RAV0400" => NullableTypeInUnion,
         "RAV0426" => TypeNameDoesNotExistInType,
         "RAV0815" => CannotAssignVoidToAnImplicitlyTypedVariable,

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -77,6 +77,9 @@ public static partial class DiagnosticBagExtensions
     public static void ReportCannotInheritFromSealedType(this DiagnosticBag diagnostics, object? typeName, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.CannotInheritFromSealedType, location, typeName));
 
+    public static void ReportOverrideMemberNotFound(this DiagnosticBag diagnostics, object? memberName, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.OverrideMemberNotFound, location, memberName));
+
     public static void ReportNullableTypeInUnion(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.NullableTypeInUnion, location));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -85,6 +85,10 @@
     Title="Cannot inherit from sealed type"
     Message="Type '{typeName}' is sealed and cannot be inherited" Category="compiler"
     Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV0307" Identifier="OverrideMemberNotFound"
+    Title="No virtual member to override"
+    Message="No virtual member named '{memberName}' was found in the base type to override"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0400" Identifier="NullableTypeInUnion"
     Title="Nullable type not allowed in union"
     Message="Nullable types are not allowed in union types" Category="compiler" Severity="Error"

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
@@ -8,7 +8,7 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
 {
     private IEnumerable<SourceParameterSymbol> _parameters;
 
-    public SourceMethodSymbol(string name, ITypeSymbol returnType, ImmutableArray<SourceParameterSymbol> parameters, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations, SyntaxReference[] declaringSyntaxReferences, bool isStatic = true, MethodKind methodKind = MethodKind.Ordinary)
+    public SourceMethodSymbol(string name, ITypeSymbol returnType, ImmutableArray<SourceParameterSymbol> parameters, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations, SyntaxReference[] declaringSyntaxReferences, bool isStatic = true, MethodKind methodKind = MethodKind.Ordinary, bool isVirtual = false, bool isOverride = false)
             : base(SymbolKind.Method, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences)
     {
         ReturnType = returnType;
@@ -17,6 +17,9 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
         IsStatic = isStatic;
 
         MethodKind = methodKind;
+
+        IsOverride = isOverride;
+        IsVirtual = isVirtual || isOverride;
     }
 
     public ITypeSymbol ReturnType { get; }
@@ -55,5 +58,9 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
 
     public bool IsVirtual { get; }
 
+    public IMethodSymbol? OverriddenMethod { get; private set; }
+
     public void SetParameters(IEnumerable<SourceParameterSymbol> parameters) => _parameters = parameters;
+
+    internal void SetOverriddenMethod(IMethodSymbol overriddenMethod) => OverriddenMethod = overriddenMethod;
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -117,6 +117,7 @@ internal class TypeDeclarationParser : SyntaxParser
                      SyntaxKind.StaticKeyword or
                      SyntaxKind.AbstractKeyword or
                      SyntaxKind.SealedKeyword or
+                     SyntaxKind.VirtualKeyword or
                      SyntaxKind.OpenKeyword or
                      SyntaxKind.OverrideKeyword)
             {

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -48,6 +48,7 @@
   <TokenKind Name="AbstractKeyword" Text="abstract" IsReservedWord="false" />
   <TokenKind Name="SealedKeyword" Text="sealed" IsReservedWord="false" />
   <TokenKind Name="OpenKeyword" Text="open" IsReservedWord="false" />
+  <TokenKind Name="VirtualKeyword" Text="virtual" IsReservedWord="false" />
   <TokenKind Name="OverrideKeyword" Text="override" IsReservedWord="false" />
   <TokenKind Name="GetKeyword" Text="get" IsReservedWord="false" />
   <TokenKind Name="SetKeyword" Text="set" IsReservedWord="false" />

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/VirtualMethodTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/VirtualMethodTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class VirtualMethodTests
+{
+    [Fact]
+    public void VirtualOverride_DispatchesThroughBaseReference()
+    {
+        const string code = """
+open class Animal {
+    public virtual Speak() -> string {
+        return "base"
+    }
+}
+
+class Dog : Animal {
+    public override Speak() -> string {
+        return "woof"
+    }
+}
+
+class Program {
+    Run() -> string {
+        let animal: Animal = Dog()
+        return animal.Speak()
+    }
+
+    Main() -> unit {
+        return
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Program", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var runMethod = type.GetMethod("Run", BindingFlags.Instance | BindingFlags.Public)!;
+
+        var value = (string)runMethod.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal("woof", value);
+    }
+}


### PR DESCRIPTION
## Summary
- bind `virtual`/`override` modifiers onto source methods, track overridden targets, and surface a diagnostic when no virtual base member exists
- emit appropriate method attributes and define method overrides so runtime dispatch honors virtual overrides
- add the `virtual` keyword to the lexer/parser and cover the basic dispatch scenario with a new codegen test
- left advanced cases (e.g., virtual properties, sealed overrides, interface edge cases) untouched for follow-up

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: PropertyTests currently failing; see console output)*

------
https://chatgpt.com/codex/tasks/task_e_68d07245c414832f9b96489d37362aa5