### PR TITLE
feat: add typeof operator support

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -359,6 +359,22 @@ let s = obj as string
 `(T)expr` performs a runtime check and throws an `InvalidCastException` when the value cannot convert to `T`. Use this form for downcasts, numeric narrowing, or unboxing scenarios.
 `expr as T` attempts the conversion and returns `null` (or a nullable value type) instead of throwing on failure.
 
+### `typeof` expressions
+
+The `typeof` operator produces the runtime [`System.Type`](https://learn.microsoft.com/dotnet/api/system.type)
+for a compile-time type. The operand must be a type syntax—predefined, user-defined,
+tuple, nullable, or union—and is not evaluated. The expression always has type
+`System.Type`. Using a namespace or otherwise invalid type yields a binding
+diagnostic.
+
+```raven
+let textType = typeof(string)
+let listType = typeof(System.Collections.Generic.List<int>)
+```
+
+`typeof` is useful when reflecting over metadata or when passing type objects to
+APIs such as `Activator.CreateInstance`.
+
 ### String literals
 
 ```raven
@@ -1646,7 +1662,7 @@ Lowest → highest (all left-associative unless noted):
 8. Additive: `+  -`
 9. Multiplicative: `*  /  %`
 10. Cast: `(T)expr`
-11. Unary (prefix): `+  -  !`
+11. Unary (prefix): `+  -  !  typeof`
 12. Postfix trailers: call `()`, member `.`, index `[]`
 
 > **Disambiguation notes**

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -717,6 +717,7 @@ partial class BlockBinder : Binder
             ParenthesizedExpressionSyntax parenthesizedExpression => BindParenthesizedExpression(parenthesizedExpression),
             CastExpressionSyntax castExpression => BindCastExpression(castExpression),
             AsExpressionSyntax asExpression => BindAsExpression(asExpression),
+            TypeOfExpressionSyntax typeOfExpression => BindTypeOfExpression(typeOfExpression),
             TupleExpressionSyntax tupleExpression => BindTupleExpression(tupleExpression),
             IfExpressionSyntax ifExpression => BindIfExpression(ifExpression),
             WhileExpressionSyntax whileExpression => BindWhileExpression(whileExpression),
@@ -1048,6 +1049,21 @@ partial class BlockBinder : Binder
         }
 
         return new BoundCastExpression(expression, targetType, conversion);
+    }
+
+    private BoundExpression BindTypeOfExpression(TypeOfExpressionSyntax typeOfExpression)
+    {
+        var boundType = BindTypeSyntax(typeOfExpression.Type);
+
+        if (boundType is BoundErrorExpression)
+            return boundType;
+
+        if (boundType is not BoundTypeExpression typeExpression)
+            return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.TypeMismatch);
+
+        var systemType = Compilation.GetSpecialType(SpecialType.System_Type);
+
+        return new BoundTypeOfExpression(typeExpression.TypeSymbol, systemType);
     }
 
     private BoundExpression ConvertMethodGroupToDelegate(BoundMethodGroupExpression methodGroup, ITypeSymbol targetType, SyntaxNode? syntax)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -74,6 +74,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundAsExpression asExpr => (BoundExpression)VisitAsExpression(asExpr)!,
             BoundDelegateCreationExpression delegateCreation => (BoundExpression)VisitDelegateCreationExpression(delegateCreation)!,
             BoundMethodGroupExpression methodGroup => (BoundExpression)VisitMethodGroupExpression(methodGroup)!,
+            BoundTypeOfExpression typeOfExpression => (BoundExpression)VisitTypeOfExpression(typeOfExpression)!,
             _ => throw new NotImplementedException($"Unhandled expression: {node.GetType().Name}"),
         };
     }
@@ -139,6 +140,11 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
     public virtual BoundNode VisitDesignator(BoundDesignator designator)
     {
         return designator.Accept(this);
+    }
+
+    public virtual BoundNode? VisitTypeOfExpression(BoundTypeOfExpression node)
+    {
+        return node;
     }
 
 }

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -93,6 +93,9 @@ internal class BoundTreeWalker : BoundTreeVisitor
                 foreach (var e in tuple.Elements)
                     VisitExpression(e);
                 break;
+            case BoundTypeOfExpression typeOfExpression:
+                VisitTypeOfExpression(typeOfExpression);
+                break;
             // Add others as needed
             default:
                 break;
@@ -197,6 +200,8 @@ internal class BoundTreeWalker : BoundTreeVisitor
     {
         VisitExpression(node.Expression);
     }
+
+    public virtual void VisitTypeOfExpression(BoundTypeOfExpression node) { }
 
     public virtual void VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
     {

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTypeOfExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTypeOfExpression.cs
@@ -1,0 +1,12 @@
+namespace Raven.CodeAnalysis;
+
+internal partial class BoundTypeOfExpression : BoundExpression
+{
+    public BoundTypeOfExpression(ITypeSymbol operandType, ITypeSymbol systemType)
+        : base(systemType)
+    {
+        OperandType = operandType;
+    }
+
+    public ITypeSymbol OperandType { get; }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -144,6 +144,10 @@ internal class ExpressionGenerator : Generator
                 EmitSelfExpression(selfExpression);
                 break;
 
+            case BoundTypeOfExpression typeOfExpression:
+                EmitTypeOfExpression(typeOfExpression);
+                break;
+
             case BoundTypeExpression:
                 break;
 
@@ -170,6 +174,14 @@ internal class ExpressionGenerator : Generator
             return;
 
         ILGenerator.Emit(OpCodes.Ldarg_0);
+    }
+
+    private void EmitTypeOfExpression(BoundTypeOfExpression typeOfExpression)
+    {
+        var operandClrType = ResolveClrType(typeOfExpression.OperandType);
+
+        ILGenerator.Emit(OpCodes.Ldtoken, operandClrType);
+        ILGenerator.Emit(OpCodes.Call, GetTypeFromHandleMethod);
     }
 
     private void EmitDelegateCreationExpression(BoundDelegateCreationExpression delegateCreation)

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -657,6 +657,10 @@ internal class ExpressionSyntaxParser : SyntaxParser
                 expr = ParseNewExpression();
                 break;
 
+            case SyntaxKind.TypeOfKeyword:
+                expr = ParseTypeOfExpression();
+                break;
+
             case SyntaxKind.OpenBracketToken:
                 expr = ParseCollectionExpression();
                 break;
@@ -792,6 +796,19 @@ internal class ExpressionSyntaxParser : SyntaxParser
         var typeName = new NameSyntaxParser(this).ParseTypeName();
 
         return ObjectCreationExpression(newKeyword, typeName, ParseArgumentListSyntax());
+    }
+
+    private ExpressionSyntax ParseTypeOfExpression()
+    {
+        var typeOfKeyword = ReadToken();
+
+        ConsumeTokenOrMissing(SyntaxKind.OpenParenToken, out var openParenToken);
+
+        var type = new NameSyntaxParser(this).ParseTypeName();
+
+        ConsumeTokenOrMissing(SyntaxKind.CloseParenToken, out var closeParenToken);
+
+        return TypeOfExpression(typeOfKeyword, openParenToken, type, closeParenToken);
     }
 
     private ExpressionSyntax ParsePredefinedTypeSyntax()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -341,6 +341,12 @@
     <Slot Name="CloseParenToken" Type="Token" />
     <Slot Name="Expression" Type="Expression" />
   </Node>
+  <Node Name="TypeOfExpression" Inherits="Expression">
+    <Slot Name="TypeOfKeyword" Type="Token" />
+    <Slot Name="OpenParenToken" Type="Token" />
+    <Slot Name="Type" Type="Type" />
+    <Slot Name="CloseParenToken" Type="Token" />
+  </Node>
   <Node Name="TypeDeclaration" Inherits="BaseTypeDeclaration" IsAbstract="true">
     <Slot Name="Keyword" Type="Token" IsAbstract="true" />
     <Slot Name="Members" Type="List" ElementType="MemberDeclaration" IsAbstract="true" />

--- a/src/Raven.CodeAnalysis/Syntax/PrettySyntaxTreePrinter.cs
+++ b/src/Raven.CodeAnalysis/Syntax/PrettySyntaxTreePrinter.cs
@@ -308,6 +308,7 @@ public static class PrettySyntaxTreePrinter
             IdentifierNameSyntax ine => $"{ine.Identifier.Text} ",
             PredefinedTypeSyntax pt => $"{pt.Keyword.Text} ",
             UnitTypeSyntax _ => "() ",
+            TypeOfExpressionSyntax typeOf => $"typeof({typeOf.Type}) ",
             _ => string.Empty
         };
     }

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -38,6 +38,7 @@
   <TokenKind Name="FalseKeyword" Text="false" IsReservedWord="true" />
   <TokenKind Name="IsKeyword" Text="is" IsReservedWord="true" />
   <TokenKind Name="AsKeyword" Text="as" IsReservedWord="true" />
+  <TokenKind Name="TypeOfKeyword" Text="typeof" IsReservedWord="true" />
   <TokenKind Name="NotKeyword" Text="not" IsReservedWord="true" />
   <TokenKind Name="WhenKeyword" Text="when" IsReservedWord="true" />
   <TokenKind Name="AndToken" Text="and" IsReservedWord="true" IsBinaryOperator="true" Precedence="2" />

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/TypeOfTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/TypeOfTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class TypeOfTests
+{
+    [Fact]
+    public void TypeOfExpression_EmitsSystemType()
+    {
+        const string code = """
+class TypeInspector {
+    static GetIntType() -> System.Type {
+        typeof(int)
+    }
+
+    static GetListType() -> System.Type {
+        typeof(System.Collections.Generic.List<int>)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("TypeInspector", throwOnError: true)!;
+
+        var getIntType = type.GetMethod("GetIntType")!;
+        var getListType = type.GetMethod("GetListType")!;
+
+        var intType = (Type)getIntType.Invoke(null, Array.Empty<object>())!;
+        var listType = (Type)getListType.Invoke(null, Array.Empty<object>())!;
+
+        Assert.Equal(typeof(int), intType);
+        Assert.Equal(typeof(System.Collections.Generic.List<int>), listType);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/TypeOfExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TypeOfExpressionTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class TypeOfExpressionTests : CompilationTestBase
+{
+    [Fact]
+    public void TypeOfExpression_ReturnsSystemType()
+    {
+        var (compilation, tree) = CreateCompilation("let t = typeof(int)");
+        var model = compilation.GetSemanticModel(tree);
+        var typeOfExpression = tree.GetRoot().DescendantNodes().OfType<TypeOfExpressionSyntax>().Single();
+
+        var typeInfo = model.GetTypeInfo(typeOfExpression);
+        Assert.Equal(SpecialType.System_Type, typeInfo.Type!.SpecialType);
+
+        var operandType = model.GetTypeInfo(typeOfExpression.Type).Type;
+        Assert.Equal(SpecialType.System_Int32, operandType!.SpecialType);
+    }
+}


### PR DESCRIPTION
## Summary
- add the typeof keyword and syntax node to the parser and syntax model
- bind and emit typeof expressions via a new bound node
- document the operator and cover it with semantic and code generation tests

## Testing
- dotnet build *(fails: pre-existing generator warnings cause build failure)*
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: pre-existing generator warnings cause build failure)*

------
https://chatgpt.com/codex/tasks/task_e_68d6443798b0832fb54f4003043ee99e