### PR TITLE
feat: infer generic method type arguments

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/GenericMethodTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/GenericMethodTests.cs
@@ -71,4 +71,83 @@ public sealed class GenericMethodTests : CompilationTestBase
         Assert.Same(intType, method.Parameters[0].Type);
         Assert.Empty(compilation.GetDiagnostics());
     }
+
+    [Fact]
+    public void GenericMethodInvocation_WithImplicitTypeArguments_BindsConstructedMethod()
+    {
+        var source = """
+            class Container
+            {
+                static identity<T>(value: T) -> T
+                {
+                    return value;
+                }
+
+                static call() -> int
+                {
+                    return identity(1);
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var method = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+
+        Assert.True(method.IsGenericMethod);
+        Assert.Equal("identity", method.Name);
+        Assert.Single(method.TypeArguments);
+        Assert.Same(intType, method.TypeArguments[0]);
+        Assert.Same(intType, method.ReturnType);
+        Assert.Same(intType, method.Parameters[0].Type);
+        Assert.Empty(compilation.GetDiagnostics());
+    }
+
+    [Fact]
+    public void GenericMethodInvocation_InfersFromConstructedGenericParameter()
+    {
+        var source = """
+            class Box<T>
+            {
+                public Value: T { get; }
+
+                public init(value: T)
+                {
+                    self.Value = value;
+                }
+            }
+
+            class Container
+            {
+                static unwrap<T>(box: Box<T>) -> T
+                {
+                    return box.Value;
+                }
+
+                static call() -> int
+                {
+                    let box = Box<int>(1);
+                    return unwrap(box);
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Last();
+        var method = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+
+        Assert.True(method.IsGenericMethod);
+        Assert.Equal("unwrap", method.Name);
+        Assert.Single(method.TypeArguments);
+        Assert.Same(intType, method.TypeArguments[0]);
+        Assert.Same(intType, method.ReturnType);
+        Assert.Same(intType, ((INamedTypeSymbol)method.Parameters[0].Type).TypeArguments[0]);
+        Assert.Empty(compilation.GetDiagnostics());
+    }
 }


### PR DESCRIPTION
## Summary
- add inference logic to resolve open generic method candidates using invocation argument types
- add regression tests covering implicit generic method invocations and nested generic parameters

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/OverloadResolver.cs,test/Raven.CodeAnalysis.Tests/Semantics/GenericMethodTests.cs
- MSBUILDTERMINALLOGGER=false dotnet test test/Raven.CodeAnalysis.Tests *(fails: pre-existing completion/semantic diagnostics and codegen issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ed34b62c832fa62f3c3ef90d7718