### PR TITLE
feat: implement using let declaration

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -12,6 +12,7 @@ partial class BlockBinder : Binder
 {
     private readonly ISymbol _containingSymbol;
     protected readonly Dictionary<string, (ILocalSymbol Symbol, int Depth)> _locals = new();
+    private readonly List<(ILocalSymbol Local, int Depth)> _localsToDispose = new();
     private int _scopeDepth;
     private bool _allowReturnsInExpression;
 
@@ -106,6 +107,8 @@ partial class BlockBinder : Binder
 
         var decl = variableDeclarator.Parent as VariableDeclarationSyntax;
         var isMutable = decl!.LetOrVarKeyword.IsKind(SyntaxKind.VarKeyword);
+        var isUsingDeclaration = decl.Parent is UsingDeclarationStatementSyntax;
+        var shouldDispose = isUsingDeclaration;
 
         ITypeSymbol type = Compilation.ErrorTypeSymbol;
         BoundExpression? boundInitializer = null;
@@ -183,9 +186,25 @@ partial class BlockBinder : Binder
         if (initializer is not null && boundInitializer is not null)
             CacheBoundNode(initializer.Value, boundInitializer);
 
+        if (isUsingDeclaration && type.TypeKind != TypeKind.Error)
+        {
+            var disposableType = Compilation.GetSpecialType(SpecialType.System_IDisposable);
+            if (disposableType.TypeKind != TypeKind.Error && !IsAssignable(disposableType, type, out _))
+            {
+                _diagnostics.ReportCannotConvertFromTypeToType(
+                    type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    disposableType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    variableDeclarator.Identifier.GetLocation());
+                shouldDispose = false;
+            }
+        }
+
         var declarator = new BoundVariableDeclarator(CreateLocalSymbol(variableDeclarator, name, isMutable, type), boundInitializer);
 
-        return new BoundLocalDeclarationStatement([declarator]);
+        if (shouldDispose)
+            _localsToDispose.Add((declarator.Local, _scopeDepth));
+
+        return new BoundLocalDeclarationStatement([declarator], isUsingDeclaration);
     }
 
     private ITypeSymbol EnsureTypeAccessible(ITypeSymbol type, Location location)
@@ -289,6 +308,7 @@ partial class BlockBinder : Binder
         BoundStatement boundNode = statement switch
         {
             LocalDeclarationStatementSyntax localDeclaration => BindLocalDeclaration(localDeclaration.Declaration.Declarators[0]),
+            UsingDeclarationStatementSyntax usingDeclaration => BindLocalDeclaration(usingDeclaration.Declaration.Declarators[0]),
             AssignmentStatementSyntax assignmentStatement => BindAssignmentStatement(assignmentStatement),
             ExpressionStatementSyntax expressionStmt => BindExpressionStatement(expressionStmt),
             IfStatementSyntax ifStmt => BindIfStatement(ifStmt),
@@ -336,7 +356,7 @@ partial class BlockBinder : Binder
                 ifExpr.ElseBranch is not null ? ExpressionToStatement(ifExpr.ElseBranch) : null),
             BoundWhileExpression whileExpr => new BoundWhileStatement(whileExpr.Condition, ExpressionToStatement(whileExpr.Body)),
             BoundForExpression forExpr => new BoundForStatement(forExpr.Local, forExpr.Collection, ExpressionToStatement(forExpr.Body)),
-            BoundBlockExpression blockExpr => new BoundBlockStatement(blockExpr.Statements),
+            BoundBlockExpression blockExpr => new BoundBlockStatement(blockExpr.Statements, blockExpr.LocalsToDispose),
             BoundAssignmentExpression assignmentExpr => new BoundAssignmentStatement(assignmentExpr),
             _ => new BoundExpressionStatement(expression),
         };
@@ -428,7 +448,15 @@ partial class BlockBinder : Binder
             boundStatements.Add(bound);
         }
 
-        var blockStmt = new BoundBlockStatement(boundStatements.ToArray());
+        var localsAtDepth = _localsToDispose
+            .Where(l => l.Depth == depth)
+            .Select(l => l.Local)
+            .ToList();
+
+        if (localsAtDepth.Count > 0)
+            _localsToDispose.RemoveAll(l => l.Depth == depth);
+
+        var blockStmt = new BoundBlockStatement(boundStatements.ToArray(), localsAtDepth.ToImmutableArray());
         CacheBoundNode(block, blockStmt);
 
         foreach (var name in _locals.Where(kvp => kvp.Value.Depth == depth).Select(kvp => kvp.Key).ToList())
