### PR TITLE
fix: synthesize default constructors for named ctors

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/AccessibilityTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/AccessibilityTests.cs
@@ -114,6 +114,31 @@ public class CtorContainer {
     }
 
     [Fact]
+    public void NamedConstructor_SynthesizesPrivateDefaultConstructor()
+    {
+        var code = """
+public class Person {
+    var name: string;
+
+    public init WithName(name: string) {
+        self.name = name;
+    }
+}
+""";
+
+        using var metadataContext = Emit(code, out var assembly);
+
+        var person = assembly.GetType("Person", throwOnError: true)!;
+
+        var publicCtor = person.GetConstructor(BindingFlags.Instance | BindingFlags.Public, binder: null, types: Type.EmptyTypes, modifiers: null);
+        Assert.Null(publicCtor);
+
+        var nonPublicCtor = person.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, binder: null, types: Type.EmptyTypes, modifiers: null);
+        Assert.NotNull(nonPublicCtor);
+        Assert.Equal(MethodAttributes.Private, nonPublicCtor!.Attributes & MethodAttributes.MemberAccessMask);
+    }
+
+    [Fact]
     public void SemanticModel_ReportsDeclaredAccessibility()
     {
         var code = """


### PR DESCRIPTION
## Summary
- stop generating public parameterless constructors when a type already declares any constructors or named constructors
- synthesize a private parameterless constructor when named constructors require one
- add a codegen test ensuring named constructors only expose a private default constructor

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests

------
https://chatgpt.com/codex/tasks/task_e_68d525f0626c832fa43f9142d3e9b994