### PR TITLE
feat: continue generic method support

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -14,11 +14,11 @@ internal class ExpressionGenerator : Generator
     private readonly BoundExpression _expression;
 
     private static readonly MethodInfo CreateDelegateMethod = typeof(Delegate)
-        .GetMethod(nameof(Delegate.CreateDelegate), new[] { typeof(Type), typeof(object), typeof(IntPtr) })
+        .GetMethod(nameof(Delegate.CreateDelegate), BindingFlags.Public | BindingFlags.Static, binder: null, new[] { typeof(Type), typeof(object), typeof(IntPtr) }, modifiers: null)
         ?? throw new InvalidOperationException("Failed to resolve Delegate.CreateDelegate(Type, object, IntPtr).");
 
     private static readonly MethodInfo GetTypeFromHandleMethod = typeof(Type)
-        .GetMethod(nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) })
+        .GetMethod(nameof(Type.GetTypeFromHandle), BindingFlags.Public | BindingFlags.Static, binder: null, new[] { typeof(RuntimeTypeHandle) }, modifiers: null)
         ?? throw new InvalidOperationException("Failed to resolve Type.GetTypeFromHandle(RuntimeTypeHandle).");
 
     public ExpressionGenerator(Generator parent, BoundExpression expression) : base(parent)

--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -264,6 +264,14 @@ internal sealed class AliasMethodSymbol : AliasSymbol, IMethodSymbol
     public bool IsVirtual => _method.IsVirtual;
 
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => _method.ExplicitInterfaceImplementations;
+
+    public ImmutableArray<ITypeParameterSymbol> TypeParameters => _method.TypeParameters;
+
+    public ImmutableArray<ITypeSymbol> TypeArguments => _method.TypeArguments;
+
+    public IMethodSymbol? ConstructedFrom => _method.ConstructedFrom;
+
+    public IMethodSymbol Construct(params ITypeSymbol[] typeArguments) => _method.Construct(typeArguments);
 }
 
 internal sealed class AliasPropertySymbol : AliasSymbol, IPropertySymbol

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Raven.CodeAnalysis.Symbols;
+
+internal sealed class ConstructedMethodSymbol : IMethodSymbol
+{
+    private readonly IMethodSymbol _definition;
+    private readonly ImmutableArray<ITypeSymbol> _typeArguments;
+    private readonly Dictionary<ITypeParameterSymbol, ITypeSymbol> _substitutionMap;
+    private ImmutableArray<IParameterSymbol>? _parameters;
+    private ITypeSymbol? _returnType;
+
+    public ConstructedMethodSymbol(IMethodSymbol definition, ImmutableArray<ITypeSymbol> typeArguments)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        _typeArguments = typeArguments;
+
+        var typeParameters = definition.TypeParameters;
+        if (typeParameters.Length != typeArguments.Length)
+            throw new ArgumentException($"Method '{definition.Name}' expects {typeParameters.Length} type arguments, but got {typeArguments.Length}.", nameof(typeArguments));
+
+        _substitutionMap = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(typeParameters.Length);
+        for (int i = 0; i < typeParameters.Length; i++)
+            _substitutionMap[typeParameters[i]] = typeArguments[i];
+    }
+
+    public IMethodSymbol Definition => _definition;
+
+    public string Name => _definition.Name;
+    public string MetadataName => _definition.MetadataName;
+    public SymbolKind Kind => _definition.Kind;
+    public bool IsImplicitlyDeclared => _definition.IsImplicitlyDeclared;
+    public bool CanBeReferencedByName => _definition.CanBeReferencedByName;
+    public bool IsAlias => _definition.IsAlias;
+    public ISymbol? UnderlyingSymbol => this;
+    public Accessibility DeclaredAccessibility => _definition.DeclaredAccessibility;
+    public bool IsStatic => _definition.IsStatic;
+    public ISymbol? ContainingSymbol => _definition.ContainingSymbol;
+    public INamedTypeSymbol? ContainingType => _definition.ContainingType;
+    public INamespaceSymbol? ContainingNamespace => _definition.ContainingNamespace;
+    public IAssemblySymbol? ContainingAssembly => _definition.ContainingAssembly;
+    public IModuleSymbol? ContainingModule => _definition.ContainingModule;
+    public ImmutableArray<Location> Locations => _definition.Locations;
+    public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _definition.DeclaringSyntaxReferences;
+
+    public ITypeSymbol ReturnType => _returnType ??= Substitute(_definition.ReturnType);
+
+    public ImmutableArray<IParameterSymbol> Parameters =>
+        _parameters ??= _definition.Parameters.Select(p => (IParameterSymbol)new ConstructedParameterSymbol(p, this)).ToImmutableArray();
+
+    public bool IsConstructor => _definition.IsConstructor;
+    public bool IsNamedConstructor => _definition.IsNamedConstructor;
+    public override bool Equals(object? obj) => _definition.Equals(obj);
+    public override int GetHashCode() => _definition.GetHashCode();
+
+    public MethodKind MethodKind => _definition.MethodKind;
+    public IMethodSymbol? OriginalDefinition => _definition.OriginalDefinition ?? _definition;
+    public bool IsAbstract => _definition.IsAbstract;
+    public bool IsAsync => _definition.IsAsync;
+    public bool IsCheckedBuiltin => _definition.IsCheckedBuiltin;
+    public bool IsDefinition => false;
+    public bool IsExtensionMethod => _definition.IsExtensionMethod;
+    public bool IsExtern => _definition.IsExtern;
+    public bool IsGenericMethod => _definition.IsGenericMethod;
+    public bool IsOverride => _definition.IsOverride;
+    public bool IsReadOnly => _definition.IsReadOnly;
+    public bool IsSealed => _definition.IsSealed;
+    public bool IsVirtual => _definition.IsVirtual;
+    public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => _definition.ExplicitInterfaceImplementations;
+    public ImmutableArray<ITypeParameterSymbol> TypeParameters => _definition.TypeParameters;
+    public ImmutableArray<ITypeSymbol> TypeArguments => _typeArguments;
+    public IMethodSymbol? ConstructedFrom => _definition;
+
+    public void Accept(SymbolVisitor visitor) => visitor.VisitMethod(this);
+    public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.VisitMethod(this);
+
+    public bool Equals(ISymbol? other) => SymbolEqualityComparer.Default.Equals(this, other);
+    public bool Equals(ISymbol? other, SymbolEqualityComparer comparer)
+    {
+        if (other is ConstructedMethodSymbol constructed)
+        {
+            if (!comparer.Equals(_definition, constructed._definition))
+                return false;
+            if (_typeArguments.Length != constructed._typeArguments.Length)
+                return false;
+
+            for (int i = 0; i < _typeArguments.Length; i++)
+            {
+                if (!comparer.Equals(_typeArguments[i], constructed._typeArguments[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        return _definition.Equals(other, comparer);
+    }
+
+    public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
+    {
+        if (typeArguments is null)
+            throw new ArgumentNullException(nameof(typeArguments));
+
+        return new ConstructedMethodSymbol(_definition, typeArguments.ToImmutableArray());
+    }
+
+    private ITypeSymbol Substitute(ITypeSymbol type)
+    {
+        if (type is ITypeParameterSymbol tp && _substitutionMap.TryGetValue(tp, out var replacement))
+            return replacement;
+
+        if (type is INamedTypeSymbol named && named.IsGenericType && !named.IsUnboundGenericType)
+        {
+            var substitutedArgs = named.TypeArguments.Select(Substitute).ToArray();
+            bool changed = false;
+            for (int i = 0; i < substitutedArgs.Length; i++)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(substitutedArgs[i], named.TypeArguments[i]))
+                {
+                    changed = true;
+                    break;
+                }
+            }
+
+            if (changed)
+                return named.Construct(substitutedArgs);
+        }
+
+        return type;
+    }
+
+    private sealed class ConstructedParameterSymbol : IParameterSymbol
+    {
+        private readonly IParameterSymbol _original;
+        private readonly ConstructedMethodSymbol _owner;
+
+        public ConstructedParameterSymbol(IParameterSymbol original, ConstructedMethodSymbol owner)
+        {
+            _original = original;
+            _owner = owner;
+        }
+
+        public string Name => _original.Name;
+        public SymbolKind Kind => _original.Kind;
+        public string MetadataName => _original.MetadataName;
+        public ISymbol? ContainingSymbol => _owner;
+        public IAssemblySymbol? ContainingAssembly => _original.ContainingAssembly;
+        public IModuleSymbol? ContainingModule => _original.ContainingModule;
+        public INamedTypeSymbol? ContainingType => _original.ContainingType;
+        public INamespaceSymbol? ContainingNamespace => _original.ContainingNamespace;
+        public ImmutableArray<Location> Locations => _original.Locations;
+        public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _original.DeclaringSyntaxReferences;
+        public bool IsImplicitlyDeclared => _original.IsImplicitlyDeclared;
+        public bool IsStatic => false;
+        public bool IsAlias => _original.IsAlias;
+        public ISymbol UnderlyingSymbol => this;
+        public Accessibility DeclaredAccessibility => _original.DeclaredAccessibility;
+        public ITypeSymbol Type => _owner.Substitute(_original.Type);
+        public bool IsParams => _original.IsParams;
+        public RefKind RefKind => _original.RefKind;
+
+        public void Accept(SymbolVisitor visitor) => visitor.VisitParameter(this);
+        public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.VisitParameter(this);
+        public bool Equals(ISymbol? other) => SymbolEqualityComparer.Default.Equals(this, other);
+        public bool Equals(ISymbol? other, SymbolEqualityComparer comparer) => comparer.Equals(this, other);
+    }
+}

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
@@ -170,6 +170,9 @@ internal sealed class SubstitutedMethodSymbol : IMethodSymbol
     public bool IsSealed => _original.IsSealed;
     public bool IsVirtual => _original.IsVirtual;
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => _original.ExplicitInterfaceImplementations;
+    public ImmutableArray<ITypeParameterSymbol> TypeParameters => _original.TypeParameters;
+    public ImmutableArray<ITypeSymbol> TypeArguments => _original.TypeArguments;
+    public IMethodSymbol? ConstructedFrom => _original.ConstructedFrom ?? _original;
     public SymbolKind Kind => _original.Kind;
     public string MetadataName => _original.MetadataName;
     public IAssemblySymbol? ContainingAssembly => _original.ContainingAssembly;
@@ -199,6 +202,11 @@ internal sealed class SubstitutedMethodSymbol : IMethodSymbol
 
     public bool Equals(ISymbol? other) =>
         SymbolEqualityComparer.Default.Equals(this, other);
+
+    public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
+    {
+        return new ConstructedMethodSymbol(this, typeArguments.ToImmutableArray());
+    }
 
     internal ConstructorInfo GetConstructorInfo(CodeGenerator codeGen)
     {

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -256,6 +256,14 @@ public interface IMethodSymbol : ISymbol
 
     ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations { get; }
 
+    ImmutableArray<ITypeParameterSymbol> TypeParameters { get; }
+
+    ImmutableArray<ITypeSymbol> TypeArguments { get; }
+
+    IMethodSymbol? ConstructedFrom { get; }
+
+    IMethodSymbol Construct(params ITypeSymbol[] typeArguments);
+
 }
 
 public enum MethodKind

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 
 namespace Raven.CodeAnalysis.Symbols;
@@ -39,6 +40,12 @@ internal sealed partial class SourceLambdaSymbol : SourceSymbol, ILambdaSymbol
 
     public IMethodSymbol? OriginalDefinition => null;
 
+    public ImmutableArray<ITypeParameterSymbol> TypeParameters => ImmutableArray<ITypeParameterSymbol>.Empty;
+
+    public ImmutableArray<ITypeSymbol> TypeArguments => ImmutableArray<ITypeSymbol>.Empty;
+
+    public IMethodSymbol? ConstructedFrom => null;
+
     public bool IsAbstract => false;
     public bool IsAsync => false;
     public bool IsCheckedBuiltin => false;
@@ -72,5 +79,10 @@ internal sealed partial class SourceLambdaSymbol : SourceSymbol, ILambdaSymbol
     public void SetCapturedVariables(IEnumerable<ISymbol> capturedVariables)
     {
         _capturedVariables = capturedVariables.ToImmutableArray();
+    }
+
+    public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
+    {
+        throw new NotSupportedException("Lambdas cannot be constructed with type arguments.");
     }
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -264,8 +264,6 @@ internal class TypeDeclarationParser : SyntaxParser
             ConsumeTokenOrNull(SyntaxKind.IdentifierToken, out identifier);
         }
 
-        // Check is open paren
-
         var parameterList = ParseParameterList();
 
         ConstructorInitializerSyntax? initializer = null;
@@ -340,6 +338,12 @@ internal class TypeDeclarationParser : SyntaxParser
         ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifier,
         SyntaxToken identifier)
     {
+        TypeParameterListSyntax? typeParameterList = null;
+        if (PeekToken().IsKind(SyntaxKind.LessThanToken))
+        {
+            typeParameterList = ParseTypeParameterList();
+        }
+
         var parameterList = ParseParameterList();
 
         var returnParameterAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseReturnTypeAnnotation();
@@ -368,14 +372,14 @@ internal class TypeDeclarationParser : SyntaxParser
 
         if (expressionBody is not null)
         {
-            return MethodDeclaration(modifiers, explicitInterfaceSpecifier, identifier, parameterList, returnParameterAnnotation, null, expressionBody, terminatorToken);
+            return MethodDeclaration(modifiers, explicitInterfaceSpecifier, identifier, typeParameterList, parameterList, returnParameterAnnotation, null, expressionBody, terminatorToken);
         }
         else if (body is not null)
         {
-            return MethodDeclaration(modifiers, explicitInterfaceSpecifier, identifier, parameterList, returnParameterAnnotation, body, null, terminatorToken);
+            return MethodDeclaration(modifiers, explicitInterfaceSpecifier, identifier, typeParameterList, parameterList, returnParameterAnnotation, body, null, terminatorToken);
         }
 
-        return MethodDeclaration(modifiers, explicitInterfaceSpecifier, identifier, parameterList, returnParameterAnnotation, null, null, terminatorToken);
+        return MethodDeclaration(modifiers, explicitInterfaceSpecifier, identifier, typeParameterList, parameterList, returnParameterAnnotation, null, null, terminatorToken);
     }
 
     private (ExplicitInterfaceSpecifierSyntax? ExplicitInterfaceSpecifier, SyntaxToken Identifier) ParseMemberNameWithExplicitInterface()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -559,6 +559,7 @@
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" />
     <Slot Name="Identifier" Type="Token" />
