### PR TITLE
feat: infer lambda parameter types

### DIFF
--- a/docs/compiler/development/lambda-functions.md
+++ b/docs/compiler/development/lambda-functions.md
@@ -1,0 +1,96 @@
+# Lambda functions investigation
+
+This note captures the current state of lambda expression support in the Raven
+compiler and highlights the remaining work needed to make them executable.
+
+## Syntax
+
+* The syntax model exposes an abstract `LambdaExpressionSyntax` with concrete
+  `SimpleLambdaExpressionSyntax` and `ParenthesizedLambdaExpressionSyntax`
+  shapes in `Model.xml`. Both forms share a leading `func` keyword, an arrow
+  token, and an expression body slot. The simple form stores a single `Parameter`
+  node while the parenthesized form reuses the `ParameterList` structure used by
+  function declarations.【F:src/Raven.CodeAnalysis/Syntax/Model.xml†L323-L377】【F:src/Raven.CodeAnalysis/Syntax/Model.xml†L391-L415】
+* `ExpressionSyntaxParser.ParseFactorExpression` treats `func` as a prefix for
+  lambda expressions. The parser delegates parameter parsing to
+  `StatementSyntaxParser.ParseParameterList`, reuses the return-type helper used
+  by declarations, consumes the `=>` token, and finally parses the expression
+  body. Only the parenthesized form is constructed today; no call site creates
+  `SimpleLambdaExpressionSyntax`.【F:src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs†L292-L334】【F:src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs†L123-L173】
+* Because blocks are first-class expressions, a lambda body can be either a
+  single expression or a braced block expression, letting the binder reuse the
+  regular expression binding pipeline.
+
+## Binding and symbols
+
+* `BlockBinder.BindLambdaExpression` performs the core semantic work. It expands
+  the parameter list into `SourceParameterSymbol` instances, tracking `ref` and
+  `out` modifiers, resolves any explicit return type, and creates a
+  `SourceLambdaSymbol` placeholder before binding the body. The body is bound in
+  a dedicated `LambdaBinder`, which inherits `BlockBinder` to reuse local-scope
+  management.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L547-L606】
+* Contextual delegate types now flow into the binder. `BlockBinder.GetTargetType`
+  supplies the expected delegate when a lambda appears in an assignment,
+  argument, or return position. Parameters without explicit annotations borrow
+  their types (and ref kinds) from that delegate, and the body is converted to
+  the delegate's return type when necessary. If no delegate context exists, the
+  binder reports `RAV2200` so callers add explicit parameter annotations before
+  inference proceeds.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L569-L702】【F:src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs†L912-L940】
+* Return types default to `Compilation.ErrorTypeSymbol` until the body finishes
+  binding. Afterwards the binder uses `ReturnTypeCollector.Infer` to aggregate
+  the types flowing out of the body (explicit `return`s plus the final
+  expression) and reconciles the inference with any annotation. Mismatches emit
+  a conversion diagnostic and the body is converted if needed before the symbol
+  is updated.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L610-L637】【F:src/Raven.CodeAnalysis/Binder/ReturnTypeCollector.cs†L8-L73】
+* `Compilation.CreateFunctionTypeSymbol` translates the final signature into an
+  appropriate `System.Func<>` or `System.Action<>` delegate by selecting the
+  overload whose arity matches the parameter count (plus a return type for
+  `Func`). The chosen delegate is stored on the lambda symbol and copied into the
+  `BoundLambdaExpression`.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L637-L654】【F:src/Raven.CodeAnalysis/Compilation.cs†L955-L1005】
+* `SourceLambdaSymbol` implements `ILambdaSymbol` and keeps the computed return
+  type, parameter list, and delegate type. The symbol is marked as a static
+  method whose `MethodKind` is `LambdaMethod`, matching Roslyn’s shape for
+  compiler-generated lambdas.【F:src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs†L6-L48】
+
+## Captured variable analysis
+
+* `LambdaBinder` records its parameters and locals so that lookups prioritize
+  lambda-scoped declarations. After binding, `CapturedVariableWalker.Analyze`
+  walks the bound body to find locals, parameters, and `self` references defined
+  outside the lambda and reports them through the
+  `BoundLambdaExpression.CapturedVariables` property. The walker’s findings are
+  persisted on the `SourceLambdaSymbol`, allowing downstream stages to determine
+  when closure materialization is required.【F:src/Raven.CodeAnalysis/Binder/LambdaBinder.cs†L1-L55】【F:src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs†L6-L72】
+* The captured-variable information now feeds code generation, guiding the
+  creation of closure classes when non-local state is accessed.
+
+## Code generation status
+
+* `ExpressionGenerator.EmitExpression` now supports both capturing and
+  non-capturing lambdas. Non-capturing lambdas continue to lower to static
+  helper methods and `ldftn` delegate construction. When captures exist, the
+  generator asks `TypeGenerator` to synthesize a nested closure type whose
+  fields mirror the captured symbols. The outer method allocates the closure,
+  copies the current values into the fields, and produces a delegate via
+  `Delegate.CreateDelegate` so the closure instance becomes the bound receiver
+  for the generated static helper.【F:src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs†L24-L223】【F:src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs†L12-L195】
+* Captured locals now flow through `System.Runtime.CompilerServices.StrongBox<T>`
+  cells so both the outer scope and the lambda body share the same storage. The
+  binder still reports captures on the lambda symbol, and the emitters translate
+  captured locals into strong-box fields on the synthesized closure and strong
+  boxes for the declaring scope's locals. Assignments and reads in either scope
+  dereference the shared cell so mutations are immediately visible to all
+  delegates.
+* Nested lambdas reuse the closure instances created by their enclosing scopes.
+  When a nested lambda captures a variable owned by a parent closure, the
+  emitter now threads the existing closure field into the inner closure rather
+  than materializing a new storage location, ensuring all delegates observe the
+  same underlying state.
+
+## Next steps
+
+1. Consider wiring up `SimpleLambdaExpressionSyntax` in the parser if a shorthand
+   form (without parentheses) is desired, or remove the unused node to reduce
+   generator output.
+2. Expand semantic and code-generation tests to cover nested closures and
+   combinations of captures with other expression features.

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -44,6 +44,8 @@
       href: development/source-generation.md
     - name: Node generator
       href: development/node-generator.md
