### PR TITLE
Add coverage for generic type declarations

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -1197,6 +1197,9 @@ public class Compilation
 
     private static (TypeParameterConstraintKind constraintKind, ImmutableArray<SyntaxReference> constraintTypeReferences) AnalyzeTypeParameterConstraints(TypeParameterSyntax parameter)
     {
+        if (parameter.ColonToken is null)
+            return (TypeParameterConstraintKind.None, ImmutableArray<SyntaxReference>.Empty);
+
         var constraints = parameter.Constraints;
         if (constraints.Count == 0)
             return (TypeParameterConstraintKind.None, ImmutableArray<SyntaxReference>.Empty);

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -1008,6 +1008,9 @@ public partial class SemanticModel
 
     private static (TypeParameterConstraintKind constraintKind, ImmutableArray<SyntaxReference> constraintTypeReferences) AnalyzeTypeParameterConstraints(TypeParameterSyntax parameter)
     {
+        if (parameter.ColonToken is null)
+            return (TypeParameterConstraintKind.None, ImmutableArray<SyntaxReference>.Empty);
+
         var constraints = parameter.Constraints;
         if (constraints.Count == 0)
             return (TypeParameterConstraintKind.None, ImmutableArray<SyntaxReference>.Empty);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/GenericTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/GenericTypeTests.cs
@@ -36,5 +36,57 @@ public class GenericTypeTests : CompilationTestBase
         Assert.Same(classSymbol.TypeParameters[0], propertySymbol.Type);
         Assert.Empty(compilation.GetDiagnostics());
     }
+
+    [Fact]
+    public void GenericClassDeclaration_Compilation_ExposesTypeParameters()
+    {
+        var source = """
+            class Box<T>
+            {
+                public Value: T { get; }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+
+        compilation.GetSemanticModel(tree);
+
+        var classSymbol = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            compilation.SourceGlobalNamespace.LookupType("Box"));
+
+        Assert.True(classSymbol.IsGenericType);
+        Assert.Equal(1, classSymbol.Arity);
+        Assert.Equal("T", classSymbol.TypeParameters[0].Name);
+        Assert.Same(classSymbol.TypeParameters[0], classSymbol.TypeArguments[0]);
+        Assert.Empty(compilation.GetDiagnostics());
+    }
+
+    [Fact]
+    public void GenericClass_WithTypeParameterConstraints_RecordsConstraintKind()
+    {
+        var source = """
+            interface IFoo {}
+
+            class Box<T: class, IFoo>
+            {
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+
+        compilation.GetSemanticModel(tree);
+
+        var classSymbol = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            compilation.SourceGlobalNamespace.LookupType("Box"));
+
+        var typeParameter = Assert.Single(classSymbol.TypeParameters);
+
+        Assert.Equal(
+            TypeParameterConstraintKind.ReferenceType | TypeParameterConstraintKind.TypeConstraint,
+            typeParameter.ConstraintKind);
+        Assert.Empty(compilation.GetDiagnostics());
+    }
 }
 


### PR DESCRIPTION
## Summary
- add semantic model coverage for generic class declarations resolved through the compilation
- add a constraint-focused generic class test to verify constraint flags
- guard type parameter constraint analysis against missing constraint lists

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter GenericClass_ExposesTypeParametersAndArguments
- dotnet test test/Raven.CodeAnalysis.Tests --filter GenericClassDeclaration_Compilation_ExposesTypeParameters
- dotnet test test/Raven.CodeAnalysis.Tests --filter GenericClass_WithTypeParameterConstraints_RecordsConstraintKind
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: SemanticClassifierTests.AliasDirective_ClassifiesQualifiedNameParts)*

------
https://chatgpt.com/codex/tasks/task_e_68d50577e03c832fa0df50147aee95ef