### PR TITLE
feat: support abstract classes

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -1142,8 +1142,9 @@ available on interfaces, where accessors remain abstract.
 
 ### Class inheritance
 
-Classes are sealed by default. Marking a class `open` allows it to be used as a base type. A base class is specified with a colon
-followed by the type name:
+Classes are sealed by default. Marking a class `open` allows it to be used as a base type. The `abstract` modifier also enables
+inheritance: abstract classes are implicitly open and may serve as base types without the `open` keyword. A base class is
+specified with a colon followed by the type name:
 
 ```raven
 open class Parent {}
@@ -1169,7 +1170,7 @@ If a derived class omits a constructor, the base class' parameterless constructo
 (`public`, `internal`, `protected`, `private`) apply as usual; `protected` members are accessible to derived classes.
 
 > **Limitations:** Only single inheritance is supported. Derived classes may currently chain only to parameterless base
-> constructors. Abstract base classes remain under design.
+> constructors.
 
 ### Method overloading
 

--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -40,9 +40,13 @@ internal class TypeGenerator
             {
                 typeAttributes |= TypeAttributes.Interface | TypeAttributes.Abstract;
             }
-            else if (named.IsSealed)
+            else
             {
-                typeAttributes |= TypeAttributes.Sealed;
+                if (named.IsAbstract)
+                    typeAttributes |= TypeAttributes.Abstract;
+
+                if (named.IsSealed)
+                    typeAttributes |= TypeAttributes.Sealed;
             }
         }
 

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -305,6 +305,9 @@ public class Compilation
                     interfaceList = builder.ToImmutable();
             }
 
+            var isAbstract = classDeclaration.Modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
+            var isSealed = !classDeclaration.Modifiers.Any(m => m.Kind == SyntaxKind.OpenKeyword) && !isAbstract;
+
             var symbol = new SourceNamedTypeSymbol(
                 classDeclaration.Identifier.Text,
                 baseTypeSymbol,
@@ -313,7 +316,9 @@ public class Compilation
                 containingType,
                 containingNamespace,
                 locations,
-                references);
+                references,
+                isSealed,
+                isAbstract);
 
             if (!interfaceList.IsDefaultOrEmpty)
                 symbol.SetInterfaces(interfaceList);
@@ -359,7 +364,10 @@ public class Compilation
                 declaringSymbol,
                 containingType,
                 containingNamespace,
-            locations, references);
+                locations,
+                references,
+                true,
+                isAbstract: true);
 
             foreach (var memberDeclaration2 in interfaceDeclaration.Members)
             {

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -568,8 +568,8 @@ public partial class SemanticModel
                                 interfaceList = builder.ToImmutable();
                         }
 
-                        var isSealed = !classDecl.Modifiers.Any(m =>
-                            m.Kind == SyntaxKind.OpenKeyword || m.Kind == SyntaxKind.AbstractKeyword);
+                        var isAbstract = classDecl.Modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
+                        var isSealed = !classDecl.Modifiers.Any(m => m.Kind == SyntaxKind.OpenKeyword) && !isAbstract;
 
                         var classSymbol = new SourceNamedTypeSymbol(
                             classDecl.Identifier.Text,
@@ -580,7 +580,8 @@ public partial class SemanticModel
                             parentNamespace.AsSourceNamespace(),
                             [classDecl.GetLocation()],
                             [classDecl.GetReference()],
-                            isSealed);
+                            isSealed,
+                            isAbstract);
 
                         if (!interfaceList.IsDefaultOrEmpty)
                             classSymbol.SetInterfaces(interfaceList);
@@ -620,7 +621,8 @@ public partial class SemanticModel
                             parentNamespace.AsSourceNamespace(),
                             [interfaceDecl.GetLocation()],
                             [interfaceDecl.GetReference()],
-                            true);
+                            true,
+                            isAbstract: true);
 
                         if (!interfaceList.IsDefaultOrEmpty)
                             interfaceSymbol.SetInterfaces(interfaceList);
@@ -743,8 +745,8 @@ public partial class SemanticModel
                         if (builder.Count > 0)
                             nestedInterfaces = builder.ToImmutable();
                     }
-                    var nestedSealed = !nestedClass.Modifiers.Any(m =>
-                        m.Kind == SyntaxKind.OpenKeyword || m.Kind == SyntaxKind.AbstractKeyword);
+                    var nestedAbstract = nestedClass.Modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
+                    var nestedSealed = !nestedClass.Modifiers.Any(m => m.Kind == SyntaxKind.OpenKeyword) && !nestedAbstract;
                     var nestedSymbol = new SourceNamedTypeSymbol(
                         nestedClass.Identifier.Text,
                         nestedBaseType!,
@@ -754,7 +756,8 @@ public partial class SemanticModel
                         classBinder.CurrentNamespace!.AsSourceNamespace(),
                         [nestedClass.GetLocation()],
                         [nestedClass.GetReference()],
-                        nestedSealed
+                        nestedSealed,
+                        nestedAbstract
                     );
 
                     if (!nestedInterfaces.IsDefaultOrEmpty)
@@ -792,7 +795,8 @@ public partial class SemanticModel
                         classBinder.CurrentNamespace!.AsSourceNamespace(),
                         [nestedInterface.GetLocation()],
                         [nestedInterface.GetReference()],
-                        true
+                        true,
+                        isAbstract: true
                     );
                     if (!parentInterfaces.IsDefaultOrEmpty)
                         nestedInterfaceSymbol.SetInterfaces(parentInterfaces);

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -17,15 +17,27 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
 
         TypeKind = TypeKind.Class;
         IsSealed = true;
+        IsAbstract = false;
     }
 
-    public SourceNamedTypeSymbol(string name, INamedTypeSymbol baseType, TypeKind typeKind, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations, SyntaxReference[] declaringSyntaxReferences, bool isSealed = false)
+    public SourceNamedTypeSymbol(
+        string name,
+        INamedTypeSymbol baseType,
+        TypeKind typeKind,
+        ISymbol containingSymbol,
+        INamedTypeSymbol? containingType,
+        INamespaceSymbol? containingNamespace,
+        Location[] locations,
+        SyntaxReference[] declaringSyntaxReferences,
+        bool isSealed = false,
+        bool isAbstract = false)
     : base(SymbolKind.Type, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences)
     {
         BaseType = baseType;
 
         TypeKind = typeKind;
         IsSealed = isSealed;
+        IsAbstract = isAbstract;
     }
 
     public bool IsNamespace { get; } = false;
@@ -41,7 +53,7 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     public ImmutableArray<ITypeSymbol> TypeArguments { get; }
     public ImmutableArray<ITypeParameterSymbol> TypeParameters { get; }
     public ITypeSymbol? ConstructedFrom { get; }
-    public bool IsAbstract { get; } = false;
+    public bool IsAbstract { get; }
     public bool IsSealed { get; }
     public bool IsGenericType { get; }
     public bool IsUnboundGenericType { get; }


### PR DESCRIPTION
## Summary
- track the abstract modifier on source type symbols and propagate it through semantic model setup so abstract classes are treated as inheritable by default
- emit CLR abstract type attributes when necessary and cover the scenario with a class inheritance test
- document that abstract classes are implicitly open in the language specification

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs,src/Raven.CodeAnalysis/SemanticModel.cs,src/Raven.CodeAnalysis/Compilation.cs,src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs,test/Raven.CodeAnalysis.Tests/Semantics/ClassInheritanceTests.cs`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Assignment_NullLiteral_To_NullableReference_PreservesConvertedType assertion)*
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "AbstractBaseClass_DerivationWithoutOpen_Succeeds"`


------
https://chatgpt.com/codex/tasks/task_e_68d0f58b6d1c832f81da21522beea171