### PR TITLE
feat: generate factory overloads without nullable slots

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/SyntaxFactory.ReturnStatementSyntax.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxFactory.ReturnStatementSyntax.cs
@@ -1,8 +1,0 @@
-using System.Runtime.CompilerServices;
-
-namespace Raven.CodeAnalysis.Syntax;
-
-public static partial class SyntaxFactory
-{
-    public static ReturnStatementSyntax ReturnStatement(SyntaxToken returnKeyword, SyntaxToken terminatorToken) => new ReturnStatementSyntax(returnKeyword, null, terminatorToken);
-}


### PR DESCRIPTION
## Summary
- update the red and green syntax node generators to emit overloads that omit nullable slots and supply default values automatically
- reuse the new overloads to remove the need for the hand-written ReturnStatement helper

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: pre-existing issues in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d645baa6bc832fbaaa4e59c447898c