@@ -491,7 +519,15 @@ partial class BlockBinder : Binder
 
         // Step 3: Create and cache the block
         var unitType = Compilation.GetSpecialType(SpecialType.System_Unit);
-        var blockExpr = new BoundBlockExpression(boundStatements.ToArray(), unitType);
+        var localsAtDepth = _localsToDispose
+            .Where(l => l.Depth == depth)
+            .Select(l => l.Local)
+            .ToList();
+
+        if (localsAtDepth.Count > 0)
+            _localsToDispose.RemoveAll(l => l.Depth == depth);
+
+        var blockExpr = new BoundBlockExpression(boundStatements.ToArray(), unitType, localsAtDepth.ToImmutableArray());
         CacheBoundNode(block, blockExpr);
 
         foreach (var name in _locals.Where(kvp => kvp.Value.Depth == depth).Select(kvp => kvp.Key).ToList())
@@ -1071,78 +1107,78 @@ partial class BlockBinder : Binder
             case BoundDiscardPattern:
                 return;
             case BoundDeclarationPattern declaration:
-            {
-                var patternType = UnwrapAlias(declaration.DeclaredType);
-
-                if (patternType.TypeKind == TypeKind.Error)
-                    return;
-
-                if (PatternCanMatch(scrutineeType, patternType))
-                    return;
-
-                var patternDisplay = GetMatchPatternDisplay(patternType);
-                var location = patternSyntax switch
                 {
-                    DeclarationPatternSyntax declarationSyntax => declarationSyntax.Type.GetLocation(),
-                    _ => patternSyntax.GetLocation(),
-                };
+                    var patternType = UnwrapAlias(declaration.DeclaredType);
 
-                _diagnostics.ReportMatchExpressionArmPatternInvalid(
-                    patternDisplay,
-                    scrutineeType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                    location);
-                return;
-            }
+                    if (patternType.TypeKind == TypeKind.Error)
+                        return;
+
+                    if (PatternCanMatch(scrutineeType, patternType))
+                        return;
+
+                    var patternDisplay = GetMatchPatternDisplay(patternType);
+                    var location = patternSyntax switch
+                    {
+                        DeclarationPatternSyntax declarationSyntax => declarationSyntax.Type.GetLocation(),
+                        _ => patternSyntax.GetLocation(),
+                    };
+
+                    _diagnostics.ReportMatchExpressionArmPatternInvalid(
+                        patternDisplay,
+                        scrutineeType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        location);
+                    return;
+                }
             case BoundConstantPattern constant:
-            {
-                var underlyingType = UnwrapAlias(constant.LiteralType.UnderlyingType);
-
-                if (underlyingType.TypeKind == TypeKind.Error)
-                    return;
-
-                if (PatternCanMatch(scrutineeType, underlyingType))
-                    return;
-
-                var patternDisplay = GetMatchPatternDisplay(constant.LiteralType);
-                var location = patternSyntax switch
                 {
-                    DeclarationPatternSyntax declarationSyntax => declarationSyntax.Type.GetLocation(),
-                    _ => patternSyntax.GetLocation(),
-                };
+                    var underlyingType = UnwrapAlias(constant.LiteralType.UnderlyingType);
 
-                _diagnostics.ReportMatchExpressionArmPatternInvalid(
-                    patternDisplay,
-                    scrutineeType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                    location);
-                return;
-            }
+                    if (underlyingType.TypeKind == TypeKind.Error)
+                        return;
+
+                    if (PatternCanMatch(scrutineeType, underlyingType))
+                        return;
+
+                    var patternDisplay = GetMatchPatternDisplay(constant.LiteralType);
+                    var location = patternSyntax switch
+                    {
+                        DeclarationPatternSyntax declarationSyntax => declarationSyntax.Type.GetLocation(),
+                        _ => patternSyntax.GetLocation(),
+                    };
+
+                    _diagnostics.ReportMatchExpressionArmPatternInvalid(
+                        patternDisplay,
+                        scrutineeType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        location);
+                    return;
+                }
             case BoundOrPattern orPattern:
-            {
-                if (patternSyntax is BinaryPatternSyntax binarySyntax)
                 {
-                    EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Left, orPattern.Left);
-                    EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Right, orPattern.Right);
-                }
+                    if (patternSyntax is BinaryPatternSyntax binarySyntax)
+                    {
+                        EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Left, orPattern.Left);
+                        EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Right, orPattern.Right);
+                    }
 
-                return;
-            }
+                    return;
+                }
             case BoundAndPattern andPattern:
