### PR TITLE
Enforce disposable values for using declarations

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -110,6 +110,23 @@ internal class MethodBodyGenerator
                     }
                 }
 
+                foreach (var usingDeclStmt in syntax.DescendantNodes()
+                    .OfType<UsingDeclarationStatementSyntax>())
+                {
+                    foreach (var localDeclarator in usingDeclStmt.Declaration.Declarators)
+                    {
+                        var localSymbol = GetDeclaredSymbol<ILocalSymbol>(localDeclarator);
+                        if (localSymbol?.Type is null)
+                            continue;
+
+                        var clrType = ResolveClrType(localSymbol.Type);
+                        var builder = ILGenerator.DeclareLocal(clrType);
+                        builder.SetLocalSymInfo(localSymbol.Name);
+
+                        scope.AddLocal(localSymbol, builder);
+                    }
+                }
+
                 foreach (var localFunctionStmt in compilationUnit.DescendantNodes().OfType<FunctionStatementSyntax>())
                 {
                     var methodSymbol = GetDeclaredSymbol<IMethodSymbol>(localFunctionStmt);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UsingDeclarationTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UsingDeclarationTests.cs
@@ -1,0 +1,73 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class UsingDeclarationTests : DiagnosticTestBase
+{
+    [Fact]
+    public void UsingDeclaration_InferredType_DisposableInitializer_NoDiagnostics()
+    {
+        const string source = """
+import System.*
+
+class Foo : IDisposable {
+    public init() {}
+    public Dispose() -> unit {}
+}
+
+using let foo = Foo()
+""";
+
+        var verifier = CreateVerifier(source);
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void UsingDeclaration_InferredType_NonDisposableInitializer_ReportsDiagnostic()
+    {
+        const string source = """
+class Foo {
+    public init() {}
+}
+
+using let foo = Foo()
+""";
+
+        var verifier = CreateVerifier(
+            source,
+            [
+                new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id)
+                    .WithSpan(5, 17, 5, 22)
+                    .WithArguments("Foo", "System.IDisposable")
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void UsingDeclaration_AnnotatedType_NonDisposableLocalType_ReportsDiagnostic()
+    {
+        const string source = """
+import System.*
+
+class Foo : IDisposable {
+    public init() {}
+    public Dispose() -> unit {}
+}
+
+using let foo: object = Foo()
+""";
+
+        var verifier = CreateVerifier(
+            source,
+            [
+                new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id)
+                    .WithSpan(8, 11, 8, 14)
+                    .WithArguments("object", "System.IDisposable")
+            ]);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- capture initializer types while binding `using` declarations so diagnostics can enforce that the assigned value implements `IDisposable`
- keep requiring the declared local type to be disposable and add regression tests for valid and invalid `using` declarations

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Semantics/UsingDeclarationTests.cs`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: known MethodReferenceCodeGenTests failures present on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d4594dfd08832fa0202e5dbb6b305f