### PR TITLE
docs: prune resolved bugs

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,15 +5,10 @@
 
 ## Prioritized failing test categories
 
-- Pattern matching and `is`/`as` expressions can produce null references or missing diagnostics.
-- Conditional access emission is incomplete.
+- Method-group overload resolution prefers ambiguity over selecting the best match.
 
 ## Current failing tests
 
-- `SampleProgramsTests.Sample_should_load_into_compilation("type-unions.rav")` – `BoundIsPatternExpression` throws `NullReferenceException` while binding patterns (bug; pattern matching not defined in the spec).
-- `MissingReturnTypeAnnotationAnalyzerTests.MethodWithBranchesReturningVoid_NoDiagnostic` – same `BoundIsPatternExpression` null reference during semantic analysis (bug; spec gap).
-- `PatternVariableTests.PatternVariableInIfCondition_EmitsSuccessfully` – pattern binding null reference prevents emission (bug; spec gap).
-- `ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue` – code generation throws `NotSupportedException` for nullable conditional access (bug).
 - `MethodReference` overload disambiguation – a simple program such as `let callback: System.Action<string> = Logger.Log` still reports `RAV2202` even though the class defines both `Log(string)` and `Log(object)`. The binder's method-group conversion treats every overload that accepts the delegate parameter type via an implicit conversion as equally valid and immediately marks the binding ambiguous instead of preferring the exact signature. See `BlockBinder.ConvertMethodGroupToDelegate`, which surfaces ambiguity whenever more than one candidate survives compatibility filtering rather than running overload resolution to pick the best match.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L820-L852】
 
 ## Skipped tests


### PR DESCRIPTION
## Summary
- remove resolved pattern-matching and conditional access issues from BUGS.md
- focus the failing-test tracker on the outstanding method-group overload resolution bug

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2fcbbba44832f9f8af23d0b93fa93