+    <Slot Name="TypeParameterList" Type="TypeParameterList" IsNullable="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsInherited="true" />
     <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="Body" Type="BlockStatement" IsNullable="true" IsInherited="true" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -241,8 +241,19 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
             explicitInterfaceSpecifier = node.ExplicitInterfaceSpecifier.Update(name, dotToken, identifierToken);
         }
 
-        var identifier = VisitToken(node.Identifier)!
-            .WithTrailingTrivia(SyntaxFactory.Space);
+        var identifier = VisitToken(node.Identifier)!;
+
+        TypeParameterListSyntax? typeParameterList = null;
+        if (node.TypeParameterList is not null)
+        {
+            identifier = identifier.WithTrailingTrivia(SyntaxFactory.TriviaList());
+            typeParameterList = (TypeParameterListSyntax)Visit(node.TypeParameterList)!;
+            typeParameterList = typeParameterList.WithTrailingTrivia(SyntaxFactory.Space);
+        }
+        else
+        {
+            identifier = identifier.WithTrailingTrivia(SyntaxFactory.Space);
+        }
 
         var parameterList = (ParameterListSyntax)VisitParameterList(node.ParameterList)!
             .WithTrailingTrivia(SyntaxFactory.Space);
@@ -252,7 +263,7 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
             returnType = (ArrowTypeClauseSyntax)VisitArrowTypeClause(node.ReturnType)!
                 .WithTrailingTrivia(SyntaxFactory.Space);
 
