### PR TITLE
Refactor PrettySyntaxTreePrinter for testability

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Syntax/PrettySyntaxTreePrinterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/PrettySyntaxTreePrinterTests.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+public class PrettySyntaxTreePrinterTests
+{
+    [Fact]
+    public void PrintSyntaxTree_ToTextWriter_ProducesExpectedOutput()
+    {
+        var code = "let x = 1;";
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var options = new PrinterOptions
+        {
+            IncludeTokens = true,
+            IncludeTrivia = false,
+            IncludeSpans = false,
+            IncludeLocations = false,
+            IncludeNames = true,
+            Colorize = false
+        };
+
+        using var writer = new StringWriter();
+        root.PrintSyntaxTree(options, writer);
+        var printed = writer.ToString();
+
+        var representation = root.GetSyntaxTreeRepresentation(options);
+
+        const string expected =
+            """
+            CompilationUnit
+            ├── GlobalStatement
+            │   └── Statement: LocalDeclarationStatement
+            │       ├── Declaration: VariableDeclaration
+            │       │   ├── LetOrVarKeyword: let LetKeyword
+            │       │   └── VariableDeclarator
+            │       │       ├── Identifier: x IdentifierToken
+            │       │       └── Initializer: EqualsValueClause
+            │       │           ├── EqualsToken: = EqualsToken
+            │       │           └── Value: NumericLiteralExpression
+            │       │               └── Token: 1 NumericLiteralToken
+            │       └── TerminatorToken: ; SemicolonToken
+            └── EndOfFileToken:  EndOfFileToken
+            """ + "\n";
+
+        Assert.Equal(representation, printed);
+        Assert.Equal(expected, printed);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `PrettySyntaxTreePrinter` to write to a provided `TextWriter` and reuse the logic for string representations
- add a syntax test that verifies the formatted output for a simple local declaration

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests -c Release --filter PrettySyntaxTreePrinterTests`


------
https://chatgpt.com/codex/tasks/task_e_68d5a35d6348832f925a7b425b7c519c