### PR TITLE
Fix metadata name lookup for generic types

### DIFF
--- a/src/Raven.CodeAnalysis/TypeSymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolExtensions.cs
@@ -49,9 +49,13 @@ public static class TypeSymbolExtensions
         // Handle named types (classes, structs, enums, etc.)
         if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
         {
-            // Attempt to resolve the fully qualified name
-            var fullyQualifiedName = namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            return compilation.CoreAssembly.GetType(fullyQualifiedName, throwOnError: false)!;
+            var metadataName = namedTypeSymbol.ToFullyQualifiedMetadataName();
+            var metadataType = compilation.CoreAssembly.GetType(metadataName, throwOnError: false);
+
+            if (metadataType is not null)
+                return metadataType;
+
+            throw new InvalidOperationException($"Unable to resolve metadata type '{metadataName}' from the core assembly.");
         }
 
         // Handle dynamic type

--- a/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
@@ -99,12 +99,12 @@ public static class TypeSymbolExtensionsForCodeGen
                 return builtType;
 
             // Otherwise, attempt to resolve from metadata (reference assemblies)
-            var fullyQualifiedName = namedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            var metadataType = compilation.CoreAssembly.GetType(fullyQualifiedName, throwOnError: false);
+            var metadataName = namedType.ToFullyQualifiedMetadataName();
+            var metadataType = compilation.CoreAssembly.GetType(metadataName, throwOnError: false);
             if (metadataType != null)
                 return metadataType;
 
-            throw new InvalidOperationException($"Unable to resolve runtime type for symbol: {fullyQualifiedName}");
+            throw new InvalidOperationException($"Unable to resolve runtime type for symbol: {metadataName}");
         }
 
         // Handle union types

--- a/test/Raven.CodeAnalysis.Tests/Symbols/TypeMetadataNameTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/TypeMetadataNameTests.cs
@@ -1,0 +1,35 @@
+using System;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class TypeMetadataNameTests
+{
+    [Fact]
+    public void ToFullyQualifiedMetadataName_IncludesGenericArity()
+    {
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        var actionDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Action`1")!;
+
+        Assert.Equal("System.Action`1", actionDefinition.ToFullyQualifiedMetadataName());
+    }
+
+    [Fact]
+    public void GetClrType_ResolvesConstructedGenericFromMetadata()
+    {
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        var actionDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Action`1")!;
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        var constructed = compilation.ConstructGenericType(actionDefinition, new ITypeSymbol[] { stringType });
+
+        var clrType = constructed.GetClrType(compilation);
+
+        Assert.Equal(typeof(Action<string>), clrType);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `ITypeSymbol.ToFullyQualifiedMetadataName` includes generic arity and nested type segments
- resolve CLR type lookups using fully qualified metadata names for runtime and code generation paths
- add regression tests covering metadata names and CLR type resolution for `System.Action<T>`

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Assignment_NullLiteral_To_NullableReference_PreservesConvertedType asserts a different bound node type; also triggers MSBuild terminal logger ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68d30bc7cc34832fb4c75ac08e064586