### PR TITLE
fix: initialize semantic models for all syntax trees

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -106,6 +106,8 @@ public class Compilation
     {
         EnsureSetup();
 
+        EnsureSemanticModelsCreated();
+
         if (_semanticModels.TryGetValue(syntaxTree, out var semanticModel))
         {
             return semanticModel;
@@ -119,6 +121,32 @@ public class Compilation
         semanticModel = new SemanticModel(this, syntaxTree);
         _semanticModels[syntaxTree] = semanticModel;
         return semanticModel;
+    }
+
+    private void EnsureSemanticModelsCreated()
+    {
+        if (_sourceTypesInitialized || _isPopulatingSourceTypes)
+            return;
+
+        try
+        {
+            _isPopulatingSourceTypes = true;
+
+            foreach (var syntaxTree in _syntaxTrees)
+            {
+                if (_semanticModels.ContainsKey(syntaxTree))
+                    continue;
+
+                var model = new SemanticModel(this, syntaxTree);
+                _semanticModels[syntaxTree] = model;
+            }
+
+            _sourceTypesInitialized = true;
+        }
+        finally
+        {
+            _isPopulatingSourceTypes = false;
+        }
     }
 
     public MetadataReference ToMetadataReference() => new CompilationReference(this);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MultipleSyntaxTreeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MultipleSyntaxTreeTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Tests;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class MultipleSyntaxTreeTests
+{
+    [Fact]
+    public void MultipleSyntaxTrees_ReferenceAcrossTrees_ProducesNoDiagnostics()
+    {
+        var tree1 = SyntaxTree.ParseText("""
+class Helper {
+    init () {}
+
+    public GetValue() -> int => 42;
+}
+""");
+
+        var tree2 = SyntaxTree.ParseText("""
+class Program {
+    Main() -> unit {
+        let helper = Helper();
+        let value = helper.GetValue();
+        return;
+    }
+}
+""");
+
+        var compilation = Compilation.Create(
+            "app",
+            new[] { tree1, tree2 },
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var semanticModel = compilation.GetSemanticModel(tree2);
+        var diagnostics = semanticModel.GetDiagnostics();
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `Compilation.GetSemanticModel` initializes semantic models for every syntax tree before returning
- add regression test covering cross-file type resolution when requesting a semantic model for a later syntax tree first

## Testing
- `dotnet build test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj -c Release --no-restore` *(fails: CS8510 already present in CompilerDiagnostics.g.cs)*

------
https://chatgpt.com/codex/tasks/task_e_68d567a44bd4832fbc28f88c5a097466