### PR TITLE
feat: support consuming extension methods

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1701,21 +1701,39 @@ partial class BlockBinder : Binder
 
         if (receiver.Type is not null)
         {
+            var methodCandidates = ImmutableArray<IMethodSymbol>.Empty;
+
             var instanceMethods = new SymbolQuery(name, receiver.Type, IsStatic: false)
                 .LookupMethods(this)
                 .ToImmutableArray();
 
             if (!instanceMethods.IsDefaultOrEmpty)
+                methodCandidates = instanceMethods;
+
+            if (IsExtensionReceiver(receiver))
+            {
+                var extensionMethods = LookupExtensionMethods(name, receiver.Type)
+                    .ToImmutableArray();
+
+                if (!extensionMethods.IsDefaultOrEmpty)
+                {
+                    methodCandidates = methodCandidates.IsDefaultOrEmpty
+                        ? extensionMethods
+                        : methodCandidates.AddRange(extensionMethods);
+                }
+            }
+
+            if (!methodCandidates.IsDefaultOrEmpty)
             {
                 if (explicitTypeArguments is { } typeArgs && genericTypeSyntax is not null)
                 {
-                    var instantiated = InstantiateMethodCandidates(instanceMethods, typeArgs, genericTypeSyntax, memberAccess.Name.GetLocation());
+                    var instantiated = InstantiateMethodCandidates(methodCandidates, typeArgs, genericTypeSyntax, memberAccess.Name.GetLocation());
                     if (!instantiated.IsDefaultOrEmpty)
                         return BindMethodGroup(receiver, instantiated, nameLocation);
                 }
                 else
                 {
-                    return BindMethodGroup(receiver, instanceMethods, nameLocation);
+                    return BindMethodGroup(receiver, methodCandidates, nameLocation);
                 }
             }
 
@@ -2763,19 +2781,31 @@ partial class BlockBinder : Binder
 
         var methodName = methodGroup.Methods[0].Name;
         var selected = methodGroup.SelectedMethod;
+        var extensionReceiver = IsExtensionReceiver(methodGroup.Receiver) ? methodGroup.Receiver : null;
+        var receiverSyntax = GetInvocationReceiverSyntax(syntax) ?? syntax.Expression;
 
-        if (selected is not null && selected.Parameters.Length == boundArguments.Length)
+        if (selected is not null && AreArgumentsCompatibleWithMethod(selected, boundArguments.Length, extensionReceiver))
         {
-            var converted = ConvertArguments(selected.Parameters, boundArguments, syntax.ArgumentList.Arguments);
+            var converted = ConvertInvocationArguments(
+                selected,
+                boundArguments,
+                syntax.ArgumentList.Arguments,
+                extensionReceiver,
+                receiverSyntax);
             return new BoundInvocationExpression(selected, converted, methodGroup.Receiver);
         }
 
-        var resolution = OverloadResolver.ResolveOverload(methodGroup.Methods, boundArguments, Compilation);
+        var resolution = OverloadResolver.ResolveOverload(methodGroup.Methods, boundArguments, Compilation, extensionReceiver);
 
         if (resolution.Success)
         {
             var method = resolution.Method!;
-            var convertedArgs = ConvertArguments(method.Parameters, boundArguments, syntax.ArgumentList.Arguments);
+            var convertedArgs = ConvertInvocationArguments(
+                method,
+                boundArguments,
+                syntax.ArgumentList.Arguments,
+                extensionReceiver,
+                receiverSyntax);
             return new BoundInvocationExpression(method, convertedArgs, methodGroup.Receiver);
         }
 
@@ -3426,6 +3456,84 @@ partial class BlockBinder : Binder
         }
 
         return converted;
