### PR TITLE
Add support for enforcing type/interface parameter constraints

### DIFF
--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -39,6 +39,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _explicitInterfaceSpecifierMustBeInterface;
     private static DiagnosticDescriptor? _containingTypeDoesNotImplementInterface;
     private static DiagnosticDescriptor? _explicitInterfaceMemberNotFound;
+    private static DiagnosticDescriptor? _typeArgumentDoesNotSatisfyConstraint;
     private static DiagnosticDescriptor? _nullableTypeInUnion;
     private static DiagnosticDescriptor? _typeNameDoesNotExistInType;
     private static DiagnosticDescriptor? _symbolIsInaccessible;
@@ -506,6 +507,19 @@ internal static partial class CompilerDiagnostics
         description: "",
         helpLinkUri: "",
         messageFormat: "Interface '{0}' does not contain a member named '{1}' matching this signature",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// RAV0320: The type '{0}' must satisfy the '{1}' constraint for type parameter '{2}' of '{3}'
+    /// </summary>
+    public static DiagnosticDescriptor TypeArgumentDoesNotSatisfyConstraint => _typeArgumentDoesNotSatisfyConstraint ??= DiagnosticDescriptor.Create(
+        id: "RAV0320",
+        title: "Type argument does not satisfy constraint",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "The type '{0}' must satisfy the '{1}' constraint for type parameter '{2}' of '{3}'",
         category: "compiler",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -1078,6 +1092,7 @@ internal static partial class CompilerDiagnostics
         ExplicitInterfaceSpecifierMustBeInterface,
         ContainingTypeDoesNotImplementInterface,
         ExplicitInterfaceMemberNotFound,
+        TypeArgumentDoesNotSatisfyConstraint,
         NullableTypeInUnion,
         TypeNameDoesNotExistInType,
         SymbolIsInaccessible,
@@ -1156,6 +1171,7 @@ internal static partial class CompilerDiagnostics
         "RAV0313" => ExplicitInterfaceSpecifierMustBeInterface,
         "RAV0314" => ContainingTypeDoesNotImplementInterface,
         "RAV0315" => ExplicitInterfaceMemberNotFound,
+        "RAV0320" => TypeArgumentDoesNotSatisfyConstraint,
         "RAV0400" => NullableTypeInUnion,
         "RAV0426" => TypeNameDoesNotExistInType,
         "RAV0500" => SymbolIsInaccessible,

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -104,6 +104,9 @@ public static partial class DiagnosticBagExtensions
     public static void ReportExplicitInterfaceMemberNotFound(this DiagnosticBag diagnostics, object? interfaceName, object? memberName, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.ExplicitInterfaceMemberNotFound, location, interfaceName, memberName));
 
+    public static void ReportTypeArgumentDoesNotSatisfyConstraint(this DiagnosticBag diagnostics, object? typeArgument, object? constraint, object? typeParameter, object? genericName, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TypeArgumentDoesNotSatisfyConstraint, location, typeArgument, constraint, typeParameter, genericName));
+
     public static void ReportNullableTypeInUnion(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.NullableTypeInUnion, location));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -121,6 +121,10 @@
     Title="Explicit interface member not found"
     Message="Interface '{interfaceName}' does not contain a member named '{memberName}' matching this signature"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV0320" Identifier="TypeArgumentDoesNotSatisfyConstraint"
+    Title="Type argument does not satisfy constraint"
+    Message="The type '{typeArgument}' must satisfy the '{constraint}' constraint for type parameter '{typeParameter}' of '{genericName}'"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0400" Identifier="NullableTypeInUnion"
     Title="Nullable type not allowed in union"
     Message="Nullable types are not allowed in union types" Category="compiler" Severity="Error"

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -398,6 +399,15 @@ public enum TypeKind
     Unit
 }
 
