### PR TITLE
Refactor binder generic type lookup

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -290,17 +290,7 @@ internal abstract class Binder
             var arity = ComputeGenericArity(generic);
             var typeArgs = ResolveGenericTypeArguments(generic);
 
-            var symbol = LookupType(generic.Identifier.Text) as INamedTypeSymbol;
-            if (symbol is not null)
-            {
-                symbol = NormalizeDefinition(symbol);
-                if (symbol.Arity != arity)
-                    symbol = FindAccessibleNamedType(generic.Identifier.Text, arity);
-            }
-            else
-            {
-                symbol = FindAccessibleNamedType(generic.Identifier.Text, arity);
-            }
+            var symbol = FindNamedTypeForGeneric(generic, arity);
 
             if (symbol is null)
             {
@@ -418,18 +408,7 @@ internal abstract class Binder
             var arity = ComputeGenericArity(gen);
             var typeArgs = ResolveGenericTypeArguments(gen);
 
-            var symbol = LookupType(gen.Identifier.Text) as INamedTypeSymbol;
-            if (symbol is not null)
-            {
-                symbol = NormalizeDefinition(symbol);
-                if (symbol.Arity != arity)
-                    symbol = FindAccessibleNamedType(gen.Identifier.Text, arity);
-            }
-            else
-            {
-                symbol = FindAccessibleNamedType(gen.Identifier.Text, arity);
-            }
-
+            var symbol = FindNamedTypeForGeneric(gen, arity);
             if (symbol is null)
                 return null;
 
@@ -463,17 +442,7 @@ internal abstract class Binder
         var arity = ComputeGenericArity(gen);
         var typeArgs = ResolveGenericTypeArguments(gen);
 
-        var symbol = LookupType(gen.Identifier.Text) as INamedTypeSymbol;
-        if (symbol is not null)
-        {
-            symbol = NormalizeDefinition(symbol);
-            if (symbol.Arity != arity)
-                symbol = FindAccessibleNamedType(gen.Identifier.Text, arity);
-        }
-        else
-        {
-            symbol = FindAccessibleNamedType(gen.Identifier.Text, arity);
-        }
+        var symbol = FindNamedTypeForGeneric(gen, arity);
 
         if (symbol is null)
             return null;
@@ -635,5 +604,22 @@ internal abstract class Binder
         }
 
         return null;
+    }
+
+    private INamedTypeSymbol? FindNamedTypeForGeneric(GenericNameSyntax generic, int arity)
+    {
+        var symbol = LookupType(generic.Identifier.Text) as INamedTypeSymbol;
+        if (symbol is not null)
+        {
+            symbol = NormalizeDefinition(symbol);
+            if (symbol.Arity != arity)
+                symbol = FindAccessibleNamedType(generic.Identifier.Text, arity);
+        }
+        else
+        {
+            symbol = FindAccessibleNamedType(generic.Identifier.Text, arity);
+        }
+
+        return symbol;
     }
 }


### PR DESCRIPTION
## Summary
- centralize binder logic for locating named generic types into a helper method
- update generic type resolution paths to reuse the helper and reduce duplication

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/Binder.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: MethodReferenceDiagnosticsTests currently report unexpected diagnostics; run ends with TerminalLogger ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a81cb0dc832f981ea34db7001d6c