### PR TITLE
docs: capture base constructor initializer support

### DIFF
--- a/docs/compiler/development/explicit-base-constructor-investigation.md
+++ b/docs/compiler/development/explicit-base-constructor-investigation.md
@@ -1,0 +1,75 @@
+# Investigation: explicit base constructor invocation
+
+## Current behavior
+
+* The emitter always injects a call to the base type's *parameterless* constructor for every ordinary (non-named) instance constructor. It loads `self`, resolves the base constructor with zero parameters, and emits a direct `call`.【F:src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs†L109-L126】【F:src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs†L382-L395】
+* Existing tests only cover the implicit chaining path: derived constructors without an initializer rely on the default base call, and succeed as long as the base constructor takes no parameters.【F:test/Raven.CodeAnalysis.Tests/CodeGen/BaseConstructorTests.cs†L11-L82】
+* The inheritance proposal documents that explicit base constructor invocation is still pending work, matching the current implementation gap.【F:docs/lang/proposals/class-inheritance.md†L31-L52】
+
+## Missing syntax support
+
+* The syntax model for constructors does not expose any slot for an initializer expression. Both `BaseConstructorDeclaration` and its derived nodes stop at the body/expression body/terminator slots, leaving no way to represent `: base(...)` or similar forms.【F:src/Raven.CodeAnalysis/Syntax/Model.xml†L153-L173】
+* The parser mirrors this limitation: after reading the parameter list it looks only for a block body, an expression-bodied arrow, or a terminator. There is no branch that consumes a constructor initializer token sequence.【F:src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs†L192-L250】
+* No lexical entry exists for a `base` keyword (or alternative syntax) in `Tokens.xml`, so even the token stream cannot distinguish an initializer clause today. Introducing an initializer will require adding the appropriate keyword or contextual token alongside the parser changes.【F:src/Raven.CodeAnalysis/Syntax/Tokens.xml†L4-L79】
+
+## Semantic gaps
+
+* Constructor symbols are created without inspecting any initializer. `BindConstructorDeclaration` collects parameters, checks for duplicate signatures, and stops. There is no storage location for a chosen base constructor or the bound argument list that an initializer would produce.【F:src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs†L257-L307】
+* The IL generator assumes that the parameterless base call is always needed and never consults the syntax/bound tree for an explicit initializer, so adding the syntax alone would still emit the implicit call first and then any user-specified call, resulting in duplicate chaining or incorrect argument passing.【F:src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs†L109-L126】
+* Because no binding occurs, there are no diagnostics for invalid initializer scenarios (missing accessible base constructor, wrong argument counts, use in static constructors, etc.), and the runtime fallback throws `NotSupportedException` when the base type has no parameterless constructor.【F:src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs†L382-L386】
+
+## Strategy and task breakdown
+
+Implementing explicit chaining requires a staged plan so we can land incremental PRs without breaking existing behavior. Each step below is a self-contained task that can be tracked independently.
+
+## Progress update
+
+The first three slices of the plan have landed in the minimal implementation:
+
+* ✅ **Task 1 — Syntax & tokens** introduced the `base` keyword, initializer syntax nodes, and parser support.
+* ✅ **Task 2 — Minimal binding pipeline** binds `: base(...)` clauses for instance constructors and stores the result on `SourceMethodSymbol`.
+* ✅ **Task 3 — Code generation integration** reuses the bound initializer when emitting constructor bodies and falls back to the implicit parameterless call when none exists.
+
+The remaining effort now concentrates on validation, diagnostics, and specification updates. The Task&nbsp;4a diagnostic slices are complete, and Task&nbsp;4 now continues as a set of smaller follow-ups so we can land them independently:
+
+* ✅ **Task 4a.1 — Static constructor guard**: report `RAV0312` when a static constructor specifies `: base(...)`.
+* ✅ **Task 4a.2 — Preserve user intent on errors**: bail out of emission when initializer binding reports argument diagnostics so we skip the legacy implicit base call instead of chaining to the wrong overload.
+* ✅ **Task 4a.3 — Missing/ambiguous base diagnostics**: surface binder diagnostics for `: base(...)` clauses that fail overload resolution and reuse arity-matched candidates to produce conversion errors instead of falling back to `RAV1501`.
+* ✅ **Task 4b — Negative coverage and regression tests**: covered `RAV0312`, `RAV1501`, and `RAV1503` with new semantic tests and added a positive codegen regression proving argument forwarding executes the base constructor exactly once.
+* 🔄 **Task 4c — Documentation refresh** *(immediate)*: update the language specification and proposals with the supported initializer syntax once validation hardens.
+
+### Task 1 — Syntax & tokens
+
+* Introduce the `base` keyword (or chosen initializer keyword) in `Tokens.xml` and regenerate the lexer tables.
+* Add a `ConstructorInitializerSyntax` node (or equivalent slots) to `Model.xml`, carrying the colon token, `base` keyword, and argument list; regenerate the syntax layer.
+* Update `TypeDeclarationParser.ParseConstructorDeclaration` so it parses an optional initializer between the parameter list and the body/expression body.
+* Acceptance criteria: constructor declarations with `: base(...)` round-trip through parsing/pretty-printing; named constructors remain unaffected.
+
+### Task 2 — Minimal binding pipeline
+
+* Extend constructor binding to visit an initializer clause, rejecting it for static or named constructors.
+* Reuse `BlockBinder.BindConstructorInvocation` (or similar helper) to resolve the chosen base constructor and perform argument conversions.
+* Store the resolved constructor symbol and converted arguments on `SourceMethodSymbol` (or an attached structure) for downstream consumers.
+* Acceptance criteria: successful binding of `: base(...)` in instance constructors; diagnostics for missing/inaccessible base constructors are deferred to a later pass if necessary.
+
+### Task 3 — Code generation integration
+
+* Teach `MethodBodyGenerator` to detect a bound initializer and emit that call instead of the hard-coded parameterless base constructor.
+* Ensure the generator loads `self` before forwarding the call and respects the binder-selected constructor and argument order.
+* Keep the existing implicit call path for constructors without an initializer.
+* Acceptance criteria: derived constructors invoking `: base(arg)` execute the base constructor exactly once; existing tests relying on implicit chaining continue to pass.
+
+### Task 4 — Validation & tests
+
+* Expand `BaseConstructorTests` to cover explicit base invocations, including argument passing and minimal diagnostic coverage (e.g., wrong argument count).
+* Add binder-level tests if necessary to assert diagnostics and symbol information.
+* Update documentation/spec proposals once the feature shape solidifies.
+* Acceptance criteria: new tests demonstrate successful chaining and at least one representative failure mode; documentation is refreshed.
+
+### Deferred follow-ups
+
+* Enforce full diagnostic coverage (accessibility, duplicate initializers, disallowed contexts) once the minimal path is stable.
+* Consider caching or exposing the bound initializer to semantic model APIs.
+* Evaluate interactions with future features (e.g., struct constructors, implicit `this(...)` chaining) after basic support ships.
+
+With these steps, we can ship a minimal explicit base constructor call and expand coverage in future tasks without entangling named constructors.