-            {
-                if (patternSyntax is BinaryPatternSyntax binarySyntax)
                 {
-                    EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Left, andPattern.Left);
-                    EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Right, andPattern.Right);
+                    if (patternSyntax is BinaryPatternSyntax binarySyntax)
+                    {
+                        EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Left, andPattern.Left);
+                        EnsureMatchArmPatternValid(scrutineeType, binarySyntax.Right, andPattern.Right);
+                    }
+
+                    return;
                 }
-
-                return;
-            }
             case BoundNotPattern notPattern:
-            {
-                if (patternSyntax is UnaryPatternSyntax unarySyntax)
-                    EnsureMatchArmPatternValid(scrutineeType, unarySyntax.Pattern, notPattern.Pattern);
+                {
+                    if (patternSyntax is UnaryPatternSyntax unarySyntax)
+                        EnsureMatchArmPatternValid(scrutineeType, unarySyntax.Pattern, notPattern.Pattern);
 
-                return;
-            }
+                    return;
+                }
         }
     }
 
@@ -1291,14 +1327,14 @@ partial class BlockBinder : Binder
             case BoundDiscardPattern:
                 return true;
             case BoundDeclarationPattern { Designator: BoundDiscardDesignator } declaration:
-            {
-                var declaredType = UnwrapAlias(declaration.DeclaredType);
+                {
+                    var declaredType = UnwrapAlias(declaration.DeclaredType);
 
-                if (SymbolEqualityComparer.Default.Equals(declaredType, scrutineeType))
-                    return true;
+                    if (SymbolEqualityComparer.Default.Equals(declaredType, scrutineeType))
+                        return true;
 
-                return declaredType.SpecialType == SpecialType.System_Object;
-            }
+                    return declaredType.SpecialType == SpecialType.System_Object;
+                }
             case BoundOrPattern orPattern:
                 return IsCatchAllPattern(scrutineeType, orPattern.Left) ||
                        IsCatchAllPattern(scrutineeType, orPattern.Right);
@@ -1318,19 +1354,19 @@ partial class BlockBinder : Binder
                 RemoveMembersAssignableToPattern(remaining, declaration.DeclaredType);
                 break;
             case BoundConstantPattern constant:
-            {
-                var literalType = UnwrapAlias(constant.LiteralType);
-
-                foreach (var candidate in remaining.ToArray())
                 {
-                    var candidateType = UnwrapAlias(candidate);
+                    var literalType = UnwrapAlias(constant.LiteralType);
 
-                    if (SymbolEqualityComparer.Default.Equals(candidateType, literalType))
-                        remaining.Remove(candidate);
+                    foreach (var candidate in remaining.ToArray())
+                    {
+                        var candidateType = UnwrapAlias(candidate);
+
+                        if (SymbolEqualityComparer.Default.Equals(candidateType, literalType))
+                            remaining.Remove(candidate);
+                    }
+
+                    break;
                 }
-
-                break;
-            }
             case BoundOrPattern orPattern:
                 RemoveCoveredUnionMembers(remaining, orPattern.Left);
                 RemoveCoveredUnionMembers(remaining, orPattern.Right);

--- a/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
@@ -143,19 +143,19 @@ class MethodBodyBinder : BlockBinder
                 }
             }
 
-            return new BoundBlockStatement(statements);
+            return new BoundBlockStatement(statements, body.LocalsToDispose);
         }
 
         public override BoundNode? VisitBlockStatement(BoundBlockStatement node)
         {
             var statements = VisitList(node.Statements).Cast<BoundStatement>().ToList();
-            return new BoundBlockStatement(statements);
+            return new BoundBlockStatement(statements, node.LocalsToDispose);
         }
 
         public override BoundNode? VisitBlockExpression(BoundBlockExpression node)
         {
             var statements = VisitList(node.Statements).Cast<BoundStatement>().ToList();
-            return new BoundBlockExpression(statements, node.UnitType);
+            return new BoundBlockExpression(statements, node.UnitType, node.LocalsToDispose);
         }
 
         public override BoundNode? VisitAssignmentStatement(BoundAssignmentStatement node)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundBlockExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundBlockExpression.cs
@@ -1,18 +1,23 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis;
 
 internal partial class BoundBlockExpression : BoundExpression
 {
-    public BoundBlockExpression(IEnumerable<BoundStatement> statements, ITypeSymbol unitType)
+    public BoundBlockExpression(IEnumerable<BoundStatement> statements, ITypeSymbol unitType, ImmutableArray<ILocalSymbol> localsToDispose = default)
         : base((statements.LastOrDefault() as BoundExpressionStatement)?.Expression.Type ?? unitType, null, BoundExpressionReason.None)
     {
         Statements = statements;
         UnitType = unitType;
+        LocalsToDispose = localsToDispose.IsDefault ? ImmutableArray<ILocalSymbol>.Empty : localsToDispose;
     }
 
     public IEnumerable<BoundStatement> Statements { get; }
     public ITypeSymbol UnitType { get; }
+    public ImmutableArray<ILocalSymbol> LocalsToDispose { get; }
 }
 

