### PR TITLE
fix: keep return statements from being eaten by terminator parsing

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -169,6 +169,13 @@ internal class SyntaxParser : ParseContext
             return true;
         }
 
+        if (IsPotentialStatementStart(current))
+        {
+            token = Token(SyntaxKind.None);
+            SetTreatNewlinesAsTokens(previous);
+            return true;
+        }
+
         var skippedTokens = new List<SyntaxToken>();
 
         while (true)
@@ -178,6 +185,14 @@ internal class SyntaxParser : ParseContext
                 t = t.WithLeadingTrivia(Array.Empty<SyntaxTrivia>());
             skippedTokens.Add(t);
             current = PeekToken();
+
+            if (IsPotentialStatementStart(current))
+            {
+                AddSkippedToPending(skippedTokens);
+                token = Token(SyntaxKind.None);
+                SetTreatNewlinesAsTokens(previous);
+                return true;
+            }
 
             if (current.Kind == SyntaxKind.SemicolonToken)
             {
@@ -202,6 +217,26 @@ internal class SyntaxParser : ParseContext
                 return true;
             }
         }
+    }
+
+    private static bool IsPotentialStatementStart(SyntaxToken token)
+    {
+        return token.Kind switch
+        {
+            SyntaxKind.None => false,
+            SyntaxKind.EndOfFileToken => false,
+            SyntaxKind.CloseBraceToken => false,
+            SyntaxKind.CloseParenToken => false,
+            SyntaxKind.CloseBracketToken => false,
+            SyntaxKind.SemicolonToken => false,
+            SyntaxKind.CommaToken => false,
+            SyntaxKind.ColonToken => false,
+            SyntaxKind.NewLineToken => false,
+            SyntaxKind.LineFeedToken => false,
+            SyntaxKind.CarriageReturnToken => false,
+            SyntaxKind.CarriageReturnLineFeedToken => false,
+            _ => true,
+        };
     }
 
     private SyntaxToken ConsumeWithLeadingSkipped(List<SyntaxToken> skippedTokens)


### PR DESCRIPTION
## Summary
- treat upcoming statement-start tokens as implicit terminators instead of skipped trivia in `TryConsumeTerminator`
- add helper that recognises tokens which should begin a new statement so they are no longer attached to preceding newlines

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --no-build *(fails: numerous pre-existing unit failures in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d5331ad03c832fbdc97f4c4a99abcd