### PR TITLE
docs: recommend decompiler for ravc assemblies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,4 @@ If your changes touch documentation only, you may skip `dotnet build` and `dotne
 * Workspace management and incremental compilation are key; favor additive changes.
 * Consult `docs/` for language grammar and feature design before modifying syntax or semantics.
 * Instruct Codex to conclude the diff instead of showing every change, and avoid gathering all line numbers for very large diffs.
+* When debugging the `ravc` output assemblies (e.g., `test.dll`), leverage the [`ICSharpCode.Decompiler`](https://www.nuget.org/packages/ICSharpCode.Decompiler/) NuGet package for inspection and analysis.


### PR DESCRIPTION
## Summary
- add guidance for using the ICSharpCode.Decompiler NuGet package when inspecting ravc-generated assemblies

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68d51b6b66a0832fae7a5af25542fde0