-        return node.Update(node.Modifiers, explicitInterfaceSpecifier, identifier, parameterList, returnType, (BlockStatementSyntax?)VisitBlockStatement(node.Body), null, node.TerminatorToken)
+        return node.Update(node.Modifiers, explicitInterfaceSpecifier, identifier, typeParameterList, parameterList, returnType, (BlockStatementSyntax?)VisitBlockStatement(node.Body), null, node.TerminatorToken)
             .WithLeadingTrivia(SyntaxFactory.TriviaList(
                 SyntaxFactory.CarriageReturnLineFeed,
                 SyntaxFactory.CarriageReturnLineFeed

--- a/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
@@ -314,6 +314,23 @@ public sealed class OverloadResolverTests : CompilationTestBase
         public bool IsVirtual => false;
 
         public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<IMethodSymbol>.Empty;
+
+        public ImmutableArray<ITypeParameterSymbol> TypeParameters => ImmutableArray<ITypeParameterSymbol>.Empty;
+
+        public ImmutableArray<ITypeSymbol> TypeArguments => ImmutableArray<ITypeSymbol>.Empty;
+
+        public IMethodSymbol? ConstructedFrom => this;
+
+        public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
+        {
+            if (typeArguments is null)
+                throw new ArgumentNullException(nameof(typeArguments));
+
+            if (typeArguments.Length != 0)
+                throw new InvalidOperationException("FakeMethodSymbol does not support generic construction.");
+
+            return this;
+        }
     }
 
     private sealed class FakeParameterSymbol : FakeSymbol, IParameterSymbol


### PR DESCRIPTION
## Summary
- add ConstructedMethodSymbol to represent instantiated generic methods, substituting return and parameter types as needed
- teach the parser and binders to accept method type parameters and skip the current declaration during duplicate signature checks
- plumb method type parameter APIs through alias/metadata symbols and update helper infrastructure, including explicit reflection lookups for delegate helpers

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: numerous semantic/codegen regressions introduced during ongoing generic method work)*

------
https://chatgpt.com/codex/tasks/task_e_68d47689600c832fb3c09d3ac54438ed