### PR TITLE
feat: add generic type declarations

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/TypeDeclarationBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeDeclarationBinder.cs
@@ -26,6 +26,15 @@ internal abstract class TypeDeclarationBinder : Binder
         return base.LookupSymbol(name);
     }
 
+    public override ITypeSymbol? LookupType(string name)
+    {
+        var typeParameter = ContainingSymbol.TypeParameters.FirstOrDefault(tp => tp.Name == name);
+        if (typeParameter is not null)
+            return typeParameter;
+
+        return base.LookupType(name);
+    }
+
     public override ISymbol? BindDeclaredSymbol(SyntaxNode node)
     {
         return node == Syntax ? ContainingSymbol : base.BindDeclaredSymbol(node);

--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -29,6 +29,15 @@ internal class TypeMemberBinder : Binder
         return base.LookupSymbol(name);
     }
 
+    public override ITypeSymbol? LookupType(string name)
+    {
+        var typeParameter = _containingType.TypeParameters.FirstOrDefault(tp => tp.Name == name);
+        if (typeParameter is not null)
+            return typeParameter;
+
+        return base.LookupType(name);
+    }
+
     public override ISymbol? BindDeclaredSymbol(SyntaxNode node)
     {
         return node switch

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -1,0 +1,61 @@
+using System.Collections.Immutable;
+
+namespace Raven.CodeAnalysis.Symbols;
+
+internal sealed class SourceTypeParameterSymbol : Symbol, ITypeParameterSymbol
+{
+    public SourceTypeParameterSymbol(
+        string name,
+        ISymbol containingSymbol,
+        INamedTypeSymbol? containingType,
+        INamespaceSymbol? containingNamespace,
+        Location[] locations,
+        SyntaxReference[] declaringSyntaxReferences,
+        int ordinal)
+        : base(SymbolKind.TypeParameter, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences)
+    {
+        Ordinal = ordinal;
+    }
+
+    public int Ordinal { get; }
+
+    public override string MetadataName => Name;
+
+    public SpecialType SpecialType => SpecialType.None;
+
+    public TypeKind TypeKind => TypeKind.TypeParameter;
+
+    public bool IsNamespace => false;
+
+    public bool IsType => true;
+
+    public bool IsReferenceType => false;
+
+    public bool IsValueType => false;
+
+    public INamedTypeSymbol? BaseType => null;
+
+    public ITypeSymbol? OriginalDefinition => this;
+
+    public ImmutableArray<ISymbol> GetMembers() => ImmutableArray<ISymbol>.Empty;
+
+    public ImmutableArray<ISymbol> GetMembers(string name) => ImmutableArray<ISymbol>.Empty;
+
+    public ITypeSymbol? LookupType(string name) => null;
+
+    public bool IsMemberDefined(string name, out ISymbol? symbol)
+    {
+        symbol = null;
+        return false;
+    }
+
+    public override void Accept(SymbolVisitor visitor)
+    {
+        visitor.DefaultVisit(this);
+    }
+
+    public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
+    {
+        return visitor.DefaultVisit(this);
+    }
+}

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -31,6 +31,14 @@
     <Slot Name="Parameters" Type="SeparatedList" ElementType="Parameter" />
     <Slot Name="CloseParenToken" Type="Token" />
   </Node>
+  <Node Name="TypeParameterList" Inherits="Node">
+    <Slot Name="LessThanToken" Type="Token" />
+    <Slot Name="Parameters" Type="SeparatedList" ElementType="TypeParameter" />
+    <Slot Name="GreaterThanToken" Type="Token" />
+  </Node>
+  <Node Name="TypeParameter" Inherits="Node">
+    <Slot Name="Identifier" Type="Token" />
+  </Node>
   <Node Name="Expression" Inherits="ExpressionOrPattern" IsAbstract="true" />
   <Node Name="VariableDesignation" Inherits="Node" IsAbstract="true" />
   <Node Name="SingleVariableDesignation" Inherits="VariableDesignation">
@@ -74,6 +82,7 @@
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Keyword" Type="Token" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
+    <Slot Name="TypeParameterList" Type="TypeParameterList" IsNullable="true" />
     <Slot Name="BaseList" Type="BaseList" IsNullable="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsNullable="true" IsInherited="true" />
     <Slot Name="OpenBraceToken" Type="Token" IsInherited="true" />
@@ -89,6 +98,7 @@
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Keyword" Type="Token" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
+    <Slot Name="TypeParameterList" Type="TypeParameterList" IsNullable="true" />
     <Slot Name="BaseList" Type="BaseList" IsNullable="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsNullable="true" IsInherited="true" />
     <Slot Name="OpenBraceToken" Type="Token" IsInherited="true" />

--- a/test/Raven.CodeAnalysis.Tests/Semantics/GenericTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/GenericTypeTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class GenericTypeTests : CompilationTestBase
+{
+    [Fact]
+    public void GenericClass_ExposesTypeParametersAndArguments()
+    {
+        var source = """
+            class Box<T>
+            {
+                public Value: T { get; }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+        var model = compilation.GetSemanticModel(tree);
+        var classDeclaration = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+
+        var classSymbol = (INamedTypeSymbol)model.GetDeclaredSymbol(classDeclaration)!;
+
+        Assert.True(classSymbol.IsGenericType);
+        Assert.Equal(1, classSymbol.Arity);
+        Assert.Equal("T", classSymbol.TypeParameters[0].Name);
+        Assert.Same(classSymbol.TypeParameters[0], classSymbol.TypeArguments[0]);
+
+        var propertySyntax = classDeclaration.Members.OfType<PropertyDeclarationSyntax>().Single();
+        var propertySymbol = (IPropertySymbol)model.GetDeclaredSymbol(propertySyntax)!;
+
+        Assert.Same(classSymbol.TypeParameters[0], propertySymbol.Type);
+        Assert.Empty(compilation.GetDiagnostics());
+    }
+}
+

--- a/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
@@ -21,6 +21,20 @@ public class ClassDeclarationParserTests : DiagnosticTestBase
     }
 
     [Fact]
+    public void ClassDeclaration_WithTypeParameters_ParsesTypeParameterList()
+    {
+        var source = "class Box<TValue, TOther> {}";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var declaration = Assert.IsType<ClassDeclarationSyntax>(Assert.Single(root.Members));
+
+        Assert.NotNull(declaration.TypeParameterList);
+        Assert.Equal(2, declaration.TypeParameterList!.Parameters.Count);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
     public void Constructor_WithExpressionBody_ParsesExpressionBody()
     {
         var source = """


### PR DESCRIPTION
## Summary
- extend the syntax model and parser so class and interface declarations accept type parameter lists
- add a source type parameter symbol and update named type symbols to track and construct generic definitions
- initialize type parameters during binding/semantic model construction and expose them through binder lookups
- add syntax and semantic regression tests covering generic class type parameter lists and binding

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: build breaks when parser project cannot see generated syntax node types in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46f95f948832fb2dd350f196f8ad1