### PR TITLE
fix: respect Program.Main when selecting entry point

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -180,7 +180,7 @@ internal class MethodGenerator
             i++;
         }
 
-        if (MethodSymbol.Name == "Main" && MethodSymbol.ContainingType?.Name == "Program")
+        if (TypeGenerator.CodeGen.Compilation.IsEntryPointCandidate(MethodSymbol))
         {
             IsEntryPointCandidate = true;
         }

--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -180,7 +180,7 @@ internal class MethodGenerator
             i++;
         }
 
-        if (MethodSymbol.Name == "Main")
+        if (MethodSymbol.Name == "Main" && MethodSymbol.ContainingType?.Name == "Program")
         {
             IsEntryPointCandidate = true;
         }

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -58,6 +58,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _fileScopedCodeRequiresConsole;
     private static DiagnosticDescriptor? _fileScopedCodeMultipleFiles;
     private static DiagnosticDescriptor? _consoleApplicationRequiresEntryPoint;
+    private static DiagnosticDescriptor? _entryPointIsAmbiguous;
     private static DiagnosticDescriptor? _tryStatementRequiresCatchOrFinally;
     private static DiagnosticDescriptor? _catchTypeMustDeriveFromSystemException;
     private static DiagnosticDescriptor? _noOverloadForMethod;
@@ -759,6 +760,19 @@ internal static partial class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
+    /// RAV1017: Program has more than one entry point defined
+    /// </summary>
+    public static DiagnosticDescriptor EntryPointIsAmbiguous => _entryPointIsAmbiguous ??= DiagnosticDescriptor.Create(
+        id: "RAV1017",
+        title: "Program has more than one entry point defined",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Program has more than one entry point defined",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// RAV1015: A try statement must include at least one catch clause or a finally clause
     /// </summary>
     public static DiagnosticDescriptor TryStatementRequiresCatchOrFinally => _tryStatementRequiresCatchOrFinally ??= DiagnosticDescriptor.Create(
@@ -1111,6 +1125,7 @@ internal static partial class CompilerDiagnostics
         FileScopedCodeRequiresConsole,
         FileScopedCodeMultipleFiles,
         ConsoleApplicationRequiresEntryPoint,
+        EntryPointIsAmbiguous,
         TryStatementRequiresCatchOrFinally,
         CatchTypeMustDeriveFromSystemException,
         NoOverloadForMethod,
@@ -1190,6 +1205,7 @@ internal static partial class CompilerDiagnostics
         "RAV1012" => FileScopedCodeRequiresConsole,
         "RAV1013" => FileScopedCodeMultipleFiles,
         "RAV1014" => ConsoleApplicationRequiresEntryPoint,
+        "RAV1017" => EntryPointIsAmbiguous,
         "RAV1015" => TryStatementRequiresCatchOrFinally,
         "RAV1016" => CatchTypeMustDeriveFromSystemException,
         "RAV1501" => NoOverloadForMethod,

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -161,6 +161,9 @@ public static partial class DiagnosticBagExtensions
     public static void ReportConsoleApplicationRequiresEntryPoint(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.ConsoleApplicationRequiresEntryPoint, location));
 
+    public static void ReportEntryPointIsAmbiguous(this DiagnosticBag diagnostics, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.EntryPointIsAmbiguous, location));
+
     public static void ReportTryStatementRequiresCatchOrFinally(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TryStatementRequiresCatchOrFinally, location));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -190,6 +190,10 @@
     Title="Console application requires entry point"
     Message="Program.Main entry point not found" Category="compiler" Severity="Error"
     EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV1017" Identifier="EntryPointIsAmbiguous"
+    Title="Program has more than one entry point defined"
+    Message="Program has more than one entry point defined" Category="compiler" Severity="Error"
+    EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV1015" Identifier="TryStatementRequiresCatchOrFinally"
     Title="try statement requires catch or finally"
     Message="A try statement must include at least one catch clause or a finally clause"


### PR DESCRIPTION
## Summary
- update the code generator to resolve the entry point through `Compilation.GetEntryPoint` and gracefully handle missing results
- limit entry point candidates to `Program.Main` when defining method builders
- add a regression test that ensures `Program.Main` is selected when multiple `Main` methods exist

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs,src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs,test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Raven.CodeAnalysis.Semantics.Tests.ObjectCreationTests.InvocationFallsBackToConstructorWhenMethodNotApplicable due to unexpected diagnostic RAV1501)*

------
https://chatgpt.com/codex/tasks/task_e_68d5596d7818832f92c5ac56b69cdc04