### PR TITLE
Add explicit interface specifier support for property declarations

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -345,8 +345,8 @@ internal class TypeDeclarationParser : SyntaxParser
                 UpdateLastToken(identifierToken);
 
                 var explicitInterfaceName = (TypeSyntax)qualifiedName.Left;
-                var explicitInterfaceSpecifier = ExplicitInterfaceSpecifier(explicitInterfaceName, qualifiedName.DotToken);
-                return (explicitInterfaceSpecifier, identifierToken);
+                var explicitInterfaceSpecifier = ExplicitInterfaceSpecifier(explicitInterfaceName, qualifiedName.DotToken, identifierToken);
+                return (explicitInterfaceSpecifier, Token(SyntaxKind.None));
             }
         }
 

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -516,6 +516,7 @@
   <Node Name="ExplicitInterfaceSpecifier" Inherits="Node">
     <Slot Name="Name" Type="Type" />
     <Slot Name="DotToken" Type="Token" />
+    <Slot Name="Identifier" Type="Token" />
   </Node>
   <Node Name="MethodDeclaration" Inherits="BaseMethodDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -237,7 +237,8 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
         {
             var name = (TypeSyntax)Visit(node.ExplicitInterfaceSpecifier.Name)!;
             var dotToken = VisitToken(node.ExplicitInterfaceSpecifier.DotToken)!;
-            explicitInterfaceSpecifier = node.ExplicitInterfaceSpecifier.Update(name, dotToken);
+            var identifierToken = VisitToken(node.ExplicitInterfaceSpecifier.Identifier)!;
+            explicitInterfaceSpecifier = node.ExplicitInterfaceSpecifier.Update(name, dotToken, identifierToken);
         }
 
         var identifier = VisitToken(node.Identifier)!


### PR DESCRIPTION
## Summary
- add the explicit interface specifier slot to property-like syntax nodes so they match method declarations
- update the type member parser to understand explicit interface qualifiers when parsing methods, properties, and indexers
- record the investigation and parser strategy in docs/compiler/development/explicit-interface-specifier.md

## Testing
- dotnet build src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d1bc23a2d4832f9ad3118fe76fd170