### PR TITLE
test: add parser trivia checkpoint coverage

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/ParserTriviaCheckpointTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/ParserTriviaCheckpointTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+
+using Shouldly;
+
+using InternalSyntaxToken = Raven.CodeAnalysis.Syntax.InternalSyntax.SyntaxToken;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class ParserTriviaCheckpointTests
+{
+    [Fact]
+    public void SingleLineCommentTrivia_PreservedAcrossCheckpoint()
+    {
+        const string code = "let x = 1; // trailing";
+        var context = CreateContextAndReadToToken(code, SyntaxKind.SemicolonToken);
+
+        var positionBeforeCheckpoint = context.Position;
+        context.LastToken.ShouldNotBeNull();
+        context.LastToken!.Kind.ShouldBe(SyntaxKind.SemicolonToken);
+
+        using (context.CreateCheckpoint())
+        {
+            var endOfFile = context.ReadToken();
+            endOfFile.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+
+            AssertTrivia(endOfFile, SyntaxKind.SingleLineCommentTrivia, "// trailing");
+
+            context.LastToken.ShouldNotBeNull();
+            context.LastToken!.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+            context.Position.ShouldBeGreaterThan(positionBeforeCheckpoint);
+        }
+
+        context.Position.ShouldBe(positionBeforeCheckpoint);
+        context.LastToken.ShouldNotBeNull();
+        context.LastToken!.Kind.ShouldBe(SyntaxKind.SemicolonToken);
+
+        var endOfFileAfterReset = context.ReadToken();
+        endOfFileAfterReset.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+        AssertTrivia(endOfFileAfterReset, SyntaxKind.SingleLineCommentTrivia, "// trailing");
+        context.LastToken.ShouldNotBeNull();
+        context.LastToken!.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+    }
+
+    [Fact]
+    public void MultiLineCommentTrivia_PreservedAcrossCheckpoint()
+    {
+        const string code = "let x = 1; /* trailing */";
+        var context = CreateContextAndReadToToken(code, SyntaxKind.SemicolonToken);
+
+        var positionBeforeCheckpoint = context.Position;
+        context.LastToken.ShouldNotBeNull();
+        context.LastToken!.Kind.ShouldBe(SyntaxKind.SemicolonToken);
+
+        using (context.CreateCheckpoint())
+        {
+            var endOfFile = context.ReadToken();
+            endOfFile.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+
+            AssertTrivia(endOfFile, SyntaxKind.MultiLineCommentTrivia, "/* trailing */");
+
+            context.LastToken.ShouldNotBeNull();
+            context.LastToken!.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+            context.Position.ShouldBeGreaterThan(positionBeforeCheckpoint);
+        }
+
+        context.Position.ShouldBe(positionBeforeCheckpoint);
+        context.LastToken.ShouldNotBeNull();
+        context.LastToken!.Kind.ShouldBe(SyntaxKind.SemicolonToken);
+
+        var endOfFileAfterReset = context.ReadToken();
+        endOfFileAfterReset.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+        AssertTrivia(endOfFileAfterReset, SyntaxKind.MultiLineCommentTrivia, "/* trailing */");
+        context.LastToken.ShouldNotBeNull();
+        context.LastToken!.Kind.ShouldBe(SyntaxKind.EndOfFileToken);
+    }
+
+    private static BaseParseContext CreateContextAndReadToToken(string code, SyntaxKind target)
+    {
+        var context = new BaseParseContext(new Lexer(new StringReader(code)));
+        ReadThroughToken(context, target);
+        return context;
+    }
+
+    private static void ReadThroughToken(BaseParseContext context, SyntaxKind target)
+    {
+        while (true)
+        {
+            var token = context.ReadToken();
+            if (token.Kind == target)
+                return;
+
+            if (token.Kind == SyntaxKind.EndOfFileToken)
+                throw new InvalidOperationException($"Token '{target}' was not found before end of file.");
+        }
+    }
+
+    private static void AssertTrivia(InternalSyntaxToken token, SyntaxKind expectedKind, string expectedText)
+    {
+        var trivia = token.LeadingTrivia.Single(t => t.Kind == expectedKind);
+        trivia.Kind.ShouldBe(expectedKind);
+        trivia.Text.ShouldBe(expectedText);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression tests that exercise parser checkpoints with pending single-line and multi-line comment trivia
- add helper utilities to drive the base parse context through targeted tokens and assert trivia restoration

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: CodeGeneratorTests.Emit_ExplicitInterfaceImplementation_EmitsPrivateOverride currently throws System.Exception in TypeDeclarationParser)*
- dotnet test test/Raven.CodeAnalysis.Tests --filter ParserTriviaCheckpointTests

------
https://chatgpt.com/codex/tasks/task_e_68d1af9aa5e4832fb2d8fd86047a75f3