### PR TITLE
feat: add try/catch/finally support

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -182,6 +182,24 @@ func log(msg: string) {
 }
 ```
 
+### Try statements
+
+`try` statements provide structured exception handling. A `try` statement wraps a block and must include at least one `catch` clause or a `finally` clause. Omitting both results in diagnostic `RAV1015`.
+
+```
+try {
+    operation()
+} catch (FormatException ex) {
+    Console.WriteLine($"Bad input: {ex.Message}")
+} finally {
+    cleanup()
+}
+```
+
+Each `catch` may declare an exception type and optional identifier using `catch (Type name)`. The declared type must be or derive from `System.Exception`; otherwise the compiler reports `RAV1016`. When the identifier is omitted, the exception value is still available for pattern-based filtering but is not bound to a local. A bare `catch` with no parentheses is equivalent to `catch (System.Exception)` and handles all exceptions of that type.
+
+The optional `finally` clause executes regardless of whether the `try` block or any `catch` clause complete normally.
+
 ## Expressions
 
 ### Target typing

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -292,6 +292,7 @@ partial class BlockBinder : Binder
             AssignmentStatementSyntax assignmentStatement => BindAssignmentStatement(assignmentStatement),
             ExpressionStatementSyntax expressionStmt => BindExpressionStatement(expressionStmt),
             IfStatementSyntax ifStmt => BindIfStatement(ifStmt),
+            TryStatementSyntax tryStmt => BindTryStatement(tryStmt),
             FunctionStatementSyntax function => BindFunction(function),
             ReturnStatementSyntax returnStatement => BindReturnStatement(returnStatement),
             BlockStatementSyntax blockStmt => BindBlockStatement(blockStmt),
@@ -325,6 +326,67 @@ partial class BlockBinder : Binder
         if (ifStmt.ElseStatement is not null)
             elseBound = BindStatement(ifStmt.ElseStatement);
         return new BoundIfStatement(condition, thenBound, elseBound);
+    }
+
+    private BoundStatement BindTryStatement(TryStatementSyntax tryStmt)
+    {
+        var tryBlock = BindBlockStatement(tryStmt.Block);
+
+        var catchBuilder = ImmutableArray.CreateBuilder<BoundCatchClause>();
+        foreach (var catchClause in tryStmt.CatchClauses)
+        {
+            catchBuilder.Add(BindCatchClause(catchClause));
+        }
+
+        BoundBlockStatement? finallyBlock = null;
+        if (tryStmt.FinallyClause is { } finallyClause)
+            finallyBlock = BindBlockStatement(finallyClause.Block);
+
+        if (catchBuilder.Count == 0 && finallyBlock is null)
+            return tryBlock;
+
+        return new BoundTryStatement(tryBlock, catchBuilder.ToImmutable(), finallyBlock);
+    }
+
+    private BoundCatchClause BindCatchClause(CatchClauseSyntax catchClause)
+    {
+        var exceptionBase = Compilation.GetTypeByMetadataName("System.Exception") ?? Compilation.ErrorTypeSymbol;
+        var exceptionType = exceptionBase;
+
+        SourceLocalSymbol? localSymbol = null;
+
+        if (catchClause.Declaration is { } declaration)
+        {
+            var declaredType = ResolveType(declaration.Type);
+            exceptionType = declaredType;
+
+            if (exceptionBase.TypeKind != TypeKind.Error &&
+                declaredType.TypeKind != TypeKind.Error &&
+                !IsAssignable(exceptionBase, declaredType, out _))
+            {
+                _diagnostics.ReportCatchTypeMustDeriveFromSystemException(
+                    declaredType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    declaration.Type.GetLocation());
+            }
+
+            if (declaration.Identifier is { } identifier &&
+                !identifier.IsMissing &&
+                identifier.Kind == SyntaxKind.IdentifierToken)
+            {
+                var name = identifier.Text;
+
+                if (LookupSymbol(name) is ILocalSymbol or IParameterSymbol or IFieldSymbol)
+                    _diagnostics.ReportVariableShadowsOuterScope(name, identifier.GetLocation());
+
+                _scopeDepth++;
+                localSymbol = CreateLocalSymbol(declaration, name, isMutable: false, declaredType);
+                _scopeDepth--;
+            }
+        }
+
+        var block = BindBlockStatement(catchClause.Block);
+
+        return new BoundCatchClause(exceptionType, localSymbol, block);
     }
 
     private BoundStatement ExpressionToStatement(BoundExpression expression)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundCatchClause.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundCatchClause.cs
@@ -1,0 +1,19 @@
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class BoundCatchClause : BoundNode
+{
+    public BoundCatchClause(ITypeSymbol exceptionType, ILocalSymbol? local, BoundBlockStatement block)
+    {
+        ExceptionType = exceptionType;
+        Local = local;
+        Block = block;
+    }
+
+    public ITypeSymbol ExceptionType { get; }
+
+    public ILocalSymbol? Local { get; }
+
+    public BoundBlockStatement Block { get; }
+}

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -45,6 +45,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundLocalDeclarationStatement localDecl => (BoundStatement)VisitLocalDeclarationStatement(localDecl)!,
             BoundFunctionStatement func => (BoundStatement)VisitFunctionStatement(func)!,
             BoundIfStatement ifStmt => (BoundStatement)VisitIfStatement(ifStmt)!,
+            BoundTryStatement tryStmt => (BoundStatement)VisitTryStatement(tryStmt)!,
             BoundWhileStatement whileStmt => (BoundStatement)VisitWhileStatement(whileStmt)!,
             BoundForStatement forStmt => (BoundStatement)VisitForStatement(forStmt)!,
             BoundBlockStatement blockStmt => (BoundStatement)VisitBlockStatement(blockStmt)!,

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -136,6 +136,9 @@ internal class BoundTreeWalker : BoundTreeVisitor
             case BoundForStatement forStmt:
                 VisitForStatement(forStmt);
                 break;
+            case BoundTryStatement tryStmt:
+                VisitTryStatement(tryStmt);
+                break;
             case BoundBlockStatement blockStmt:
                 VisitBlockStatement(blockStmt);
                 break;
@@ -224,6 +227,22 @@ internal class BoundTreeWalker : BoundTreeVisitor
     {
         VisitExpression(node.Collection);
         VisitStatement(node.Body);
+    }
+
+    public virtual void VisitTryStatement(BoundTryStatement node)
+    {
+        VisitBlockStatement(node.TryBlock);
+
+        foreach (var catchClause in node.CatchClauses)
+            VisitCatchClause(catchClause);
+
+        if (node.FinallyBlock is not null)
+            VisitBlockStatement(node.FinallyBlock);
+    }
+
+    public virtual void VisitCatchClause(BoundCatchClause node)
+    {
+        VisitBlockStatement(node.Block);
     }
 
     public virtual void VisitBlockStatement(BoundBlockStatement node)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTryStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTryStatement.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Raven.CodeAnalysis;
+
+internal partial class BoundTryStatement : BoundStatement
+{
+    public BoundTryStatement(
+        BoundBlockStatement tryBlock,
+        ImmutableArray<BoundCatchClause> catchClauses,
+        BoundBlockStatement? finallyBlock)
+    {
+        TryBlock = tryBlock;
+        CatchClauses = catchClauses;
+        FinallyBlock = finallyBlock;
+    }
+
+    public BoundBlockStatement TryBlock { get; }
+
+    public ImmutableArray<BoundCatchClause> CatchClauses { get; }
+
+    public BoundBlockStatement? FinallyBlock { get; }
+
+    public BoundTryStatement Update(
+        BoundBlockStatement tryBlock,
+        IEnumerable<BoundCatchClause> catchClauses,
+        BoundBlockStatement? finallyBlock)
+    {
+        return Update(tryBlock, ImmutableArray.CreateRange(catchClauses), finallyBlock);
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -49,6 +49,10 @@ internal class StatementGenerator : Generator
                 EmitForStatement(forStatement);
                 break;
 
+            case BoundTryStatement tryStatement:
+                EmitTryStatement(tryStatement);
+                break;
+
             case BoundBlockStatement blockStatement:
                 EmitBlockStatement(blockStatement);
                 break;
@@ -228,6 +232,51 @@ internal class StatementGenerator : Generator
             ILGenerator.Emit(OpCodes.Br_S, beginLabel);
             ILGenerator.MarkLabel(endLabel);
         }
+    }
+
+    private void EmitTryStatement(BoundTryStatement tryStatement)
+    {
+        ILGenerator.BeginExceptionBlock();
+
+        var tryScope = new Scope(this);
+        new StatementGenerator(tryScope, tryStatement.TryBlock).Emit();
+
+        foreach (var catchClause in tryStatement.CatchClauses)
+        {
+            var catchType = catchClause.ExceptionType;
+            if (catchType.TypeKind == TypeKind.Error)
+                catchType = Compilation.GetSpecialType(SpecialType.System_Object);
+
+            ILGenerator.BeginCatchBlock(ResolveClrType(catchType));
+
+            var catchScope = new Scope(this);
+
+            if (catchClause.Local is { } localSymbol)
+            {
+                var localType = localSymbol.Type;
+                if (localType.TypeKind == TypeKind.Error)
+                    localType = Compilation.GetSpecialType(SpecialType.System_Object);
+
+                var localBuilder = ILGenerator.DeclareLocal(ResolveClrType(localType));
+                catchScope.AddLocal(localSymbol, localBuilder);
+                ILGenerator.Emit(OpCodes.Stloc, localBuilder);
+            }
+            else
+            {
+                ILGenerator.Emit(OpCodes.Pop);
+            }
+
+            new StatementGenerator(catchScope, catchClause.Block).Emit();
+        }
+
+        if (tryStatement.FinallyBlock is { } finallyBlock)
+        {
+            ILGenerator.BeginFinallyBlock();
+            var finallyScope = new Scope(this);
+            new StatementGenerator(finallyScope, finallyBlock).Emit();
+        }
+
+        ILGenerator.EndExceptionBlock();
     }
 
     private void EmitBlockStatement(BoundBlockStatement blockStatement)

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -57,6 +57,8 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _fileScopedCodeRequiresConsole;
     private static DiagnosticDescriptor? _fileScopedCodeMultipleFiles;
     private static DiagnosticDescriptor? _consoleApplicationRequiresEntryPoint;
+    private static DiagnosticDescriptor? _tryStatementRequiresCatchOrFinally;
+    private static DiagnosticDescriptor? _catchTypeMustDeriveFromSystemException;
     private static DiagnosticDescriptor? _noOverloadForMethod;
     private static DiagnosticDescriptor? _cannotConvertFromTypeToType;
     private static DiagnosticDescriptor? _cannotAssignFromTypeToType;
@@ -743,6 +745,32 @@ internal static partial class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
+    /// RAV1015: A try statement must include at least one catch clause or a finally clause
+    /// </summary>
+    public static DiagnosticDescriptor TryStatementRequiresCatchOrFinally => _tryStatementRequiresCatchOrFinally ??= DiagnosticDescriptor.Create(
+        id: "RAV1015",
+        title: "try statement requires catch or finally",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "A try statement must include at least one catch clause or a finally clause",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// RAV1016: Type '{0}' is not derived from System.Exception
+    /// </summary>
+    public static DiagnosticDescriptor CatchTypeMustDeriveFromSystemException => _catchTypeMustDeriveFromSystemException ??= DiagnosticDescriptor.Create(
+        id: "RAV1016",
+        title: "Catch type must derive from System.Exception",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Type '{0}' is not derived from System.Exception",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// RAV1501: No overload for method '{0}' takes {1} arguments
     /// </summary>
     public static DiagnosticDescriptor NoOverloadForMethod => _noOverloadForMethod ??= DiagnosticDescriptor.Create(
@@ -1068,6 +1096,8 @@ internal static partial class CompilerDiagnostics
         FileScopedCodeRequiresConsole,
         FileScopedCodeMultipleFiles,
         ConsoleApplicationRequiresEntryPoint,
+        TryStatementRequiresCatchOrFinally,
+        CatchTypeMustDeriveFromSystemException,
         NoOverloadForMethod,
         CannotConvertFromTypeToType,
         CannotAssignFromTypeToType,
@@ -1144,6 +1174,8 @@ internal static partial class CompilerDiagnostics
         "RAV1012" => FileScopedCodeRequiresConsole,
         "RAV1013" => FileScopedCodeMultipleFiles,
         "RAV1014" => ConsoleApplicationRequiresEntryPoint,
+        "RAV1015" => TryStatementRequiresCatchOrFinally,
+        "RAV1016" => CatchTypeMustDeriveFromSystemException,
         "RAV1501" => NoOverloadForMethod,
         "RAV1503" => CannotConvertFromTypeToType,
         "RAV1504" => CannotAssignFromTypeToType,

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -158,6 +158,12 @@ public static partial class DiagnosticBagExtensions
     public static void ReportConsoleApplicationRequiresEntryPoint(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.ConsoleApplicationRequiresEntryPoint, location));
 
+    public static void ReportTryStatementRequiresCatchOrFinally(this DiagnosticBag diagnostics, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TryStatementRequiresCatchOrFinally, location));
+
+    public static void ReportCatchTypeMustDeriveFromSystemException(this DiagnosticBag diagnostics, object? typeName, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.CatchTypeMustDeriveFromSystemException, location, typeName));
+
     public static void ReportNoOverloadForMethod(this DiagnosticBag diagnostics, object? method, object? count, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.NoOverloadForMethod, location, method, count));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -186,6 +186,14 @@
     Title="Console application requires entry point"
     Message="Program.Main entry point not found" Category="compiler" Severity="Error"
     EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV1015" Identifier="TryStatementRequiresCatchOrFinally"
+    Title="try statement requires catch or finally"
+    Message="A try statement must include at least one catch clause or a finally clause"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV1016" Identifier="CatchTypeMustDeriveFromSystemException"
+    Title="Catch type must derive from System.Exception"
+    Message="Type '{typeName}' is not derived from System.Exception"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV1501" Identifier="NoOverloadForMethod"
     Title="No overload for method taking argument"
     Message="No overload for method '{method}' takes {count} arguments" Category="compiler"

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -33,6 +33,10 @@ internal class StatementSyntaxParser : SyntaxParser
                 statement = ParseIfStatementSyntax();
                 break;
 
+            case SyntaxKind.TryKeyword:
+                statement = ParseTryStatementSyntax();
+                break;
+
             case SyntaxKind.OpenBraceToken:
                 statement = ParseBlockStatementSyntax();
                 break;
@@ -71,6 +75,79 @@ internal class StatementSyntaxParser : SyntaxParser
         TryConsumeTerminator(out var terminatorToken);
 
         return IfStatement(ifKeyword, condition!, thenStatement!, elseKeyword, elseStatement, terminatorToken);
+    }
+
+    private TryStatementSyntax ParseTryStatementSyntax()
+    {
+        var tryKeyword = ReadToken();
+
+        var block = ParseBlockStatementSyntax();
+
+        var catchClauses = new List<CatchClauseSyntax>();
+
+        while (IsNextToken(SyntaxKind.CatchKeyword, out _))
+        {
+            catchClauses.Add(ParseCatchClauseSyntax());
+        }
+
+        FinallyClauseSyntax? finallyClause = null;
+
+        if (IsNextToken(SyntaxKind.FinallyKeyword, out _))
+        {
+            finallyClause = ParseFinallyClauseSyntax();
+        }
+
+        if (catchClauses.Count == 0 && finallyClause is null)
+        {
+            AddDiagnostic(DiagnosticInfo.Create(
+                CompilerDiagnostics.TryStatementRequiresCatchOrFinally,
+                GetSpanOfLastToken()));
+        }
+
+        SetTreatNewlinesAsTokens(true);
+        TryConsumeTerminator(out var terminatorToken);
+
+        return TryStatement(
+            tryKeyword,
+            block,
+            List(catchClauses.ToArray()),
+            finallyClause,
+            terminatorToken,
+            Diagnostics);
+    }
+
+    private CatchClauseSyntax ParseCatchClauseSyntax()
+    {
+        var catchKeyword = ReadToken();
+
+        CatchDeclarationSyntax? declaration = null;
+
+        if (ConsumeToken(SyntaxKind.OpenParenToken, out var openParenToken))
+        {
+            var type = new NameSyntaxParser(this).ParseTypeName();
+
+            SyntaxToken? identifier = null;
+
+            if (CanTokenBeIdentifier(PeekToken()))
+            {
+                identifier = ReadIdentifierToken();
+            }
+
+            ConsumeTokenOrMissing(SyntaxKind.CloseParenToken, out var closeParenToken);
+
+            declaration = CatchDeclaration(openParenToken, type!, identifier, closeParenToken);
+        }
+
+        var block = ParseBlockStatementSyntax();
+
+        return CatchClause(catchKeyword, declaration, block);
+    }
+
+    private FinallyClauseSyntax ParseFinallyClauseSyntax()
+    {
+        var finallyKeyword = ReadToken();
+        var block = ParseBlockStatementSyntax();
+        return FinallyClause(finallyKeyword, block);
     }
 
     private StatementSyntax? ParseFunctionSyntax()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -114,6 +114,13 @@
     <Slot Name="ElseStatement" Type="Statement" IsNullable="true" />
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
+  <Node Name="TryStatement" Inherits="Statement">
+    <Slot Name="TryKeyword" Type="Token" />
+    <Slot Name="Block" Type="BlockStatement" />
+    <Slot Name="CatchClauses" Type="List" ElementType="CatchClause" />
+    <Slot Name="FinallyClause" Type="FinallyClause" IsNullable="true" />
+    <Slot Name="TerminatorToken" Type="Token" />
+  </Node>
   <Node Name="LocalDeclarationStatement" Inherits="Statement">
     <Slot Name="Declaration" Type="VariableDeclaration" />
     <Slot Name="TerminatorToken" Type="Token" />
@@ -186,6 +193,21 @@
     <Slot Name="ReturnKeyword" Type="Token" />
     <Slot Name="Expression" Type="Expression" IsNullable="true" />
     <Slot Name="TerminatorToken" Type="Token" />
+  </Node>
+  <Node Name="CatchClause" Inherits="Node">
+    <Slot Name="CatchKeyword" Type="Token" />
+    <Slot Name="Declaration" Type="CatchDeclaration" IsNullable="true" />
+    <Slot Name="Block" Type="BlockStatement" />
+  </Node>
+  <Node Name="CatchDeclaration" Inherits="Node">
+    <Slot Name="OpenParenToken" Type="Token" />
+    <Slot Name="Type" Type="Type" />
+    <Slot Name="Identifier" Type="Token" IsNullable="true" />
+    <Slot Name="CloseParenToken" Type="Token" />
+  </Node>
+  <Node Name="FinallyClause" Inherits="Node">
+    <Slot Name="FinallyKeyword" Type="Token" />
+    <Slot Name="Block" Type="BlockStatement" />
   </Node>
   <Node Name="CompilationUnit" Inherits="Node">
     <Slot Name="Imports" Type="List" ElementType="ImportDirective" />

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -24,6 +24,9 @@
   <TokenKind Name="SelfKeyword" Text="self" IsReservedWord="true" />
   <TokenKind Name="IfKeyword" Text="if" IsReservedWord="true" />
   <TokenKind Name="ElseKeyword" Text="else" IsReservedWord="true" />
+  <TokenKind Name="TryKeyword" Text="try" IsReservedWord="true" />
+  <TokenKind Name="CatchKeyword" Text="catch" IsReservedWord="true" />
+  <TokenKind Name="FinallyKeyword" Text="finally" IsReservedWord="true" />
   <TokenKind Name="WhileKeyword" Text="while" IsReservedWord="true" />
   <TokenKind Name="ForKeyword" Text="for" IsReservedWord="true" />
   <TokenKind Name="EachKeyword" Text="each" IsReservedWord="true" />

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExceptionHandlingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExceptionHandlingTests.cs
@@ -1,0 +1,38 @@
+using Raven.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class ExceptionHandlingTests : DiagnosticTestBase
+{
+    [Fact]
+    public void TryStatement_WithoutCatchOrFinally_ReportsDiagnostic()
+    {
+        var code = "try { }";
+
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV1015").WithSpan(1, 1, 1, 4)
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void CatchClause_WithNonExceptionType_ReportsDiagnostic()
+    {
+        var code = """
+try {
+}
+catch (int ex) {
+}
+""";
+
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV1016").WithSpan(3, 8, 3, 11).WithArguments("int")
+            ]);
+
+        verifier.Verify();
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 
 using Raven.CodeAnalysis.Syntax;
@@ -283,5 +284,24 @@ public class ParserNewlineTests
 
         Assert.Equal(SyntaxKind.None, token.Kind);
         Assert.Equal(SyntaxKind.EndOfFileToken, context.PeekToken().Kind);
+    }
+
+    [Fact]
+    public void TryStatement_WithCatchAndFinally_ParsesClauses()
+    {
+        var source = "try { } catch (Exception ex) { } finally { }";
+        var lexer = new Lexer(new StringReader(source));
+        var context = new BaseParseContext(lexer);
+        var parser = new StatementSyntaxParser(context);
+
+        var statement = (TryStatementSyntax)parser.ParseStatement().CreateRed();
+
+        Assert.Equal(SyntaxKind.TryStatement, statement.Kind);
+        Assert.Single(statement.CatchClauses);
+
+        var catchClause = statement.CatchClauses[0];
+        Assert.NotNull(catchClause.Declaration);
+        Assert.Equal("ex", catchClause.Declaration!.Identifier?.Text);
+        Assert.NotNull(statement.FinallyClause);
     }
 }


### PR DESCRIPTION
## Summary
- add try/catch/finally tokens, syntax nodes, and parser support plus documentation updates
- bind try statements with catch diagnostics and emit IL for try/catch/finally including new bound nodes
- extend tests to cover parsing and diagnostics for exception handling and register new diagnostics

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests (fails: LambdaCodeGenTests.Lambda_CapturedLocalSharesMutations stack overflows in existing test)


------
https://chatgpt.com/codex/tasks/task_e_68d43ae1c85c832f8122cf7615281812