### PR TITLE
feat: add extension method completions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/ImportBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/ImportBinder.cs
@@ -121,25 +121,25 @@ class ImportBinder : Binder
         return ParentBinder?.LookupSymbols(name) ?? Enumerable.Empty<ISymbol>();
     }
 
-    public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string name, ITypeSymbol receiverType)
+    public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
     {
         var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
 
         foreach (var scope in _namespaceOrTypeScopeImports)
         {
-            foreach (var method in GetExtensionMethodsFromScope(scope, name))
+            foreach (var method in GetExtensionMethodsFromScope(scope, name, includePartialMatches))
                 if (seen.Add(method))
                     yield return method;
         }
 
         foreach (var type in _typeImports)
         {
-            foreach (var method in GetExtensionMethodsFromScope(type, name))
+            foreach (var method in GetExtensionMethodsFromScope(type, name, includePartialMatches))
                 if (seen.Add(method))
                     yield return method;
         }
 
-        foreach (var method in base.LookupExtensionMethods(name, receiverType))
+        foreach (var method in base.LookupExtensionMethods(name, receiverType, includePartialMatches))
             if (seen.Add(method))
                 yield return method;
     }

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -34,15 +34,15 @@ class NamespaceBinder : Binder
 
     public INamespaceSymbol NamespaceSymbol => _namespaceSymbol;
 
-    public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string name, ITypeSymbol receiverType)
+    public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
     {
         var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
 
-        foreach (var method in GetExtensionMethodsFromScope(_namespaceSymbol, name))
+        foreach (var method in GetExtensionMethodsFromScope(_namespaceSymbol, name, includePartialMatches))
             if (seen.Add(method))
                 yield return method;
 
-        foreach (var method in base.LookupExtensionMethods(name, receiverType))
+        foreach (var method in base.LookupExtensionMethods(name, receiverType, includePartialMatches))
             if (seen.Add(method))
                 yield return method;
     }

--- a/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
@@ -157,8 +157,29 @@ internal partial class PEMethodSymbol : PESymbol, IMethodSymbol
 
     public bool IsDefinition => true; // Metadata methods are always definitions
 
-    public bool IsExtensionMethod =>
-        _methodInfo?.GetCustomAttribute(typeof(ExtensionAttribute), false) is not null;
+    public bool IsExtensionMethod
+    {
+        get
+        {
+            if (_methodInfo is null)
+                return false;
+
+            try
+            {
+                foreach (var attribute in _methodInfo.GetCustomAttributesData())
+                {
+                    if (attribute.AttributeType.FullName == typeof(ExtensionAttribute).FullName)
+                        return true;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return false;
+        }
+    }
 
     public bool IsExtern => _methodInfo.IsAbstract || (_methodInfo.Attributes & MethodAttributes.PinvokeImpl) != 0;
 


### PR DESCRIPTION
## Summary
- allow binder extension lookup to return partial matches so completion can enumerate available extension methods
- surface extension methods in member access completion results and harden metadata inspection
- add a completion test exercising an imported LINQ extension method

## Testing
- `dotnet build src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj`
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter GetCompletions_AfterDot_IncludesExtensionMethods --no-build` *(fails: System.InvalidOperationException from MetadataLoadContext when querying extension attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cdec7b18832f8b1765a729262e02