### PR TITLE
Fix duplicate program function symbol emission

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/FunctionBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/FunctionBinder.cs
@@ -32,6 +32,19 @@ class FunctionBinder : Binder
 
         //ISymbol container = null; //this.ContainingSymbol;
         var container = Compilation.SourceGlobalNamespace.LookupType("Program") as INamedTypeSymbol;
+        if (container is null)
+            throw new InvalidOperationException("Synthesized Program type not found.");
+
+        var existingMethod = container
+            .GetMembers(_syntax.Identifier.Text)
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.DeclaringSyntaxReferences.Any(r => r.GetSyntax() == _syntax));
+
+        if (existingMethod is SourceMethodSymbol existingSource)
+        {
+            _methodSymbol = existingSource;
+            return _methodSymbol;
+        }
 
         var returnType = _syntax.ReturnType is null
             ? Compilation.GetSpecialType(SpecialType.System_Unit)


### PR DESCRIPTION
## Summary
- avoid synthesizing duplicate source method symbols when retrieving binders for top-level function statements
- reuse the previously created symbol if the function binder is invoked again for the same declaration

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d52a7dc674832f82a3014ddd4b6a8c