--- a/docs/lang/proposals/class-inheritance.md
+++ b/docs/lang/proposals/class-inheritance.md
@@ -30,7 +30,19 @@ default). A sealed class remains inheritable by its known children, allowing too
 
 ### Constructors
 
-If a derived class omits a constructor, the base class' default constructor is called automatically. Explicit constructors must chain to a base constructor; default constructors are planned but not yet available.
+If a derived class omits a constructor, the base class' default constructor is called automatically. A constructor that needs to forward arguments may declare an initializer clause between its parameter list and body:
+
+```raven
+open class Base { public init(value: int) {} }
+
+class Derived : Base {
+    public init(value: int): base(value) {
+        // Body runs after the base constructor finishes.
+    }
+}
+```
+
+The initializer runs before the derived body executes. It is only available on ordinary instance constructors; static constructors report `RAV0312`, and named constructors continue to build user-defined factory patterns without chaining.
 
 ### Access modifiers
 
@@ -41,7 +53,7 @@ Classes and their members support the existing access modifiers (`public`, `inte
 - ✅ `open` classes and base type syntax
 - ✅ Default constructor chaining to the base default constructor
 - ✅ Access modifiers on classes and members
-- ⚠️ Explicit base constructor invocation
+- ✅ Explicit base constructor invocation
 - ⚠️ Advanced inheritance features (interfaces, abstract classes, etc.)
 
 ## Limitations

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -1177,10 +1177,24 @@ final override so the CLR records the implementation in the type's interface map
 aration rules and inheritance.
 
 If a derived class omits a constructor, the base class' parameterless constructor is invoked automatically. Access modifiers
-(`public`, `internal`, `protected`, `private`) apply as usual; `protected` members are accessible to derived classes.
+(`public`, `internal`, `protected`, `private`) apply as usual; `protected` members are accessible to derived classes. An
+instance constructor may chain to a specific base overload by adding a constructor initializer between its parameter list and
+body:
 
-> **Limitations:** Only single inheritance is supported. Derived classes may currently chain only to parameterless base
-> constructors.
+```raven
+open class Base { public init(value: int) {} }
+
+class Derived : Base {
+    public init(value: int): base(value) {
+        // The base invocation runs before the derived body executes.
+    }
+}
+```
+
+The initializer is only available on ordinary instance constructors. Static constructors report `RAV0312`, and named
+constructors continue to behave as user-defined factories without chaining.
+
+> **Limitations:** Only single inheritance is supported.
 
 ### Method overloading
 

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -2539,7 +2539,7 @@ partial class BlockBinder : Binder
         return new BoundCastExpression(expression, targetType, conversion);
     }
 
-    private BoundExpression[] ConvertArguments(ImmutableArray<IParameterSymbol> parameters, IReadOnlyList<BoundExpression> arguments, SeparatedSyntaxList<ArgumentSyntax> argumentSyntaxes)
+    protected BoundExpression[] ConvertArguments(ImmutableArray<IParameterSymbol> parameters, IReadOnlyList<BoundExpression> arguments, SeparatedSyntaxList<ArgumentSyntax> argumentSyntaxes)
     {
         var converted = new BoundExpression[arguments.Count];
 

--- a/src/Raven.CodeAnalysis/Binder/ConstructorInitializerBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/ConstructorInitializerBinder.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed class ConstructorInitializerBinder : MethodBodyBinder
+{
+    private readonly SourceMethodSymbol _constructor;
+
+    public ConstructorInitializerBinder(SourceMethodSymbol constructor, Binder parent)
+        : base(constructor, parent)
+    {
+        _constructor = constructor;
+    }
+
+    public BoundObjectCreationExpression? Bind(ConstructorInitializerSyntax initializerSyntax)
+    {
+        return initializerSyntax switch
+        {
+            BaseConstructorInitializerSyntax baseInitializer => BindBaseInitializer(baseInitializer),
+            _ => null
+        };
+    }
+
+    private BoundObjectCreationExpression? BindBaseInitializer(BaseConstructorInitializerSyntax initializerSyntax)
+    {
+        var baseType = _constructor.ContainingType?.BaseType;
+        if (baseType is null)
+            return null;
+
+        var boundArguments = new List<BoundExpression>();
+        var hasErrors = false;
+
+        foreach (var argument in initializerSyntax.ArgumentList.Arguments)
+        {
+            var boundArgument = BindExpression(argument.Expression);
+            if (boundArgument is BoundErrorExpression)
+                hasErrors = true;
+
+            boundArguments.Add(boundArgument);
+        }
+
+        if (hasErrors)
+            return null;
+
+        var constructors = baseType.Constructors.Where(c => !c.IsStatic).ToImmutableArray();
+        var resolution = OverloadResolver.ResolveOverload(constructors, boundArguments.ToArray(), Compilation);
+
+        if (!resolution.Success)
+        {
+            if (resolution.IsAmbiguous)
+            {
+                _diagnostics.ReportCallIsAmbiguous(baseType.Name, resolution.AmbiguousCandidates, initializerSyntax.ArgumentList.GetLocation());
+                return null;
+            }
+
+            var matchingByArity = constructors.Where(c => c.Parameters.Length == boundArguments.Count).ToImmutableArray();
+            if (matchingByArity.Length == 1)
+            {
+                var candidate = matchingByArity[0];
+                var converted = ConvertArguments(candidate.Parameters, boundArguments, initializerSyntax.ArgumentList.Arguments);
+                if (converted.Any(static argument => argument is BoundErrorExpression))
+                    return null;
+            }
+
+            _diagnostics.ReportNoOverloadForMethod(baseType.Name, boundArguments.Count, initializerSyntax.ArgumentList.GetLocation());
+            return null;
+        }
+
+        var constructor = resolution.Method!;
+        var convertedArguments = ConvertArguments(constructor.Parameters, boundArguments, initializerSyntax.ArgumentList.Arguments);
+        if (convertedArguments.Any(static argument => argument is BoundErrorExpression))
+            return null;
+
+        var receiver = new BoundSelfExpression(_constructor.ContainingType!);
+
+        return new BoundObjectCreationExpression(constructor, convertedArguments, receiver);
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1004,6 +1004,11 @@ internal class ExpressionGenerator : Generator
         var parameters = constructorSymbol.Parameters.ToArray();
         var arguments = objectCreationExpression.Arguments.ToArray();
 
+        if (objectCreationExpression.Receiver is not null)
+        {
+            EmitExpression(objectCreationExpression.Receiver);
+        }
+
         for (int i = 0; i < arguments.Length; i++)
         {
             var param = parameters[i];
@@ -1042,7 +1047,14 @@ internal class ExpressionGenerator : Generator
             _ => throw new Exception()
         };
 
-        ILGenerator.Emit(OpCodes.Newobj, constructorInfo);
+        if (objectCreationExpression.Receiver is not null)
+        {
+            ILGenerator.Emit(OpCodes.Call, constructorInfo);
+        }
+        else
+        {
+            ILGenerator.Emit(OpCodes.Newobj, constructorInfo);
+        }
     }
 
     private void EmitAssignmentExpression(BoundAssignmentExpression node)

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -35,6 +35,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _sealedMemberMustOverride;
     private static DiagnosticDescriptor? _cannotOverrideSealedMember;
     private static DiagnosticDescriptor? _staticMemberCannotBeVirtualOrOverride;
+    private static DiagnosticDescriptor? _constructorInitializerNotAllowedOnStaticConstructor;
     private static DiagnosticDescriptor? _nullableTypeInUnion;
     private static DiagnosticDescriptor? _typeNameDoesNotExistInType;
     private static DiagnosticDescriptor? _cannotAssignVoidToAnImplicitlyTypedVariable;
@@ -443,6 +444,19 @@ internal static partial class CompilerDiagnostics
         description: "",
         helpLinkUri: "",
         messageFormat: "Static member '{0}' cannot be marked '{1}'",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// RAV0312: Static constructors cannot specify a base constructor initializer
+    /// </summary>
+    public static DiagnosticDescriptor ConstructorInitializerNotAllowedOnStaticConstructor => _constructorInitializerNotAllowedOnStaticConstructor ??= DiagnosticDescriptor.Create(
+        id: "RAV0312",
+        title: "Static constructors cannot specify a base initializer",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Static constructors cannot specify a base constructor initializer",
         category: "compiler",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -920,6 +934,7 @@ internal static partial class CompilerDiagnostics
         SealedMemberMustOverride,
         CannotOverrideSealedMember,
         StaticMemberCannotBeVirtualOrOverride,
+        ConstructorInitializerNotAllowedOnStaticConstructor,
         NullableTypeInUnion,
         TypeNameDoesNotExistInType,
         CannotAssignVoidToAnImplicitlyTypedVariable,
@@ -987,6 +1002,7 @@ internal static partial class CompilerDiagnostics
         "RAV0309" => SealedMemberMustOverride,
         "RAV0310" => CannotOverrideSealedMember,
         "RAV0311" => StaticMemberCannotBeVirtualOrOverride,
+        "RAV0312" => ConstructorInitializerNotAllowedOnStaticConstructor,
         "RAV0400" => NullableTypeInUnion,
         "RAV0426" => TypeNameDoesNotExistInType,
         "RAV0815" => CannotAssignVoidToAnImplicitlyTypedVariable,

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -92,6 +92,9 @@ public static partial class DiagnosticBagExtensions
     public static void ReportStaticMemberCannotBeVirtualOrOverride(this DiagnosticBag diagnostics, object? memberName, object? modifier, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.StaticMemberCannotBeVirtualOrOverride, location, memberName, modifier));
 
+    public static void ReportConstructorInitializerNotAllowedOnStaticConstructor(this DiagnosticBag diagnostics, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.ConstructorInitializerNotAllowedOnStaticConstructor, location));
+
     public static void ReportNullableTypeInUnion(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.NullableTypeInUnion, location));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -105,6 +105,10 @@
     Title="Static members cannot be virtual or override"
     Message="Static member '{memberName}' cannot be marked '{modifier}'"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV0312" Identifier="ConstructorInitializerNotAllowedOnStaticConstructor"
+    Title="Static constructors cannot specify a base initializer"
+    Message="Static constructors cannot specify a base constructor initializer"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0400" Identifier="NullableTypeInUnion"
     Title="Nullable type not allowed in union"
     Message="Nullable types are not allowed in union types" Category="compiler" Severity="Error"

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 
+using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
 
 namespace Raven.CodeAnalysis.Symbols;
@@ -77,4 +78,12 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
     public void SetParameters(IEnumerable<SourceParameterSymbol> parameters) => _parameters = parameters;
 
     internal void SetOverriddenMethod(IMethodSymbol overriddenMethod) => OverriddenMethod = overriddenMethod;
+
+    public BoundObjectCreationExpression? ConstructorInitializer { get; private set; }
+
+    public bool HasConstructorInitializerSyntax { get; private set; }
+
+    internal void MarkConstructorInitializerSyntax() => HasConstructorInitializerSyntax = true;
+
+    internal void SetConstructorInitializer(BoundObjectCreationExpression? initializer) => ConstructorInitializer = initializer;
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -441,7 +441,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
         return expr;
     }
 
-    private ArgumentListSyntax ParseArgumentListSyntax()
+    internal ArgumentListSyntax ParseArgumentListSyntax()
     {
         var openParenToken = ReadToken();
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -207,6 +207,15 @@ internal class TypeDeclarationParser : SyntaxParser
 
         var parameterList = ParseParameterList();
 
+        ConstructorInitializerSyntax? initializer = null;
+        if (PeekToken().IsKind(SyntaxKind.ColonToken))
+        {
+            var colonToken = ReadToken();
+            ConsumeTokenOrMissing(SyntaxKind.BaseKeyword, out var baseKeyword);
+            var argumentList = new ExpressionSyntaxParser(this).ParseArgumentListSyntax();
+            initializer = BaseConstructorInitializer(colonToken, baseKeyword, argumentList);
+        }
+
         var token = PeekToken();
 
         BlockStatementSyntax? body = null;
@@ -227,11 +236,11 @@ internal class TypeDeclarationParser : SyntaxParser
         {
             if (expressionBody is not null)
             {
-                return ConstructorDeclaration(modifiers, initKeyword, parameterList, null, expressionBody, terminatorToken);
+                return ConstructorDeclaration(modifiers, initKeyword, parameterList, initializer, null, expressionBody, terminatorToken);
             }
             else if (body is not null)
             {
-                return ConstructorDeclaration(modifiers, initKeyword, parameterList, body, null, terminatorToken);
+                return ConstructorDeclaration(modifiers, initKeyword, parameterList, initializer, body, null, terminatorToken);
             }
         }
         else

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/SyntaxRewriter.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/SyntaxRewriter.cs
@@ -68,6 +68,11 @@ internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode?>
         return node.Accept(this);
     }
 
+    public virtual ConstructorInitializerSyntax? VisitConstructorInitializer(ConstructorInitializerSyntax? node)
+    {
+        return (ConstructorInitializerSyntax?)node?.Accept(this);
+    }
+
     public virtual SyntaxList? VisitList(SyntaxList list)
     {
         List<GreenNode> newList = [];

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -158,6 +158,7 @@
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="InitKeyword" Type="Token" IsInherited="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsInherited="true" />
+    <Slot Name="Initializer" Type="ConstructorInitializer" IsNullable="true" />
     <Slot Name="Body" Type="BlockStatement" IsNullable="true" IsInherited="true" />
     <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" IsInherited="true" />
     <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
@@ -170,6 +171,16 @@
     <Slot Name="Body" Type="BlockStatement" IsNullable="true" IsInherited="true" />
     <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" IsInherited="true" />
     <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
+  </Node>
+  <Node Name="ConstructorInitializer" Inherits="Node" IsAbstract="true">
+    <Slot Name="ColonToken" Type="Token" IsAbstract="true" />
+    <Slot Name="Keyword" Type="Token" IsAbstract="true" />
+    <Slot Name="ArgumentList" Type="ArgumentList" IsAbstract="true" />
+  </Node>
+  <Node Name="BaseConstructorInitializer" Inherits="ConstructorInitializer">
+    <Slot Name="ColonToken" Type="Token" IsInherited="true" />
+    <Slot Name="Keyword" Type="Token" IsInherited="true" />
+    <Slot Name="ArgumentList" Type="ArgumentList" IsInherited="true" />
   </Node>
   <Node Name="ReturnStatement" Inherits="Statement">
     <Slot Name="ReturnKeyword" Type="Token" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxRewriter.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxRewriter.cs
@@ -76,6 +76,11 @@ public abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode?>
         return node?.Accept(this);
     }
 
+    public virtual ConstructorInitializerSyntax? VisitConstructorInitializer(ConstructorInitializerSyntax? node)
+    {
+        return (ConstructorInitializerSyntax?)node?.Accept(this);
+    }
+
     public virtual SyntaxList<TElement>? VisitList<TElement>(SyntaxList<TElement>? list0)
         where TElement : SyntaxNode
     {

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -20,6 +20,7 @@
   <TokenKind Name="ClassKeyword" Text="class" IsReservedWord="true" />
   <TokenKind Name="InterfaceKeyword" Text="interface" IsReservedWord="true" />
   <TokenKind Name="InitKeyword" Text="init" IsReservedWord="false" />
+  <TokenKind Name="BaseKeyword" Text="base" IsReservedWord="true" />
   <TokenKind Name="SelfKeyword" Text="self" IsReservedWord="true" />
   <TokenKind Name="IfKeyword" Text="if" IsReservedWord="true" />
   <TokenKind Name="ElseKeyword" Text="else" IsReservedWord="true" />

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ConstructorInitializerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ConstructorInitializerTests.cs
@@ -1,0 +1,73 @@
+using Raven.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class ConstructorInitializerTests : DiagnosticTestBase
+{
+    [Fact]
+    public void StaticConstructor_WithBaseInitializer_ReportsDiagnostic()
+    {
+        var code = """
+open class Base {
+    public init() {}
+}
+
+class Derived : Base {
+    public static init(): base() {}
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV0312").WithSpan(6, 27, 6, 31)
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void ConstructorInitializer_WithNoMatchingOverload_ReportsDiagnostic()
+    {
+        var code = """
+open class Base {
+    public init() {}
+}
+
+class Derived : Base {
+    public init(): base(1) {}
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV1501").WithSpan(6, 24, 6, 27).WithArguments("Base", 1)
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void ConstructorInitializer_WithIncompatibleArgumentType_ReportsDiagnostic()
+    {
+        var code = """
+open class Base {
+    public init(value: int) {}
+}
+
+class Derived : Base {
+    public init(): base("text") {}
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV1503").WithSpan(6, 25, 6, 31).WithArguments("\"text\"", "int")
+            ]);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- mark Task 4b complete in the base-constructor investigation and record the new semantic/codegen coverage
- update the class inheritance proposal to describe the : base(...) initializer and mark the feature as implemented
- refresh the language specification to explain constructor initializer clauses and their restrictions

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~ConstructorInitializerTests"

------
https://chatgpt.com/codex/tasks/task_e_68d1079ba9b4832f9ad9431064ee996e