--- a/src/Raven.CodeAnalysis/BoundTree/BoundBlockStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundBlockStatement.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis;
 
 internal partial class BoundBlockStatement : BoundStatement
 {
     public IEnumerable<BoundStatement> Statements { get; }
+    public ImmutableArray<ILocalSymbol> LocalsToDispose { get; }
 
-    public BoundBlockStatement(IEnumerable<BoundStatement> statements)
+    public BoundBlockStatement(IEnumerable<BoundStatement> statements, ImmutableArray<ILocalSymbol> localsToDispose = default)
     {
         Statements = statements;
+        LocalsToDispose = localsToDispose.IsDefault ? ImmutableArray<ILocalSymbol>.Empty : localsToDispose;
     }
 }

--- a/src/Raven.CodeAnalysis/BoundTree/BoundLocalDeclarationStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundLocalDeclarationStatement.cs
@@ -3,10 +3,12 @@ namespace Raven.CodeAnalysis;
 sealed partial class BoundLocalDeclarationStatement : BoundStatement
 {
     public IEnumerable<BoundVariableDeclarator> Declarators { get; }
+    public bool IsUsing { get; }
 
-    public BoundLocalDeclarationStatement(IEnumerable<BoundVariableDeclarator> declarators)
+    public BoundLocalDeclarationStatement(IEnumerable<BoundVariableDeclarator> declarators, bool isUsing = false)
     {
         Declarators = declarators;
+        IsUsing = isUsing;
     }
 
     public override ISymbol Symbol => Declarators.First().Local;

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs
@@ -1,14 +1,23 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Reflection.Emit;
+
+using Raven.CodeAnalysis.Symbols;
 
 namespace Raven.CodeAnalysis.CodeGen;
 
 class Scope : Generator
 {
     private readonly IDictionary<ISymbol, LocalBuilder> _localBuilders = new Dictionary<ISymbol, LocalBuilder>(SymbolEqualityComparer.Default);
+    private readonly ImmutableArray<ILocalSymbol> _localsToDispose;
 
-    public Scope(Generator parent) : base(parent)
+    public Scope(Generator parent) : this(parent, ImmutableArray<ILocalSymbol>.Empty)
     {
+    }
 
+    public Scope(Generator parent, ImmutableArray<ILocalSymbol> localsToDispose) : base(parent)
+    {
+        _localsToDispose = localsToDispose.IsDefault ? ImmutableArray<ILocalSymbol>.Empty : localsToDispose;
     }
 
     public override void AddLocal(ILocalSymbol localSymbol, LocalBuilder builder)
@@ -24,4 +33,18 @@ class Scope : Generator
 
         return Parent?.GetLocal(localSymbol);
     }
+
+    public override IEnumerable<ILocalSymbol> EnumerateLocalsToDispose()
+    {
+        for (int i = _localsToDispose.Length - 1; i >= 0; i--)
+            yield return _localsToDispose[i];
+
+        if (Parent is not null)
+        {
+            foreach (var local in Parent.EnumerateLocalsToDispose())
+                yield return local;
+        }
+    }
+
+    public ImmutableArray<ILocalSymbol> LocalsToDispose => _localsToDispose;
 }

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection.Emit;
 
