### PR TITLE
fix: support generic parameter emission

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
@@ -130,4 +130,6 @@ public ImmutableArray<ITypeSymbol> ConstraintTypes =>
         symbol = null;
         return false;
     }
+
+    internal Type GetTypeInfo() => _type;
 }

--- a/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
@@ -33,6 +33,17 @@ public static class TypeSymbolExtensionsForCodeGen
             return namedTypeSymbol.GetTypeInfo();
         }
 
+        if (typeSymbol is ITypeParameterSymbol typeParameterSymbol)
+        {
+            if (codeGen.TryGetRuntimeTypeForTypeParameter(typeParameterSymbol, out var parameterType))
+                return parameterType;
+
+            if (typeParameterSymbol is PETypeParameterSymbol peTypeParameter)
+                return peTypeParameter.GetTypeInfo();
+
+            throw new InvalidOperationException($"Unable to resolve runtime type for type parameter: {typeParameterSymbol.Name}");
+        }
+
         var compilation = codeGen.Compilation;
 
         // Handle arrays


### PR DESCRIPTION
## Summary
- resolve CLR types for type parameters by consulting registered builder mappings during code generation
- register generic type and method parameters (including constraints) when defining type and method builders
- expose the runtime type for metadata type parameters to unblock mixed source/metadata generic scenarios

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing failing tests and MSBuild logger crash in current baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68d50cd92dc8832f8bade1cb9d9001dc