### PR TITLE
Fix namespace binder for file-scoped namespaces

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -22,7 +22,7 @@ class BinderFactory
         // Now safely construct this node's binder with a guaranteed parent
         Binder? newBinder = node switch
         {
-            NamespaceDeclarationSyntax ns => CreateNamespaceBinder(ns, parentBinder!),
+            BaseNamespaceDeclarationSyntax ns => CreateNamespaceBinder(ns, parentBinder!),
             MethodDeclarationSyntax => parentBinder,
             BlockSyntax => CreateBlockBinder(parentBinder),
             BlockStatementSyntax => CreateBlockBinder(parentBinder),
@@ -64,7 +64,7 @@ class BinderFactory
         return null;
     }
 
-    private Binder CreateNamespaceBinder(NamespaceDeclarationSyntax nsSyntax, Binder parentBinder)
+    private Binder CreateNamespaceBinder(BaseNamespaceDeclarationSyntax nsSyntax, Binder parentBinder)
     {
         var nsSymbol = _compilation.GetNamespaceSymbol(nsSyntax.Name.ToString());
         var nsBinder = new NamespaceBinder(parentBinder, nsSymbol!);

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -19,7 +19,7 @@ class NamespaceBinder : Binder
 
     public override ISymbol? BindDeclaredSymbol(SyntaxNode node)
     {
-        if (node is NamespaceDeclarationSyntax)
+        if (node is BaseNamespaceDeclarationSyntax)
             return _namespaceSymbol;
 
         return base.BindDeclaredSymbol(node);


### PR DESCRIPTION
## Summary
- update the binder factory to create namespace binders for both block-scoped and file-scoped namespace declarations
- ensure namespace binders expose their symbol for any base namespace syntax node so alias and import resolution works

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: ConsoleApp_WithMultipleMainMethods_ProducesAmbiguousDiagnostic currently asserts diagnostics that are no longer produced)*

------
https://chatgpt.com/codex/tasks/task_e_68d5729ca73c832fb0f3825522405b21