@@ -57,20 +58,39 @@ internal class StatementGenerator : Generator
 
     private void EmitReturnStatement(BoundReturnStatement returnStatement)
     {
-        if (returnStatement.Expression is not null)
-        {
-            new ExpressionGenerator(this, returnStatement.Expression).Emit();
+        var localsToDispose = EnumerateLocalsToDispose().ToImmutableArray();
+        var returnType = MethodSymbol.ReturnType;
+        var expression = returnStatement.Expression;
+        ITypeSymbol? expressionType = expression?.Type;
+        LocalBuilder? resultTemp = null;
 
-            var expressionType = returnStatement.Expression.Type;
-            var returnType = MethodSymbol.ReturnType;
+        if (expression is not null)
+        {
+            new ExpressionGenerator(this, expression).Emit();
 
             if (returnType.SpecialType == SpecialType.System_Unit)
             {
-                // The method returns void in IL, so discard the unit value.
                 ILGenerator.Emit(OpCodes.Pop);
+                expression = null;
+                expressionType = null;
             }
-            else if (expressionType?.IsValueType == true &&
-                     (returnType.SpecialType is SpecialType.System_Object || returnType is IUnionTypeSymbol))
+            else if (localsToDispose.Length > 0 && expressionType is not null)
+            {
+                var clrType = ResolveClrType(expressionType);
+                resultTemp = ILGenerator.DeclareLocal(clrType);
+                ILGenerator.Emit(OpCodes.Stloc, resultTemp);
+            }
+        }
+
+        EmitDispose(localsToDispose);
+
+        if (expression is not null)
+        {
+            if (resultTemp is not null)
+                ILGenerator.Emit(OpCodes.Ldloc, resultTemp);
+
+            if (expressionType?.IsValueType == true &&
+                (returnType.SpecialType is SpecialType.System_Object || returnType is IUnionTypeSymbol))
             {
                 ILGenerator.Emit(OpCodes.Box, ResolveClrType(expressionType));
             }
@@ -232,8 +252,11 @@ internal class StatementGenerator : Generator
 
     private void EmitBlockStatement(BoundBlockStatement blockStatement)
     {
+        var scope = new Scope(this, blockStatement.LocalsToDispose);
         foreach (var s in blockStatement.Statements)
-            new StatementGenerator(this, s).Emit();
+            new StatementGenerator(scope, s).Emit();
+
+        EmitDispose(blockStatement.LocalsToDispose);
     }
 
     private void EmitBranchOpForCondition(BoundExpression expression, Label end, Scope scope)

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -33,6 +33,10 @@ internal class StatementSyntaxParser : SyntaxParser
                 statement = ParseIfStatementSyntax();
                 break;
 
+            case SyntaxKind.UsingKeyword:
+                statement = ParseUsingDeclarationStatementSyntax();
+                break;
+
             case SyntaxKind.OpenBraceToken:
                 statement = ParseBlockStatementSyntax();
                 break;
@@ -198,6 +202,15 @@ internal class StatementSyntaxParser : SyntaxParser
         }
 
         return ReturnStatement(returnKeyword, expression, terminatorToken, Diagnostics);
+    }
+
+    private UsingDeclarationStatementSyntax ParseUsingDeclarationStatementSyntax()
+    {
+        var usingKeyword = ReadToken();
+        var declaration = ParseVariableDeclarationSyntax();
+        var terminatorToken = ConsumeTerminator();
+
+        return UsingDeclarationStatement(usingKeyword, declaration, terminatorToken, Diagnostics);
     }
 
     private StatementSyntax? ParseDeclarationOrExpressionStatementSyntax()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -114,6 +114,11 @@
     <Slot Name="ElseStatement" Type="Statement" IsNullable="true" />
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
+  <Node Name="UsingDeclarationStatement" Inherits="Statement">
+    <Slot Name="UsingKeyword" Type="Token" />
+    <Slot Name="Declaration" Type="VariableDeclaration" />
+    <Slot Name="TerminatorToken" Type="Token" />
+  </Node>
   <Node Name="LocalDeclarationStatement" Inherits="Statement">
     <Slot Name="Declaration" Type="VariableDeclaration" />
     <Slot Name="TerminatorToken" Type="Token" />

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -11,6 +11,7 @@
   <TokenKind Name="ObjectKeyword" Text="object" IsReservedWord="true" />
   <TokenKind Name="ImportKeyword" Text="import" IsReservedWord="false" />
   <TokenKind Name="AliasKeyword" Text="alias" IsReservedWord="false" />
+  <TokenKind Name="UsingKeyword" Text="using" IsReservedWord="false" />
   <TokenKind Name="NamespaceKeyword" Text="namespace" IsReservedWord="false" />
   <TokenKind Name="LetKeyword" Text="let" IsReservedWord="true" />
   <TokenKind Name="VarKeyword" Text="var" IsReservedWord="true" />


### PR DESCRIPTION
## Summary
- add syntax and parsing support for `using let` declarations
- validate that `using` locals are disposable and track them per scope in the binder
- emit disposal IL at block exit and for early returns

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs --include src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs --include src/Raven.CodeAnalysis/BoundTree/BoundBlockExpression.cs --include src/Raven.CodeAnalysis/BoundTree/BoundBlockStatement.cs --include src/Raven.CodeAnalysis/BoundTree/BoundLocalDeclarationStatement.cs --include src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs --include src/Raven.CodeAnalysis/CodeGen/Generators/Generator.cs --include src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs --include src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs --include src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs --include src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
- dotnet build


------
https://chatgpt.com/codex/tasks/task_e_68d439ec3748832fa2517df7a0e6a27e