### PR TITLE
fix: hide inaccessible symbols from completion

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -40,7 +40,7 @@ internal abstract class Binder
         }
     }
 
-    protected bool IsSymbolAccessible(ISymbol symbol)
+    protected internal bool IsSymbolAccessible(ISymbol symbol)
     {
         if (symbol is null)
             return true;


### PR DESCRIPTION
## Summary
- expose Binder.IsSymbolAccessible for use outside binder subclasses
- filter completion lists using accessibility checks for type member, object creation, and general symbol suggestions
- add a regression test that ensures private static members are omitted from type completions

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~CompletionServiceTests.GetCompletions_OnType_ExcludesInaccessibleMembers" --logger "console;verbosity=minimal"
- dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName~CompletionServiceTests" *(fails in this environment because the existing import/alias completion tests return no items even without these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d5101b14b4832f9b26b40b9afe0a85