### PR TITLE
fix: tidy type mismatch diagnostic quoting

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -170,8 +170,8 @@ partial class BlockBinder : Binder
                 if (!IsAssignable(type, boundInitializer.Type!, out var conversion))
                 {
                     _diagnostics.ReportCannotAssignFromTypeToType(
-                        boundInitializer.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        boundInitializer.Type!.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        type.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
                         initializer.Value.GetLocation());
                     boundInitializer = new BoundErrorExpression(type, null, BoundExpressionReason.TypeMismatch);
                 }
@@ -3059,8 +3059,8 @@ partial class BlockBinder : Binder
                     if (!IsAssignable(arrayType.ElementType, right.Type, out var conversion))
                     {
                         _diagnostics.ReportCannotAssignFromTypeToType(
-                            right.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                            arrayType.ElementType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                            right.Type.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                            arrayType.ElementType.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
                             rightSyntax.GetLocation());
                         return new BoundErrorExpression(arrayType.ElementType, null, BoundExpressionReason.TypeMismatch);
                     }
@@ -3088,8 +3088,8 @@ partial class BlockBinder : Binder
                 if (!IsAssignable(indexer.Type, right.Type, out var conversion))
                 {
                     _diagnostics.ReportCannotAssignFromTypeToType(
-                        right.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        indexer.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        right.Type.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        indexer.Type.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
                         rightSyntax.GetLocation());
                     return new BoundErrorExpression(indexer.Type, null, BoundExpressionReason.TypeMismatch);
                 }
@@ -3124,8 +3124,8 @@ partial class BlockBinder : Binder
                 if (!IsAssignable(localSymbol.Type, right2.Type!, out var conversion))
                 {
                     _diagnostics.ReportCannotAssignFromTypeToType(
-                        right2.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        localSymbol.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        right2.Type!.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        localSymbol.Type.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
                         rightSyntax.GetLocation());
                     return new BoundErrorExpression(localSymbol.Type, null, BoundExpressionReason.TypeMismatch);
                 }
@@ -3150,8 +3150,8 @@ partial class BlockBinder : Binder
                 if (!IsAssignable(fieldSymbol.Type, right2.Type!, out var conversion))
                 {
                     _diagnostics.ReportCannotAssignFromTypeToType(
-                        right2.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        fieldSymbol.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        right2.Type!.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        fieldSymbol.Type.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
                         rightSyntax.GetLocation());
                     return new BoundErrorExpression(fieldSymbol.Type, null, BoundExpressionReason.TypeMismatch);
                 }
@@ -3194,8 +3194,8 @@ partial class BlockBinder : Binder
                 if (!IsAssignable(propertySymbol.Type, right2.Type!, out var conversion))
                 {
                     _diagnostics.ReportCannotAssignFromTypeToType(
-                        right2.Type!.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        propertySymbol.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        right2.Type!.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        propertySymbol.Type.ToDisplayStringForTypeMismatchDiagnostic(SymbolDisplayFormat.MinimallyQualifiedFormat),
                         rightSyntax.GetLocation());
                     return new BoundErrorExpression(propertySymbol.Type, null, BoundExpressionReason.TypeMismatch);
                 }

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -811,14 +811,14 @@ internal static partial class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
-    /// RAV1504: Cannot assign '{0}' to '{1}'
+    /// RAV1504: Cannot assign {0} to {1}
     /// </summary>
     public static DiagnosticDescriptor CannotAssignFromTypeToType => _cannotAssignFromTypeToType ??= DiagnosticDescriptor.Create(
         id: "RAV1504",
         title: "Cannot assign to type",
         description: "",
         helpLinkUri: "",
-        messageFormat: "Cannot assign '{0}' to '{1}'",
+        messageFormat: "Cannot assign {0} to {1}",
         category: "compiler",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -207,7 +207,7 @@
     Message="Cannot convert from '{fromType}' to '{toType}'" Category="compiler"
     Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV1504" Identifier="CannotAssignFromTypeToType" Title="Cannot assign to type"
-    Message="Cannot assign '{fromType}' to '{toType}'" Category="compiler" Severity="Error"
+    Message="Cannot assign {fromType} to {toType}" Category="compiler" Severity="Error"
     EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV1525" Identifier="InvalidExpressionTerm" Title="Invalid expression term"
     Message="Invalid expression term '{tokenText}'" Category="compiler" Severity="Error"

--- a/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
@@ -69,6 +69,16 @@ public static partial class SymbolExtensions
         return typeSymbol.ToDisplayStringKeywordAware(format);
     }
 
+    public static string ToDisplayStringForTypeMismatchDiagnostic(this ITypeSymbol typeSymbol, SymbolDisplayFormat format)
+    {
+        var display = typeSymbol.ToDisplayStringKeywordAware(format);
+
+        if (display.IndexOf('\'') >= 0 || display.IndexOf('"') >= 0)
+            return display;
+
+        return $"'{display}'";
+    }
+
     public static string ToDisplayString(this ISymbol symbol, SymbolDisplayFormat? format = default!)
     {
         format ??= SymbolDisplayFormat.CSharpErrorMessageFormat;


### PR DESCRIPTION
## Summary
- update RAV1504 to avoid double quoting literal type names in diagnostics
- add a helper that quotes type names only when needed and use it when reporting assignment mismatches

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing ArgumentNullException in PropertyDeclarationSyntax ctor)*

------
https://chatgpt.com/codex/tasks/task_e_68d52f866438832f965f6d7e3630bf4c