### PR TITLE
fix: make entry point resolution signature-based

### DIFF
--- a/docs/compiler/diagnostics.md
+++ b/docs/compiler/diagnostics.md
@@ -325,11 +325,26 @@ print("hi") // RAV1013
 ```
 
 ## RAV1014: Console application requires entry point
-Console applications must define a `func main` entry point.
+Console applications must provide an entry point. Either include file-scope
+statements (which synthesize `Program.Main`) or declare a static `Main` method
+that matches one of the supported signatures.
 
 ```raven
-// Console project without a main function
+// Console project without top-level statements or a matching Main method
 // RAV1014: Program.Main entry point not found
+```
+
+## RAV1017: Program has more than one entry point defined
+Only one method may satisfy the entry-point requirements. Declaring multiple
+matching `Main` methods—or mixing top-level statements with a qualifying
+method—causes the compiler to reject the program.
+
+```raven
+let message = "hi"
+
+class App {
+    Main() -> unit { } // RAV1017: Program has more than one entry point defined
+}
 ```
 
 ## RAV1501: No overload for method takes argument

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -749,6 +749,27 @@ Function declarations (local function statements) within file-scope code are
 hoisted and may be referenced from anywhere in that file-scoped region,
 regardless of their order.
 
+### Entry point resolution
+
+Console applications begin executing at the synthesized `Program.Main` method
+that backs file-scope code. When a project does not contain file-scope
+statements, the compiler instead looks for a user-defined entry point. Any
+static method named `Main` qualifies when it meets the following requirements:
+
+* The method returns `unit`, `void`, or `int`.
+* It has no type parameters.
+* It declares either no parameters or a single parameter of type `string[]`
+  (representing the command-line arguments).
+
+If exactly one method satisfies these conditions, it becomes the entry point for
+the compilation. When no method qualifies, the compiler reports
+`RAV1014` *Program.Main entry point not found*. Declaring more than one valid
+`Main` (including mixing top-level statements with a matching method) causes the
+compiler to emit `RAV1017` *Program has more than one entry point defined*.
+
+Library and script output kinds ignore the entry point search; they never report
+missing or ambiguous entry-point diagnostics.
+
 ## Functions
 
 ```raven

--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -180,7 +180,7 @@ internal class MethodGenerator
             i++;
         }
 
-        if (MethodSymbol.Name == "Main")
+        if (TypeGenerator.CodeGen.Compilation.IsEntryPointCandidate(MethodSymbol))
         {
             IsEntryPointCandidate = true;
         }

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -58,6 +58,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _fileScopedCodeRequiresConsole;
     private static DiagnosticDescriptor? _fileScopedCodeMultipleFiles;
     private static DiagnosticDescriptor? _consoleApplicationRequiresEntryPoint;
+    private static DiagnosticDescriptor? _entryPointIsAmbiguous;
     private static DiagnosticDescriptor? _tryStatementRequiresCatchOrFinally;
     private static DiagnosticDescriptor? _catchTypeMustDeriveFromSystemException;
     private static DiagnosticDescriptor? _noOverloadForMethod;
@@ -759,6 +760,19 @@ internal static partial class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
+    /// RAV1017: Program has more than one entry point defined
+    /// </summary>
+    public static DiagnosticDescriptor EntryPointIsAmbiguous => _entryPointIsAmbiguous ??= DiagnosticDescriptor.Create(
+        id: "RAV1017",
+        title: "Program has more than one entry point defined",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "Program has more than one entry point defined",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// RAV1015: A try statement must include at least one catch clause or a finally clause
     /// </summary>
     public static DiagnosticDescriptor TryStatementRequiresCatchOrFinally => _tryStatementRequiresCatchOrFinally ??= DiagnosticDescriptor.Create(
@@ -1111,6 +1125,7 @@ internal static partial class CompilerDiagnostics
         FileScopedCodeRequiresConsole,
         FileScopedCodeMultipleFiles,
         ConsoleApplicationRequiresEntryPoint,
+        EntryPointIsAmbiguous,
         TryStatementRequiresCatchOrFinally,
         CatchTypeMustDeriveFromSystemException,
         NoOverloadForMethod,
@@ -1190,6 +1205,7 @@ internal static partial class CompilerDiagnostics
         "RAV1012" => FileScopedCodeRequiresConsole,
         "RAV1013" => FileScopedCodeMultipleFiles,
         "RAV1014" => ConsoleApplicationRequiresEntryPoint,
+        "RAV1017" => EntryPointIsAmbiguous,
         "RAV1015" => TryStatementRequiresCatchOrFinally,
         "RAV1016" => CatchTypeMustDeriveFromSystemException,
         "RAV1501" => NoOverloadForMethod,

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -161,6 +161,9 @@ public static partial class DiagnosticBagExtensions
     public static void ReportConsoleApplicationRequiresEntryPoint(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.ConsoleApplicationRequiresEntryPoint, location));
 
+    public static void ReportEntryPointIsAmbiguous(this DiagnosticBag diagnostics, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.EntryPointIsAmbiguous, location));
+
     public static void ReportTryStatementRequiresCatchOrFinally(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.TryStatementRequiresCatchOrFinally, location));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -190,6 +190,10 @@
     Title="Console application requires entry point"
     Message="Program.Main entry point not found" Category="compiler" Severity="Error"
     EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV1017" Identifier="EntryPointIsAmbiguous"
+    Title="Program has more than one entry point defined"
+    Message="Program has more than one entry point defined" Category="compiler" Severity="Error"
+    EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV1015" Identifier="TryStatementRequiresCatchOrFinally"
     Title="try statement requires catch or finally"
     Message="A try statement must include at least one catch clause or a finally clause"


### PR DESCRIPTION
## Summary
- resolve the compilation entry point by evaluating signature-valid `Main` methods, cache the result, and surface an ambiguity diagnostic when multiple candidates remain
- tighten code generation entry-point candidate detection and add a compiler diagnostic + reporting helper for ambiguous entry points
- expand code generation and semantic tests to cover non-Program entry points and ambiguity scenarios, including top-level statements

## Testing
- dotnet run --project ../../tools/DiagnosticsGenerator -- -f
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Compilation.cs
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: AccessibilityTests.NestedTypeAccessibility_IsEmittedCorrectly asserts missing nested type)*

------
https://chatgpt.com/codex/tasks/task_e_68d5596d7818832f92c5ac56b69cdc04