### PR TITLE
Add explicit interface specifier support for property declarations

### DIFF
--- a/docs/compiler/development/explicit-interface-specifier.md
+++ b/docs/compiler/development/explicit-interface-specifier.md
@@ -1,0 +1,49 @@
+# Explicit Interface Specifier Syntax Investigation
+
+This note captures the parser work needed to support explicit interface member
+names in the Raven syntax tree. The end goal was to align the surface structure
+with Roslyn, while keeping the changes restricted to syntax modeling and
+parsing.
+
+## Syntax tree modeling
+
+* `Model.xml` now gives `BasePropertyDeclaration` a nullable
+  `ExplicitInterfaceSpecifier` slot. This aligns property-like declarations with
+  `MethodDeclaration`, which already exposed the specifier. Adding the slot to
+  the base node ensures that both properties and indexers can surface the value
+  without duplicating metadata in every derived node.
+* `ExplicitInterfaceSpecifier` itself gained an `Identifier` slot so the
+  explicit member name travels with the qualifier. When this slot is present on
+  a member declaration, the declaration's `Identifier` token is set to
+  `SyntaxKind.None`.
+* The generated red/green nodes and factories pick up the new slot after running
+  `tools/NodeGenerator` in the `src/Raven.CodeAnalysis/Syntax` directory.
+
+## Parser changes
+
+* `ParseMember()` can no longer rely on `PeekToken(1)` to decide between
+  methods, properties, and indexers—the explicit interface qualifier inserts a
+  `.` before the name. The routine now creates a checkpoint, calls the shared
+  `ParseMemberNameWithExplicitInterface()` helper, inspects the token that
+  follows the parsed name, and rewinds the stream before delegating to the
+  concrete member parser. This makes the decision resilient to interface
+  qualifiers.
+* `ParsePropertyDeclaration()`, `ParseIndexerDeclaration()`, and
+  `ParseMethodOrConstructorDeclaration()` call
+  `ParseMemberNameWithExplicitInterface()` directly. They now accept the
+  explicit interface specifier and reuse the same helper regardless of member
+  kind.
+* `ParseMemberNameWithExplicitInterface()` handles the qualifier by parsing a
+  `TypeSyntax` and, when the result is a `QualifiedNameSyntax`, splitting off
+  the right-most simple name. The left side feeds the new
+  `ExplicitInterfaceSpecifier`, while the right-most token populates the
+  specifier's `Identifier` slot. The member's own identifier token is replaced
+  with `SyntaxKind.None`, signalling to later phases that the name lives inside
+  the specifier.
+
+## Implementation notes
+
+* The helper converts the right-most name token into an identifier with
+  `ToIdentifierToken` before storing it on the explicit-interface specifier.
+* Because lookahead uses checkpoints, the parser rewinds cleanly after probing
+  the stream to decide which member form to parse.

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -89,10 +89,10 @@ InvocationOperatorDeclaration
                                ( Block | '=>' Expression ) ;
 
 PropertyDeclaration      ::= MemberModifiers?
-                             Identifier ':' Type AccessorList ;
+                             ExplicitInterfaceSpecifier? Identifier ':' Type AccessorList ;
 
 IndexerDeclaration       ::= MemberModifiers?
-                             Identifier BracketedParameterList ':' Type AccessorList ;
+                             ExplicitInterfaceSpecifier? Identifier BracketedParameterList ':' Type AccessorList ;
 
 AccessorList             ::= '{' Accessor {Accessor} '}' ;
 Accessor                 ::= AccessorModifier? ('get' | 'set')

--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -40,7 +40,8 @@ internal class MethodGenerator
             })
             .ToArray();
 
-        var isExplicitInterfaceImplementation = MethodSymbol.MethodKind == MethodKind.ExplicitInterfaceImplementation;
+        var isExplicitInterfaceImplementation = MethodSymbol.MethodKind == MethodKind.ExplicitInterfaceImplementation
+            || !MethodSymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty;
 
         MethodAttributes attributes = MethodAttributes.HideBySig;
 

--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -213,7 +213,7 @@ internal class TypeGenerator
                             }
                         }
 
-                        var propBuilder = TypeBuilder.DefineProperty(propertySymbol.Name, PropertyAttributes.None, propertyType, paramTypes);
+                        var propBuilder = TypeBuilder.DefineProperty(propertySymbol.MetadataName, PropertyAttributes.None, propertyType, paramTypes);
 
                         if (getGen != null)
                             propBuilder.SetGetMethod((MethodBuilder)getGen.MethodBase);

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourcePropertySymbol.cs
@@ -3,6 +3,7 @@ namespace Raven.CodeAnalysis.Symbols;
 internal partial class SourcePropertySymbol : SourceSymbol, IPropertySymbol
 {
     private readonly bool _isStatic;
+    private readonly string _metadataName;
     private SourceFieldSymbol? _backingField;
 
     public SourcePropertySymbol(
@@ -14,12 +15,14 @@ internal partial class SourcePropertySymbol : SourceSymbol, IPropertySymbol
         Location[] locations,
         SyntaxReference[] declaringSyntaxReferences,
         bool isIndexer = false,
-        bool isStatic = false)
+        bool isStatic = false,
+        string? metadataName = null)
         : base(SymbolKind.Property, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences)
     {
         Type = propertyType;
         IsIndexer = isIndexer;
         _isStatic = isStatic;
+        _metadataName = metadataName ?? name;
     }
 
     public ITypeSymbol Type { get; }
