### PR TITLE
fix: handle IDisposable special type

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -894,6 +894,10 @@ public class Compilation
         {
             return GetTypeByMetadataName("System.Delegate");
         }
+        else if (specialType is SpecialType.System_IDisposable)
+        {
+            return GetTypeByMetadataName("System.IDisposable");
+        }
         else if (specialType is SpecialType.System_IntPtr)
         {
             return GetTypeByMetadataName("System.IntPtr");


### PR DESCRIPTION
## Summary
- add System.IDisposable handling to Compilation.GetSpecialType to support using declarations

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests (fails: existing test failures and logger exception)

------
https://chatgpt.com/codex/tasks/task_e_68d45172c5bc832fa7553800dec52e51