### PR TITLE
docs: refresh lambda sample

### DIFF
--- a/src/Raven.Compiler/samples/lambda.rav
+++ b/src/Raven.Compiler/samples/lambda.rav
@@ -1,12 +1,36 @@
 /*
- * Lambda expressions (WIP)
+ * Lambda expressions
  * * * */
 
-let i = 2
+import System.Console.*
 
-let f = func (a : int, b : int) -> int = a + b + i
+// Expression-bodied lambda assigned to a local delegate
+let add = func (a: int, b: int) -> int => a + b
+WriteLine("2 + 3 = " + add(2, 3).ToString())
 
-let f2 = func (a: int, b: int) -> int = {
-    let sum = a + b
-    return sum + i
+// Block-bodied lambda that captures and mutates an outer variable
+var offset = 10
+let adjust = func (value: int) -> int => {
+    let result = value + offset
+    offset = offset + 1
+    result
 }
+
+WriteLine("adjust(5) = " + adjust(5).ToString())
+WriteLine("offset after adjust = " + offset.ToString())
+
+// Nested lambda returning a closure that shares captured state
+let makeIncrementer = func (start: int) => {
+    var current = start
+
+    let increment = func (delta: int) -> int => {
+        current = current + delta
+        current
+    }
+
+    return increment
+}
+
+let increment = makeIncrementer(3)
+WriteLine("first call = " + increment(2).ToString())
+WriteLine("second call = " + increment(4).ToString())


### PR DESCRIPTION
## Summary
- update the lambda sample to use the implemented `func (...) =>` syntax
- demonstrate capturing locals and returning nested closures so the sample mirrors runtime behavior

## Testing
- `dotnet build` *(fails: missing generated syntax types in Raven.CodeAnalysis after running NodeGenerator)*

------
https://chatgpt.com/codex/tasks/task_e_68d5297241a4832f95094a7f4e1d2e79