+    - name: Lambda functions
+      href: development/lambda-functions.md
     - name: Completion service
       href: development/completion-service.md
     - name: Analyzers

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -742,6 +742,28 @@ func outer() {
 }
 ```
 
+### Lambda expressions and captured variables
+
+Lambda expressions use the `func` keyword followed by a parameter list, an
+arrow, and either an expression or block body. Lambdas may appear wherever a
+function value is expected. When a lambda references a local defined in an
+outer scope, the compiler lifts that local into shared closure storage so both
+the outer scope and the lambda observe the same value. Each captured local is
+wrapped in a reference cell (implemented with `System.Runtime.CompilerServices.StrongBox<T>`)
+when the local is declared. Reads and writes in any scope dereference that
+shared cell, so mutating a `var` binding after creating a lambda immediately
+affects all delegates that captured it. Capturing `self` produces a reference to
+the enclosing instance, and capturing parameters preserves the argument value
+from the invoking scope. Nested lambdas reuse the closure instances produced by
+their enclosing scopes so that captures shared across multiple lambda layers
+continue to reference the same storage locations.
+
+Lambda parameter types are optional when the expression is converted to a known
+delegate type. The compiler infers the parameter types (and any `ref`/`out`
+modifiers) from the delegate's `Invoke` signature and converts the body to the
+delegate's return type. If no delegate context is available, diagnostic
+`RAV2200` is reported and explicit parameter annotations are required.
+
 ### `ref`/`out` arguments
 
 Parameters can be declared by reference using `&Type`. Use `out` before

--- a/src/Raven.CodeAnalysis/Binder/LambdaBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/LambdaBinder.cs
@@ -69,10 +69,31 @@ sealed class CapturedVariableWalker : BoundTreeWalker
 
     public override void VisitLocalAccess(BoundLocalAccess node)
     {
-        if (node.Symbol is ISymbol symbol)
-        {
-            _accessedSymbols.Add(symbol);
-        }
+        AddSymbol(node.Symbol);
         base.VisitLocalAccess(node);
+    }
+
+    public override void VisitParameterAccess(BoundParameterAccess node)
+    {
+        AddSymbol(node.Symbol);
+        base.VisitParameterAccess(node);
+    }
+
+    public override void VisitVariableExpression(BoundVariableExpression node)
+    {
+        AddSymbol(node.Symbol);
+        base.VisitVariableExpression(node);
+    }
+
+    public override void VisitSelfExpression(BoundSelfExpression node)
+    {
+        AddSymbol(node.Symbol);
+        base.VisitSelfExpression(node);
+    }
+
+    private void AddSymbol(ISymbol? symbol)
+    {
+        if (symbol is not null)
+            _accessedSymbols.Add(symbol);
     }
 }

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -73,6 +73,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _matchExpressionNotExhaustive;
     private static DiagnosticDescriptor? _matchExpressionArmUnreachable;
     private static DiagnosticDescriptor? _matchExpressionArmPatternInvalid;
+    private static DiagnosticDescriptor? _lambdaParameterTypeCannotBeInferred;
 
     /// <summary>
     /// RAV0021: Cannot apply indexing with [] to an expression of type '{0}'
@@ -945,6 +946,19 @@ internal static partial class CompilerDiagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// RAV2200: Cannot infer the type of parameter '{0}'. Specify an explicit type or use the lambda in a delegate-typed context
+    /// </summary>
+    public static DiagnosticDescriptor LambdaParameterTypeCannotBeInferred => _lambdaParameterTypeCannotBeInferred ??= DiagnosticDescriptor.Create(
+        id: "RAV2200",
+        title: "Lambda parameter type cannot be inferred",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Cannot infer the type of parameter '{0}'. Specify an explicit type or use the lambda in a delegate-typed context",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public static DiagnosticDescriptor[] AllDescriptors => _allDescriptors ??=
     [
         CannotApplyIndexingWithToAnExpressionOfType,
@@ -1014,6 +1028,7 @@ internal static partial class CompilerDiagnostics
         MatchExpressionNotExhaustive,
         MatchExpressionArmUnreachable,
         MatchExpressionArmPatternInvalid,
+        LambdaParameterTypeCannotBeInferred,
     ];
 
     public static DiagnosticDescriptor? GetDescriptor(string diagnosticId) => diagnosticId switch
@@ -1085,6 +1100,7 @@ internal static partial class CompilerDiagnostics
         "RAV2100" => MatchExpressionNotExhaustive,
         "RAV2101" => MatchExpressionArmUnreachable,
         "RAV2102" => MatchExpressionArmPatternInvalid,
+        "RAV2200" => LambdaParameterTypeCannotBeInferred,
         _ => null
     };
 }

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -206,4 +206,7 @@ public static partial class DiagnosticBagExtensions
     public static void ReportMatchExpressionArmPatternInvalid(this DiagnosticBag diagnostics, object? patternType, object? scrutineeType, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.MatchExpressionArmPatternInvalid, location, patternType, scrutineeType));
 
+    public static void ReportLambdaParameterTypeCannotBeInferred(this DiagnosticBag diagnostics, object? parameterName, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.LambdaParameterTypeCannotBeInferred, location, parameterName));
+
 }

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -241,4 +241,7 @@
   <Descriptor Id="RAV2102" Identifier="MatchExpressionArmPatternInvalid" Title="Match arm pattern is not valid"
     Message="Pattern {patternType} is not valid for scrutinee of type '{scrutineeType}'"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV2200" Identifier="LambdaParameterTypeCannotBeInferred" Title="Lambda parameter type cannot be inferred"
+    Message="Cannot infer the type of parameter '{parameterName}'. Specify an explicit type or use the lambda in a delegate-typed context"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
 </Diagnostics>

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
@@ -4,6 +4,8 @@ namespace Raven.CodeAnalysis.Symbols;
 
 internal sealed partial class SourceLambdaSymbol : SourceSymbol, ILambdaSymbol
 {
+    private ImmutableArray<ISymbol> _capturedVariables = ImmutableArray<ISymbol>.Empty;
+
     public SourceLambdaSymbol(
         IReadOnlyList<IParameterSymbol> parameters,
         ITypeSymbol returnType,
@@ -58,8 +60,17 @@ internal sealed partial class SourceLambdaSymbol : SourceSymbol, ILambdaSymbol
 
     public ITypeSymbol? DelegateType { get; private set; }
 
+    public ImmutableArray<ISymbol> CapturedVariables => _capturedVariables;
+
+    public bool HasCaptures => !_capturedVariables.IsDefaultOrEmpty && _capturedVariables.Length > 0;
+
     public void SetDelegateType(ITypeSymbol delegateType)
     {
         DelegateType = delegateType;
+    }
+
+    public void SetCapturedVariables(IEnumerable<ISymbol> capturedVariables)
+    {
+        _capturedVariables = capturedVariables.ToImmutableArray();
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/LambdaCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/LambdaCodeGenTests.cs
@@ -1,0 +1,266 @@
+using System;
+using System.IO;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class LambdaCodeGenTests
+{
+    [Fact]
+    public void Lambda_ExpressionBody_ReturnsSum()
+    {
+        var code = """
+class Calculator {
+    Add() -> int {
+        let add = func (x: int, y: int) -> int => x + y
+        return add(2, 3)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Calculator", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Add")!;
+
+        var value = (int)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal(5, value);
+    }
+
+    [Fact]
+    public void Lambda_BlockBody_ReturnsComputedValue()
+    {
+        var code = """
+class Calculator {
+    Sum() -> int {
+        let make = func (x: int, y: int) -> int => {
+            let total = x + y
+            total
+        }
+
+        return make(4, 6)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Calculator", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Sum")!;
+
+        var value = (int)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal(10, value);
+    }
+
+    [Fact]
+    public void Lambda_CapturesParameter_ReturnsExpectedResult()
+    {
+        var code = """
+class Calculator {
+    Combine(x: int) -> int {
+        let add = func (y: int) -> int => x + y
+        return add(4)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Calculator", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Combine")!;
+
+        var value = (int)method.Invoke(instance, new object[] { 6 })!;
+        Assert.Equal(10, value);
+    }
+
+    [Fact]
+    public void Lambda_CapturesLocal_ReturnsValue()
+    {
+        var code = """
+class Counter {
+    Multiply() -> int {
+        let factor = 5
+        let multiply = func (value: int) -> int => factor * value
+        return multiply(3)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Counter", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Multiply")!;
+
+        var value = (int)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal(15, value);
+    }
+
+    [Fact]
+    public void Lambda_CapturesSelfField_UsesInstanceState()
+    {
+        var code = """
+class Holder {
+    value: int = 8
+
+    Compute() -> int {
+        let add = func (offset: int) -> int => self.value + offset
+        return add(7)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Holder", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Compute")!;
+
+        var value = (int)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal(15, value);
+    }
+
+    [Fact]
+    public void Lambda_CapturedLocalSharesMutations()
+    {
+        var code = """
+class Counter {
+    Run() -> int {
+        var total = 1
+        let add = func (delta: int) -> int => {
+            total = total + delta
+            total
+        }
+
+        total = 10
+        let result = add(2)
+        return total + result
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Counter", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+
+        var value = (int)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal(24, value);
+    }
+
+    [Fact]
+    public void Lambda_NestedLambda_ReusesOuterCapturedState()
+    {
+        var code = """
+class Counter {
+    Run() -> int {
+        var total = 1
+        let make = func () => {
+            let inner = func (delta: int) -> int => {
+                total = total + delta
+                return total
+            }
+
+            return inner
+        }
+
+        let increment = make()
+        let first = increment(2)
+        let second = increment(3)
+        return total + first + second
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Counter", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run")!;
+
+        var value = (int)method.Invoke(instance, Array.Empty<object>())!;
+        Assert.Equal(15, value);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LambdaCapturedVariablesTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LambdaCapturedVariablesTests.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class LambdaCapturedVariablesTests
+{
+    [Fact]
+    public void Lambda_CapturingParameter_ReportsParameterAsCapture()
+    {
+        var code = """
+class Calculator {
+    Apply(base: int) -> int {
+        let lambda = func (offset: int) -> int => base + offset
+        return lambda(2)
+    }
+}
+""";
+
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var lambdaSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .First(node => node.Kind == SyntaxKind.ParenthesizedLambdaExpression);
+
+        var boundLambda = Assert.IsType<BoundLambdaExpression>(model.GetBoundNode(lambdaSyntax));
+
+        var captured = boundLambda.CapturedVariables.ToArray();
+        var parameter = Assert.Single(boundLambda.Parameters, p => p.Name == "base");
+
+        Assert.Contains(parameter, captured, SymbolEqualityComparer.Default);
+    }
+
+    [Fact]
+    public void Lambda_CapturingLocal_ReportsLocalAsCapture()
+    {
+        var code = """
+class Calculator {
+    Apply() -> int {
+        let factor = 3
+        let lambda = func (value: int) -> int => factor * value
+        return lambda(4)
+    }
+}
+""";
+
+        var tree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(tree)
+            .AddReferences(TestMetadataReferences.Default);
+
+        var model = compilation.GetSemanticModel(tree);
+        var lambdaSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .First(node => node.Kind == SyntaxKind.ParenthesizedLambdaExpression);
+
+        var boundLambda = Assert.IsType<BoundLambdaExpression>(model.GetBoundNode(lambdaSyntax));
+
+        var captured = boundLambda.CapturedVariables.ToArray();
+        var local = Assert.Single(captured.OfType<ILocalSymbol>(), symbol => symbol.Name == "factor");
+
+        Assert.Contains(local, captured, SymbolEqualityComparer.Default);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Semantics.Tests;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class LambdaInferenceTests : CompilationTestBase
+{
+    [Fact]
+    public void Lambda_WithoutParameterTypes_UsesTargetDelegateSignature()
+    {
+        const string code = """
+import System.*
+class Calculator {
+    Transform(value: int, projector: Func<int, int>) -> int {
+        return projector(value)
+    }
+
+    Apply() -> int {
+        return Transform(5, func (delta) => delta + 1)
+    }
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(code);
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var lambdaSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<ParenthesizedLambdaExpressionSyntax>()
+            .Single();
+
+        var boundLambda = Assert.IsType<BoundLambdaExpression>(model.GetBoundNode(lambdaSyntax));
+
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var parameter = Assert.Single(boundLambda.Parameters);
+        Assert.True(SymbolEqualityComparer.Default.Equals(intType, parameter.Type));
+        Assert.True(SymbolEqualityComparer.Default.Equals(intType, boundLambda.ReturnType));
+
+        var transformSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<FunctionStatementSyntax>()
+            .First(f => f.Identifier.Text == "Transform");
+        var transformSymbol = Assert.IsType<IMethodSymbol>(model.GetDeclaredSymbol(transformSyntax));
+        var projectorParameter = Assert.Single(transformSymbol.Parameters, p => p.Name == "projector");
+        Assert.True(SymbolEqualityComparer.Default.Equals(projectorParameter.Type, boundLambda.DelegateType));
+    }
+}
+
+public class LambdaInferenceDiagnosticsTests : DiagnosticTestBase
+{
+    [Fact]
+    public void Lambda_WithoutDelegateContext_ReportsParameterInferenceError()
+    {
+        const string code = """
+class Container {
+    Provide() -> unit {
+        let lambda = func (value) => value
+    }
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            [
+                new DiagnosticResult("RAV2200").WithSpan(3, 28, 3, 33).WithArguments("value"),
+            ]);
+
+        verifier.Verify();
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/PropertyBindingTests.cs
@@ -93,7 +93,7 @@ public class PropertyBindingTests : DiagnosticTestBase
             """;
 
         var verifier = CreateVerifier(testCode,
-            [new DiagnosticResult("RAV0200").WithSpan(6, 9, 6, 13).WithArguments("Name")]);
+            [new DiagnosticResult("RAV0200").WithSpan(4, 9, 4, 13).WithArguments("Name")]);
 
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- infer lambda parameter and return types from the delegate target, falling back to diagnostic RAV2200 when no delegate context exists
- register the new diagnostic in the compiler tables and explain contextual lambda inference in the developer notes and language spec
- add semantic and diagnostic tests covering delegate-driven inference and missing-context errors

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build`
- `MSBUILDTERMINALLOGGER=false dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68d2535755a0832fb09799eaa04c8714