@@ -31,6 +34,8 @@ internal partial class SourcePropertySymbol : SourceSymbol, IPropertySymbol
     public bool IsIndexer { get; }
 
     public override bool IsStatic => _isStatic;
+
+    public override string MetadataName => _metadataName;
 
     public bool IsAutoProperty => _backingField is not null;
 

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -379,6 +379,7 @@
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BasePropertyDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
+    <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" IsAbstract="true" />
     <Slot Name="Identifier" Type="Token" IsAbstract="true" />
     <Slot Name="Type" Type="TypeAnnotationClause" IsAbstract="true" />
     <Slot Name="AccessorList" Type="AccessorList" IsNullable="true" IsAbstract="true" />
@@ -431,6 +432,7 @@
   </Node>
   <Node Name="IndexerDeclaration" Inherits="BasePropertyDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
+    <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
     <Slot Name="ParameterList" Type="BracketedParameterList" />
     <Slot Name="Type" Type="TypeAnnotationClause" IsInherited="true" />
@@ -465,6 +467,7 @@
   </Node>
   <Node Name="PropertyDeclaration" Inherits="BasePropertyDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
+    <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
     <Slot Name="Type" Type="TypeAnnotationClause" IsInherited="true" />
     <Slot Name="AccessorList" Type="AccessorList" IsNullable="true" IsInherited="true" />
@@ -513,6 +516,7 @@
   <Node Name="ExplicitInterfaceSpecifier" Inherits="Node">
     <Slot Name="Name" Type="Type" />
     <Slot Name="DotToken" Type="Token" />
+    <Slot Name="Identifier" Type="Token" />
   </Node>
   <Node Name="MethodDeclaration" Inherits="BaseMethodDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -237,7 +237,8 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
         {
             var name = (TypeSyntax)Visit(node.ExplicitInterfaceSpecifier.Name)!;
             var dotToken = VisitToken(node.ExplicitInterfaceSpecifier.DotToken)!;
-            explicitInterfaceSpecifier = node.ExplicitInterfaceSpecifier.Update(name, dotToken);
+            var identifierToken = VisitToken(node.ExplicitInterfaceSpecifier.Identifier)!;
+            explicitInterfaceSpecifier = node.ExplicitInterfaceSpecifier.Update(name, dotToken, identifierToken);
         }
 
         var identifier = VisitToken(node.Identifier)!

--- a/test/Raven.CodeAnalysis.Tests/Syntax/PropertyDeclarationSyntaxTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/PropertyDeclarationSyntaxTest.cs
@@ -1,4 +1,9 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
+
+using Xunit;
 
 namespace Raven.CodeAnalysis.Syntax.Tests;
 
@@ -18,5 +23,31 @@ public class PropertyDeclarationSyntaxTest : DiagnosticTestBase
 
         var verifier = CreateVerifier(testCode);
         verifier.Verify();
+    }
+
+    [Fact]
+    public void ExplicitInterfaceProperty_UsesSpecifierIdentifier()
+    {
+        const string code =
+            """
+            class Foo {
+                IFoo.Value: int {
+                    get => 0
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+
+        var property = root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single(p => p.ExplicitInterfaceSpecifier is not null);
+
+        var explicitInterface = property.ExplicitInterfaceSpecifier;
+        Assert.NotNull(explicitInterface);
+        Assert.Equal(SyntaxKind.None, property.Identifier.Kind);
+        Assert.Equal("Value", explicitInterface!.Identifier.Text);
+        Assert.Equal("IFoo", explicitInterface.Name.ToString());
     }
 }


### PR DESCRIPTION
## Summary
- add the explicit interface specifier slot to property-like syntax nodes so they match method declarations
- update the type member parser to understand explicit interface qualifiers when parsing methods, properties, and indexers
- record the investigation and parser strategy in docs/compiler/development/explicit-interface-specifier.md
- normalize explicit interface metadata handling in the binder, wiring property/indexer specifiers and accessor implementations to their interfaces
- surface property metadata names through SourcePropertySymbol and consume them in the code generator so explicit interface properties emit the correct definitions
- treat accessor methods as explicit implementations during emission and add a codegen regression test for explicit-interface properties

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter FullyQualifiedName~Emit_ExplicitInterfacePropertyImplementation_EmitsPrivateOverride --logger "console;verbosity=minimal"

------
https://chatgpt.com/codex/tasks/task_e_68d1bc23a2d4832f9ad3118fe76fd170