### PR TITLE
fix: dispose top-level using declarations

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UsingDeclarationCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UsingDeclarationCodeGenTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class UsingDeclarationCodeGenTests
+{
+    [Fact]
+    public void TopLevelUsingDeclaration_DisposesAtEndOfScript()
+    {
+        var code = """
+import System.*
+
+class Foo : IDisposable {
+    public init() => Console.WriteLine("Init")
+    public Do() => Console.WriteLine("Do")
+    public Dispose() -> unit => Console.WriteLine("Dispose")
+}
+
+using let foo = Foo()
+foo.Do()
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create(
+                "script",
+                new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var entryPoint = assembly.EntryPoint!;
+
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+
+        try
+        {
+            Console.SetOut(writer);
+
+            var parameters = entryPoint.GetParameters().Length == 0
+                ? null
+                : new object?[] { Array.Empty<string>() };
+
+            entryPoint.Invoke(null, parameters);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        var output = writer.ToString()
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(new[] { "Init", "Do", "Dispose" }, output);
+    }
+}


### PR DESCRIPTION
## Summary
- track top-level `using let` declarations so their locals are disposed when the script scope ends
- update IL emission to execute global statements within a scope that can dispose the recorded locals
- add a regression test that verifies a top-level using declaration calls `Dispose`

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs,test/Raven.CodeAnalysis.Tests/CodeGen/UsingDeclarationCodeGenTests.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: MethodReferenceDiagnosticsTests expect different diagnostics; build also aborts due to TerminalLogger issue after failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d45e004134832f9e60dea7f550cf39