### PR TITLE
Fix newline token mode after parsing expression-bodied members

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -978,9 +978,11 @@ internal class ExpressionSyntaxParser : SyntaxParser
     {
         var arrowToken = ReadToken();
 
+        var previous = TreatNewlinesAsTokens;
+
         var expression = new ExpressionSyntaxParser(this).ParseExpression();
 
-        SetTreatNewlinesAsTokens(true);
+        SetTreatNewlinesAsTokens(previous);
 
         return ArrowExpressionClause(arrowToken, expression);
     }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
@@ -19,4 +19,83 @@ public class ClassDeclarationParserTests : DiagnosticTestBase
         Assert.Equal(2, declaration.ParameterList!.Parameters.Count);
         Assert.Empty(tree.GetDiagnostics());
     }
+
+    [Fact]
+    public void Constructor_WithExpressionBody_ParsesExpressionBody()
+    {
+        var source = """
+            class Person {
+                public init()
+                    => Console.WriteLine("Hello")
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var ctor = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
+
+        Assert.Null(ctor.Body);
+        Assert.NotNull(ctor.ExpressionBody);
+        Assert.True(ctor.ExpressionBody!.ArrowToken.IsKind(SyntaxKind.FatArrowToken));
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void Constructor_WithInitializerAndExpressionBody_ParsesBoth()
+    {
+        var source = """
+            class Derived : Base {
+                public init(): base(1)
+                    => Foo()
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var ctor = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
+
+        Assert.NotNull(ctor.Initializer);
+        Assert.NotNull(ctor.ExpressionBody);
+        Assert.True(ctor.ExpressionBody!.ArrowToken.IsKind(SyntaxKind.FatArrowToken));
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void NamedConstructor_WithExpressionBody_ParsesExpressionBody()
+    {
+        var source = """
+            class Person {
+                public init WithName(name: string) => Person()
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var ctor = tree.GetRoot().DescendantNodes().OfType<NamedConstructorDeclarationSyntax>().Single();
+
+        Assert.Null(ctor.Body);
+        Assert.NotNull(ctor.ExpressionBody);
+        Assert.True(ctor.ExpressionBody!.ArrowToken.IsKind(SyntaxKind.FatArrowToken));
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void Constructor_WithExpressionBody_FollowedByMethod_ParsesBothMembers()
+    {
+        var source = """
+            class Foo {
+                public init() => Console.WriteLine("Init")
+                public Dispose() -> unit {}
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var @class = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+
+        var members = @class.Members;
+
+        Assert.Collection(
+            members,
+            member => Assert.IsType<ConstructorDeclarationSyntax>(member),
+            member => Assert.IsType<MethodDeclarationSyntax>(member));
+
+        Assert.Empty(tree.GetDiagnostics());
+    }
 }


### PR DESCRIPTION
## Summary
- restore the TreatNewlinesAsTokens state after parsing arrow expression clauses so constructor expression bodies no longer affect following members
- add a parser regression test that ensures an expression-bodied constructor doesn't break parsing of the next method

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter ClassDeclarationParserTests`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: existing ArgumentNullException in semantic tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b1e8f880832fbd0b7341b8c1bb5d