+[Flags]
+public enum TypeParameterConstraintKind
+{
+    None = 0,
+    ReferenceType = 1 << 0,
+    ValueType = 1 << 1,
+    TypeConstraint = 1 << 2,
+}
+
 public interface INamedTypeSymbol : ITypeSymbol
 {
     int Arity { get; }
@@ -438,6 +448,9 @@ public interface IUnionTypeSymbol : ITypeSymbol
 
 public interface ITypeParameterSymbol : ITypeSymbol
 {
+    TypeParameterConstraintKind ConstraintKind { get; }
+
+    ImmutableArray<ITypeSymbol> ConstraintTypes { get; }
 }
 
 public interface ILocalSymbol : ISymbol

--- a/src/Raven.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
@@ -11,18 +12,24 @@ internal sealed partial class PETypeParameterSymbol : Symbol, ITypeParameterSymb
 {
     private readonly Type _type;
 
+    private readonly TypeResolver _typeResolver;
+    private TypeParameterConstraintKind? _lazyConstraintKind;
+    private ImmutableArray<ITypeSymbol>? _lazyConstraintTypes;
+
     public PETypeParameterSymbol(
         Type type,
         ISymbol containingSymbol,
         INamedTypeSymbol? containingType,
         INamespaceSymbol? containingNamespace,
-        Location[] locations)
+        Location[] locations,
+        TypeResolver typeResolver)
         : base(containingSymbol, containingType, containingNamespace, locations, [])
     {
         if (!type.IsGenericParameter)
             throw new ArgumentException("Type must be a generic parameter", nameof(type));
 
         _type = type;
+        _typeResolver = typeResolver;
     }
 
     public override string Name => _type.Name;
@@ -34,6 +41,30 @@ internal sealed partial class PETypeParameterSymbol : Symbol, ITypeParameterSymb
     protected PEModuleSymbol PEContainingModule => (PEModuleSymbol)ContainingModule;
 
     public int Ordinal => _type.GenericParameterPosition;
+
+    public TypeParameterConstraintKind ConstraintKind
+    {
+        get
+        {
+            if (_lazyConstraintKind is not null)
+                return _lazyConstraintKind.Value;
+
+            var attributes = _type.GenericParameterAttributes;
+            var kind = TypeParameterConstraintKind.None;
+
+            if ((attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+                kind |= TypeParameterConstraintKind.ReferenceType;
+
+            if ((attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+                kind |= TypeParameterConstraintKind.ValueType;
+
+            if (_type.GetGenericParameterConstraints().Length > 0)
+                kind |= TypeParameterConstraintKind.TypeConstraint;
+
+            _lazyConstraintKind = kind;
+            return kind;
+        }
+    }
 
     //public bool HasConstructorConstraint => (_type.GenericParameterAttributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
     //public bool HasReferenceTypeConstraint => (_type.GenericParameterAttributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
@@ -55,6 +86,33 @@ public ImmutableArray<ITypeSymbol> ConstraintTypes =>
         .Cast<ITypeSymbol>()
         .ToImmutableArray();
 */
+
+    public ImmutableArray<ITypeSymbol> ConstraintTypes
+    {
+        get
+        {
+            if (_lazyConstraintTypes.HasValue)
+                return _lazyConstraintTypes.Value;
+
+            var constraints = _type.GetGenericParameterConstraints();
+            if (constraints.Length == 0)
+            {
+                _lazyConstraintTypes = ImmutableArray<ITypeSymbol>.Empty;
+                return _lazyConstraintTypes.Value;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<ITypeSymbol>(constraints.Length);
+            foreach (var constraint in constraints)
+            {
+                var resolved = _typeResolver.ResolveType(constraint, _type.DeclaringMethod);
+                if (resolved is not null)
+                    builder.Add(resolved);
+            }
+
+            _lazyConstraintTypes = builder.ToImmutable();
+            return _lazyConstraintTypes.Value;
+        }
+    }
 
     public INamedTypeSymbol? BaseType => null; // Not applicable to type parameters
     public ITypeSymbol? OriginalDefinition => this;

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -38,6 +38,18 @@
   </Node>
   <Node Name="TypeParameter" Inherits="Node">
     <Slot Name="Identifier" Type="Token" />
+    <Slot Name="ColonToken" Type="Token" IsNullable="true" />
+    <Slot Name="Constraints" Type="SeparatedList" ElementType="TypeParameterConstraint" IsNullable="true" />
+  </Node>
+  <Node Name="TypeParameterConstraint" Inherits="Node" IsAbstract="true" />
+  <Node Name="ClassConstraint" Inherits="TypeParameterConstraint">
+    <Slot Name="ClassKeyword" Type="Token" />
+  </Node>
+  <Node Name="StructConstraint" Inherits="TypeParameterConstraint">
+    <Slot Name="StructKeyword" Type="Token" />
+  </Node>
+  <Node Name="TypeConstraint" Inherits="TypeParameterConstraint">
+    <Slot Name="Type" Type="Type" />
   </Node>
   <Node Name="Expression" Inherits="ExpressionOrPattern" IsAbstract="true" />
   <Node Name="VariableDesignation" Inherits="Node" IsAbstract="true" />

--- a/src/Raven.CodeAnalysis/TypeResolver.cs
+++ b/src/Raven.CodeAnalysis/TypeResolver.cs
@@ -157,7 +157,7 @@ internal class TypeResolver(Compilation compilation)
                 return ResolveMethodTypeParameter(type, methodSymbol);
             }
 
-            return new PETypeParameterSymbol(type, declaringNamedType, declaringNamedType, declaringNamedType.ContainingNamespace, []);
+            return new PETypeParameterSymbol(type, declaringNamedType, declaringNamedType, declaringNamedType.ContainingNamespace, [], this);
         }
 
         if (type.IsArray)
@@ -180,7 +180,7 @@ internal class TypeResolver(Compilation compilation)
         if (_methodTypeParameters.TryGetValue(key, out var existing))
             return existing;
 
-        var symbol = new PETypeParameterSymbol(type, methodSymbol, methodSymbol.ContainingType, methodSymbol.ContainingNamespace, [new MetadataLocation(methodSymbol.ContainingModule!)]);
+        var symbol = new PETypeParameterSymbol(type, methodSymbol, methodSymbol.ContainingType, methodSymbol.ContainingNamespace, [new MetadataLocation(methodSymbol.ContainingModule!)], this);
         _methodTypeParameters[key] = symbol;
         return symbol;
     }


### PR DESCRIPTION
## Summary
- preserve and resolve source type parameter constraint types so constraint metadata is available during binding
- ensure type and method binders initialize constraint types and validate `class`, `struct`, and specific type/interface constraints when applying generic arguments

## Testing
- `dotnet build` *(warnings: existing NU1608, nullable analysis, analyzer noise)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f9038078832fb4909a2584fd46b1