### PR TITLE
docs: clarify import directive documentation

### DIFF
--- a/docs/compiler/diagnostics.md
+++ b/docs/compiler/diagnostics.md
@@ -168,7 +168,7 @@ c.x = 0 // RAV0200
 Referenced a nested type or namespace that does not exist.
 
 ```raven
-use System.Missing // RAV0234
+import System.Missing // RAV0234
 ```
 
 ## RAV0235: Type expected without wildcard
@@ -265,7 +265,7 @@ Import directives must precede alias directives and declarations.
 
 ```raven
 type C {}
-use System // RAV1005
+import System // RAV1005
 ```
 
 ## RAV1006: Alias directive out of order
@@ -429,10 +429,10 @@ alias Bad = notatype // RAV2020
 ```
 
 ## RAV2021: Invalid import target
-`use` directives can only import namespaces or types.
+`import` directives can only bring namespaces or types into scope.
 
 ```raven
-use System.Console.WriteLine // RAV2021
+import System.Console.WriteLine // RAV2021
 ```
 
 ## RAV2022: Spread source must be enumerable

--- a/docs/lang/proposals/import-directive.md
+++ b/docs/lang/proposals/import-directive.md
@@ -42,7 +42,7 @@ namespace System.Net
 import Http.HttpClient // System.Net.Http.HttpClient
 import Http.* // System.Net.Http.*
 
-import SB = System.StringBuilder // System.StringBuilder
+alias SB = System.StringBuilder // Aliases use the separate `alias` directive
 ```
 
 ## Questions

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -635,10 +635,11 @@ import System.Math.*
 let pi = PI
 ```
 
-Import directives appear at the beginning of a compilation unit or namespace. All
-imports for a given scope must come before any alias directives or member
-declarations. Placing an import directive after an alias or member is a
-compile-time error (`RAV1005`).
+Import directives appear at the beginning of a compilation unit or namespace and
+simply make existing namespaces or types available. They do not introduce new
+names. To bind a custom name, use an `alias` directive. All imports for a given
+scope must come before any alias directives or member declarations. Placing an
+import directive after an alias or member is a compile-time error (`RAV1005`).
 
 ### Alias directive
 


### PR DESCRIPTION
## Summary
- clarify the language spec so import directives are described as only bringing existing namespaces or types into scope
- update the import directive proposal to demonstrate aliasing with the `alias` directive instead of `import`
- fix diagnostics documentation to reference the `import` directive rather than the legacy `use` wording

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d3127fc5b4832fa1c1730482c04322