+    }
+
+    private BoundExpression[] ConvertInvocationArguments(
+        IMethodSymbol method,
+        BoundExpression[] invocationArguments,
+        SeparatedSyntaxList<ArgumentSyntax> argumentSyntaxes,
+        BoundExpression? extensionReceiver,
+        SyntaxNode receiverSyntax)
+    {
+        if (method.IsExtensionMethod && IsExtensionReceiver(extensionReceiver))
+        {
+            var parameters = method.Parameters;
+            var converted = new BoundExpression[parameters.Length];
+
+            converted[0] = ConvertSingleArgument(
+                extensionReceiver!,
+                parameters[0],
+                receiverSyntax);
+
+            if (parameters.Length > 1)
+            {
+                var convertedRest = ConvertArguments(parameters.RemoveAt(0), invocationArguments, argumentSyntaxes);
+                Array.Copy(convertedRest, 0, converted, 1, convertedRest.Length);
+            }
+
+            return converted;
+        }
+
+        return ConvertArguments(method.Parameters, invocationArguments, argumentSyntaxes);
+    }
+
+    private BoundExpression ConvertSingleArgument(BoundExpression argument, IParameterSymbol parameter, SyntaxNode syntax)
+    {
+        if (parameter.RefKind is RefKind.Ref or RefKind.Out or RefKind.In)
+            return argument;
+
+        if (!ShouldAttemptConversion(argument) ||
+            parameter.Type.TypeKind == TypeKind.Error ||
+            argument.Type is null)
+        {
+            return argument;
+        }
+
+        if (!IsAssignable(parameter.Type, argument.Type, out var conversion))
+        {
+            _diagnostics.ReportCannotConvertFromTypeToType(
+                argument.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                parameter.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                syntax.GetLocation());
+
+            return new BoundErrorExpression(parameter.Type, null, BoundExpressionReason.TypeMismatch);
+        }
+
+        return ApplyConversion(argument, parameter.Type, conversion, syntax);
+    }
+
+    private static bool AreArgumentsCompatibleWithMethod(IMethodSymbol method, int argumentCount, BoundExpression? receiver)
+    {
+        if (method.IsExtensionMethod && IsExtensionReceiver(receiver))
+            return method.Parameters.Length == argumentCount + 1;
+
+        return method.Parameters.Length == argumentCount;
+    }
+
+    private static bool IsExtensionReceiver(BoundExpression? receiver)
+    {
+        return receiver is not null and not BoundTypeExpression and not BoundNamespaceExpression;
+    }
+
+    private static SyntaxNode? GetInvocationReceiverSyntax(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Expression,
+            MemberBindingExpressionSyntax binding when invocation.Parent is ConditionalAccessExpressionSyntax conditional && conditional.WhenNotNull == invocation
+                => conditional.Expression,
+            _ => null
+        };
     }
 
     private BoundExpression BindCollectionExpression(CollectionExpressionSyntax syntax)

--- a/src/Raven.CodeAnalysis/Binder/ImportBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/ImportBinder.cs
@@ -120,4 +120,27 @@ class ImportBinder : Binder
 
         return ParentBinder?.LookupSymbols(name) ?? Enumerable.Empty<ISymbol>();
     }
+
+    public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string name, ITypeSymbol receiverType)
+    {
+        var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var scope in _namespaceOrTypeScopeImports)
+        {
+            foreach (var method in GetExtensionMethodsFromScope(scope, name))
+                if (seen.Add(method))
+                    yield return method;
+        }
+
+        foreach (var type in _typeImports)
+        {
+            foreach (var method in GetExtensionMethodsFromScope(type, name))
+                if (seen.Add(method))
+                    yield return method;
+        }
+
+        foreach (var method in base.LookupExtensionMethods(name, receiverType))
+            if (seen.Add(method))
+                yield return method;
+    }
 }

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -33,4 +33,17 @@ class NamespaceBinder : Binder
     public IEnumerable<SourceNamedTypeSymbol> DeclaredTypes => _declaredTypes;
 
     public INamespaceSymbol NamespaceSymbol => _namespaceSymbol;
+
+    public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string name, ITypeSymbol receiverType)
+    {
+        var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var method in GetExtensionMethodsFromScope(_namespaceSymbol, name))
+            if (seen.Add(method))
+                yield return method;
+
+        foreach (var method in base.LookupExtensionMethods(name, receiverType))
+            if (seen.Add(method))
+                yield return method;
+    }
 }


### PR DESCRIPTION
## Summary
Implemented extension method lookup across namespace, import, and member scopes so that member access binding can surface extension method groups. Invocation binding now recognizes extension receivers, converts the receiver into the first argument, and passes that information into overload resolution. The overload resolver accounts for reduced extension signatures when evaluating candidates and tie-breaking. Together these changes allow instance-style calls into .NET extension APIs such as LINQ.

## Testing
- dotnet format src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj --include src/Raven.CodeAnalysis/Binder/Binder.cs,src/Raven.CodeAnalysis/Binder/ImportBinder.cs,src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs,src/Raven.CodeAnalysis/OverloadResolver.cs
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests

------
https://chatgpt.com/codex/tasks/task_e_68d5b70d4290832fbdef8d40d0c53981