### PR TITLE
fix: improve generic type resolution

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ImportResolutionTest.cs
@@ -84,6 +84,19 @@ public class ImportResolutionTest : DiagnosticTestBase
     }
 
     [Fact]
+    public void FullyQualifiedFuncWithMultipleTypeArguments_ShouldNot_ProduceDiagnostic()
+    {
+        string testCode =
+            """
+            System.Func<int, string>
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void ImportFullyQualifiedOpenGenericType_ShouldNot_ProduceDiagnostic2()
     {
         string testCode =
@@ -91,6 +104,36 @@ public class ImportResolutionTest : DiagnosticTestBase
             import System.Collections.Generic.List<>
 
             List<int>
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void ImportNamespaceProvidesFuncWithMultipleTypeArguments_ShouldNot_ProduceDiagnostic()
+    {
+        string testCode =
+            """
+            import System.*
+
+            Func<int, string>
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void ImportOpenGenericFunc_MakesTypeAvailable()
+    {
+        string testCode =
+            """
+            import System.Func<,>
+
+            Func<int, string>
             """;
 
         var verifier = CreateVerifier(testCode);


### PR DESCRIPTION
## Summary
- adjust binder type resolution to match generic arity, reuse accessible definitions, and support open generic lookups when possible
- update BlockBinder type binding to select matching generic definitions and reuse aliases with or without type arguments
- extend import resolution tests to cover System.Func variants and open generic imports

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests (fails: Raven.CodeAnalysis.Tests.TypeMetadataNameTests.GetClrType_ResolvesConstructedGenericFromMetadata)


------
https://chatgpt.com/codex/tasks/task_e_68d310f35344832faf2a30477b02d434