### PR TITLE
feat: bind optional parameter defaults

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -2442,7 +2442,7 @@ partial class BlockBinder : Binder
                 if (argErrors)
                     return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.ArgumentBindingFailed);
 
-                if (method.Parameters.Length == argExprs.Count)
+                if (AreArgumentsCompatibleWithMethod(method, argExprs.Count, memberExpr.Receiver))
                 {
                     var convertedArgs = ConvertArguments(method.Parameters, argExprs, syntax.ArgumentList.Arguments);
                     return new BoundInvocationExpression(method, convertedArgs, memberExpr.Receiver);
@@ -2499,7 +2499,7 @@ partial class BlockBinder : Binder
                 if (argErrors)
                     return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.ArgumentBindingFailed);
 
-                if (method.Parameters.Length == argExprs.Count)
+                if (AreArgumentsCompatibleWithMethod(method, argExprs.Count, memberExpr.Receiver))
                 {
                     var convertedArgs = ConvertArguments(method.Parameters, argExprs, syntax.ArgumentList.Arguments);
                     return new BoundInvocationExpression(method, convertedArgs, memberExpr.Receiver);
@@ -3421,9 +3421,10 @@ partial class BlockBinder : Binder
 
     protected BoundExpression[] ConvertArguments(ImmutableArray<IParameterSymbol> parameters, IReadOnlyList<BoundExpression> arguments, SeparatedSyntaxList<ArgumentSyntax> argumentSyntaxes)
     {
-        var converted = new BoundExpression[arguments.Count];
+        var converted = new BoundExpression[parameters.Length];
 
-        for (int i = 0; i < arguments.Count; i++)
+        int i = 0;
+        for (; i < arguments.Count && i < parameters.Length; i++)
         {
             var argument = arguments[i];
             var parameter = parameters[i];
@@ -3443,19 +3444,63 @@ partial class BlockBinder : Binder
 
             if (!IsAssignable(parameter.Type, argument.Type, out var conversion))
             {
-                _diagnostics.ReportCannotConvertFromTypeToType(
-                    argument.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                    parameter.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                    argumentSyntaxes[i].Expression.GetLocation());
+                var syntax = i < argumentSyntaxes.Count ? argumentSyntaxes[i].Expression : null;
+                var location = syntax?.GetLocation() ?? parameter.Locations.FirstOrDefault();
+
+                if (location is not null)
+                {
+                    _diagnostics.ReportCannotConvertFromTypeToType(
+                        argument.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        parameter.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        location);
+                }
 
                 converted[i] = new BoundErrorExpression(parameter.Type, null, BoundExpressionReason.TypeMismatch);
                 continue;
             }
 
-            converted[i] = ApplyConversion(argument, parameter.Type, conversion, argumentSyntaxes[i].Expression);
+            var syntaxNode = i < argumentSyntaxes.Count ? argumentSyntaxes[i].Expression : null;
+            converted[i] = ApplyConversion(argument, parameter.Type, conversion, syntaxNode);
+        }
+
+        for (; i < parameters.Length; i++)
+        {
+            converted[i] = CreateOptionalArgument(parameters[i]);
         }
 
         return converted;
+    }
+
+    protected BoundExpression CreateOptionalArgument(IParameterSymbol parameter)
+    {
+        if (!parameter.HasExplicitDefaultValue)
+            return new BoundErrorExpression(parameter.Type, null, BoundExpressionReason.ArgumentBindingFailed);
+
+        var value = parameter.ExplicitDefaultValue;
+
+        if (value is null)
+        {
+            return new BoundLiteralExpression(
+                BoundLiteralExpressionKind.NullLiteral,
+                null!,
+                Compilation.NullTypeSymbol,
+                parameter.Type);
+        }
+
+        return value switch
+        {
+            bool b => new BoundLiteralExpression(
+                b ? BoundLiteralExpressionKind.TrueLiteral : BoundLiteralExpressionKind.FalseLiteral,
+                b,
+                parameter.Type),
+            string s => new BoundLiteralExpression(BoundLiteralExpressionKind.StringLiteral, s, parameter.Type),
+            char c => new BoundLiteralExpression(BoundLiteralExpressionKind.CharLiteral, c, parameter.Type),
+            int i => new BoundLiteralExpression(BoundLiteralExpressionKind.NumericLiteral, i, parameter.Type),
+            long l => new BoundLiteralExpression(BoundLiteralExpressionKind.NumericLiteral, l, parameter.Type),
+            float f => new BoundLiteralExpression(BoundLiteralExpressionKind.NumericLiteral, f, parameter.Type),
+            double d => new BoundLiteralExpression(BoundLiteralExpressionKind.NumericLiteral, d, parameter.Type),
+            _ => new BoundErrorExpression(parameter.Type, null, BoundExpressionReason.ArgumentBindingFailed)
+        };
     }
 
     private BoundExpression[] ConvertInvocationArguments(
@@ -3512,12 +3557,32 @@ partial class BlockBinder : Binder
         return ApplyConversion(argument, parameter.Type, conversion, syntax);
     }
 
-    private static bool AreArgumentsCompatibleWithMethod(IMethodSymbol method, int argumentCount, BoundExpression? receiver)
+    protected static bool AreArgumentsCompatibleWithMethod(IMethodSymbol method, int argumentCount, BoundExpression? receiver)
     {
-        if (method.IsExtensionMethod && IsExtensionReceiver(receiver))
-            return method.Parameters.Length == argumentCount + 1;
+        var providedCount = argumentCount;
 
-        return method.Parameters.Length == argumentCount;
+        if (method.IsExtensionMethod && IsExtensionReceiver(receiver))
+            providedCount++;
+
+        return SupportsArgumentCount(method.Parameters, providedCount);
+    }
+
+    protected static bool SupportsArgumentCount(ImmutableArray<IParameterSymbol> parameters, int providedCount)
+    {
+        if (providedCount > parameters.Length)
+            return false;
+
+        var required = GetRequiredParameterCount(parameters);
+        return providedCount >= required;
+    }
+
+    protected static int GetRequiredParameterCount(ImmutableArray<IParameterSymbol> parameters)
+    {
+        var required = parameters.Length;
+        while (required > 0 && parameters[required - 1].HasExplicitDefaultValue)
+            required--;
+
+        return required;
     }
 
     private static bool IsExtensionReceiver(BoundExpression? receiver)

--- a/src/Raven.CodeAnalysis/Binder/ConstructorInitializerBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/ConstructorInitializerBinder.cs
@@ -58,7 +58,9 @@ internal sealed class ConstructorInitializerBinder : MethodBodyBinder
                 return null;
             }
 
-            var matchingByArity = constructors.Where(c => c.Parameters.Length == boundArguments.Count).ToImmutableArray();
+            var matchingByArity = constructors
+                .Where(c => SupportsArgumentCount(c.Parameters, boundArguments.Count))
+                .ToImmutableArray();
             if (matchingByArity.Length == 1)
             {
                 var candidate = matchingByArity[0];

--- a/src/Raven.CodeAnalysis/Binder/FunctionBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/FunctionBinder.cs
@@ -74,6 +74,7 @@ class FunctionBinder : Binder
                 }
 
                 var type = ResolveType(typeSyntax);
+                var hasDefaultValue = TypeMemberBinder.TryEvaluateParameterDefaultValue(p, type, out var defaultValue);
                 return new SourceParameterSymbol(
                     p.Identifier.Text,
                     type,
@@ -82,7 +83,9 @@ class FunctionBinder : Binder
                     container.ContainingNamespace,
                     [p.GetLocation()],
                     [p.GetReference()],
-                    refKind);
+                    refKind,
+                    hasDefaultValue,
+                    defaultValue);
             })
             .ToArray();
 

--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -21,9 +21,9 @@ internal sealed class OverloadResolver
         {
             var parameters = method.Parameters;
             var treatAsExtension = method.IsExtensionMethod && receiver is not null;
-            var expectedParameters = treatAsExtension ? arguments.Length + 1 : arguments.Length;
+            var providedCount = arguments.Length + (treatAsExtension ? 1 : 0);
 
-            if (parameters.Length != expectedParameters)
+            if (!HasSufficientArguments(parameters, providedCount))
                 continue;
 
             if (!TryMatch(method, arguments, receiver, treatAsExtension, compilation, out var score))
@@ -217,6 +217,12 @@ internal sealed class OverloadResolver
                 return false;
         }
 
+        for (; parameterIndex < parameters.Length; parameterIndex++)
+        {
+            if (!parameters[parameterIndex].HasExplicitDefaultValue)
+                return false;
+        }
+
         return true;
     }
 
@@ -310,6 +316,24 @@ internal sealed class OverloadResolver
             return 5;
 
         return 10; // fallback or unspecified conversion
+    }
+
+    private static bool HasSufficientArguments(ImmutableArray<IParameterSymbol> parameters, int providedCount)
+    {
+        if (providedCount > parameters.Length)
+            return false;
+
+        var required = GetRequiredParameterCount(parameters);
+        return providedCount >= required;
+    }
+
+    private static int GetRequiredParameterCount(ImmutableArray<IParameterSymbol> parameters)
+    {
+        var required = parameters.Length;
+        while (required > 0 && parameters[required - 1].HasExplicitDefaultValue)
+            required--;
+
+        return required;
     }
 }
 

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -1212,6 +1212,7 @@ public partial class SemanticModel
                 ? Compilation.ErrorTypeSymbol
                 : classBinder.ResolveType(typeSyntax);
 
+            var hasDefaultValue = TypeMemberBinder.TryEvaluateParameterDefaultValue(parameterSyntax, parameterType, out var defaultValue);
             var parameterSymbol = new SourceParameterSymbol(
                 parameterSyntax.Identifier.Text,
                 parameterType,
@@ -1220,7 +1221,9 @@ public partial class SemanticModel
                 namespaceSymbol,
                 [parameterSyntax.GetLocation()],
                 [parameterSyntax.GetReference()],
-                refKind);
+                refKind,
+                hasDefaultValue,
+                defaultValue);
 
             parameters.Add(parameterSymbol);
 

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -161,6 +161,8 @@ internal sealed class ConstructedMethodSymbol : IMethodSymbol
         public ITypeSymbol Type => _owner.Substitute(_original.Type);
         public bool IsParams => _original.IsParams;
         public RefKind RefKind => _original.RefKind;
+        public bool HasExplicitDefaultValue => _original.HasExplicitDefaultValue;
+        public object? ExplicitDefaultValue => _original.ExplicitDefaultValue;
 
         public void Accept(SymbolVisitor visitor) => visitor.VisitParameter(this);
         public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.VisitParameter(this);

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
@@ -448,6 +448,8 @@ internal sealed class SubstitutedParameterSymbol : IParameterSymbol
     public bool IsAlias => false;
     public bool IsParams => _original.IsParams;
     public RefKind RefKind => _original.RefKind;
+    public bool HasExplicitDefaultValue => _original.HasExplicitDefaultValue;
+    public object? ExplicitDefaultValue => _original.ExplicitDefaultValue;
 
     public void Accept(SymbolVisitor visitor) => visitor.VisitParameter(this);
     public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.VisitParameter(this);

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -296,6 +296,10 @@ public interface IParameterSymbol : ISymbol
     bool IsParams { get; }
 
     RefKind RefKind { get; }
+
+    bool HasExplicitDefaultValue { get; }
+
+    object? ExplicitDefaultValue { get; }
 }
 
 

--- a/src/Raven.CodeAnalysis/Symbols/PE/PEParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEParameterSymbol.cs
@@ -40,4 +40,8 @@ internal partial class PEParameterSymbol : PESymbol, IParameterSymbol
     }
 
     public ParameterInfo GetParameterInfo() => _parameterInfo;
+
+    public bool HasExplicitDefaultValue => _parameterInfo.HasDefaultValue;
+
+    public object? ExplicitDefaultValue => _parameterInfo.HasDefaultValue ? _parameterInfo.DefaultValue : null;
 }

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceParameterSymbol.cs
@@ -2,11 +2,23 @@ namespace Raven.CodeAnalysis.Symbols;
 
 internal partial class SourceParameterSymbol : SourceSymbol, IParameterSymbol
 {
-    public SourceParameterSymbol(string name, ITypeSymbol parameterType, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations, SyntaxReference[] declaringSyntaxReferences, RefKind refKind = RefKind.None)
+    public SourceParameterSymbol(
+        string name,
+        ITypeSymbol parameterType,
+        ISymbol containingSymbol,
+        INamedTypeSymbol? containingType,
+        INamespaceSymbol? containingNamespace,
+        Location[] locations,
+        SyntaxReference[] declaringSyntaxReferences,
+        RefKind refKind = RefKind.None,
+        bool hasExplicitDefaultValue = false,
+        object? explicitDefaultValue = null)
         : base(SymbolKind.Parameter, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences)
     {
         Type = parameterType;
         RefKind = refKind;
+        HasExplicitDefaultValue = hasExplicitDefaultValue;
+        ExplicitDefaultValue = explicitDefaultValue;
     }
 
     public ITypeSymbol Type { get; }
@@ -14,4 +26,10 @@ internal partial class SourceParameterSymbol : SourceSymbol, IParameterSymbol
     public bool IsParams => false;
 
     public RefKind RefKind { get; }
+
+    public bool HasExplicitDefaultValue { get; }
+
+    public object? ExplicitDefaultValue { get; }
+
+    public bool IsOptional => HasExplicitDefaultValue;
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -234,7 +234,13 @@ internal class StatementSyntaxParser : SyntaxParser
 
             var typeAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
 
-            parameterList.Add(Parameter(modifiers, name, typeAnnotation));
+            EqualsValueClauseSyntax? defaultValue = null;
+            if (IsNextToken(SyntaxKind.EqualsToken, out _))
+            {
+                defaultValue = new EqualsValueClauseSyntaxParser(this).Parse();
+            }
+
+            parameterList.Add(Parameter(modifiers, name, typeAnnotation, defaultValue));
 
             var commaToken = PeekToken();
             if (commaToken.IsKind(SyntaxKind.CommaToken))

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -634,7 +634,13 @@ internal class TypeDeclarationParser : SyntaxParser
 
             var typeAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
 
-            parameterList.Add(Parameter(modifiers, name, typeAnnotation));
+            EqualsValueClauseSyntax? defaultValue = null;
+            if (IsNextToken(SyntaxKind.EqualsToken, out _))
+            {
+                defaultValue = new EqualsValueClauseSyntaxParser(this).Parse();
+            }
+
+            parameterList.Add(Parameter(modifiers, name, typeAnnotation, defaultValue));
 
             var commaToken = PeekToken();
             if (commaToken.IsKind(SyntaxKind.CommaToken))
@@ -764,7 +770,13 @@ internal class TypeDeclarationParser : SyntaxParser
 
             var typeAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseTypeAnnotation();
 
-            parameterList.Add(Parameter(modifiers, name, typeAnnotation));
+            EqualsValueClauseSyntax? defaultValue = null;
+            if (IsNextToken(SyntaxKind.EqualsToken, out _))
+            {
+                defaultValue = new EqualsValueClauseSyntaxParser(this).Parse();
+            }
+
+            parameterList.Add(Parameter(modifiers, name, typeAnnotation, defaultValue));
 
             var commaToken = PeekToken();
             if (commaToken.IsKind(SyntaxKind.CommaToken))

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -446,6 +446,7 @@
     <Slot Name="Modifiers" Type="TokenList" />
     <Slot Name="Identifier" Type="Token" />
     <Slot Name="TypeAnnotation" Type="TypeAnnotationClause" IsNullable="true" />
+    <Slot Name="DefaultValue" Type="EqualsValueClause" IsNullable="true" />
   </Node>
   <Node Name="EnumMemberDeclaration" Inherits="MemberDeclaration">
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -294,10 +294,22 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
 
     public override SyntaxNode? VisitParameter(ParameterSyntax node)
     {
-        var name = node.Identifier.WithTrailingTrivia(SyntaxFactory.Space);
+        var identifier = node.Identifier;
 
-        return node.Update(node.Modifiers, name,
-            node.TypeAnnotation is not null ? (TypeAnnotationClauseSyntax?)VisitTypeAnnotationClause(node.TypeAnnotation) : null);
+        if (node.TypeAnnotation is not null || node.DefaultValue is not null)
+        {
+            identifier = identifier.WithTrailingTrivia(SyntaxFactory.Space);
+        }
+
+        var typeAnnotation = node.TypeAnnotation is not null
+            ? (TypeAnnotationClauseSyntax?)VisitTypeAnnotationClause(node.TypeAnnotation)
+            : null;
+
+        var defaultValue = node.DefaultValue is not null
+            ? (EqualsValueClauseSyntax?)VisitEqualsValueClause(node.DefaultValue)
+            : null;
+
+        return node.Update(node.Modifiers, identifier, typeAnnotation, defaultValue);
     }
 
     public override SyntaxNode? VisitTypeAnnotationClause(TypeAnnotationClauseSyntax node)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/OptionalParameterSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/OptionalParameterSemanticTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public sealed class OptionalParameterSemanticTests : CompilationTestBase
+{
+    [Fact]
+    public void Invocation_OmitsOptionalArgument_UsesDefaultValue()
+    {
+        const string source = """
+class Calculator {
+    static Add(value: int = 42) -> int {
+        return value
+    }
+}
+
+let result = Calculator.Add()
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single(node => node.Expression is MemberAccessExpressionSyntax member && member.Name.Identifier.Text == "Add");
+
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+        var arguments = boundInvocation.Arguments.ToArray();
+
+        Assert.Single(arguments);
+        var literal = Assert.IsType<BoundLiteralExpression>(arguments[0]);
+        Assert.Equal(42, literal.Value);
+
+        var parameter = boundInvocation.Method.Parameters.Single();
+        Assert.True(parameter.HasExplicitDefaultValue);
+        Assert.Equal(42, parameter.ExplicitDefaultValue);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
@@ -274,6 +274,21 @@ public class ParserNewlineTests
     }
 
     [Fact]
+    public void Parameter_WithDefaultValue_ParsesEqualsValueClause()
+    {
+        var source = "func foo(bar: int = 42) {}";
+        var lexer = new Lexer(new StringReader(source));
+        var context = new BaseParseContext(lexer);
+        var parser = new StatementSyntaxParser(context);
+
+        var statement = (FunctionStatementSyntax)parser.ParseStatement().CreateRed();
+        var parameter = statement.ParameterList.Parameters.Single();
+
+        Assert.NotNull(parameter.DefaultValue);
+        Assert.Equal(SyntaxKind.NumericLiteralExpression, parameter.DefaultValue!.Value.Kind);
+    }
+
+    [Fact]
     public void SkipUntil_AtEndOfFile_ReturnsNoneToken()
     {
         var source = string.Empty;

--- a/test/Raven.CodeAnalysis.Tests/Syntax/SeparatedListSyntaxTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/SeparatedListSyntaxTest.cs
@@ -16,7 +16,7 @@ public class SeparatedListSyntaxTest(ITestOutputHelper testOutputHelper)
     public void Create_WithOneNode()
     {
         var separatedSyntaxList = SeparatedList<ParameterSyntax>([
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null),
+            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
         ]);
 
         separatedSyntaxList.Count.ShouldBe(1);
@@ -28,7 +28,7 @@ public class SeparatedListSyntaxTest(ITestOutputHelper testOutputHelper)
     public void Create_WithOneNodeAndOneSeparator()
     {
         var separatedSyntaxList = SeparatedList<ParameterSyntax>([
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null),
+            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
             CommaToken
         ]);
 
@@ -41,9 +41,9 @@ public class SeparatedListSyntaxTest(ITestOutputHelper testOutputHelper)
     public void Create_WithTwoNodesAndOneSeparator()
     {
         var separatedSyntaxList = SeparatedList<ParameterSyntax>([
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null),
+            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
             CommaToken,
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("b"), null)
+            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("b"), null, null)
         ]);
 
         separatedSyntaxList.Count.ShouldBe(2);


### PR DESCRIPTION
## Summary
- evaluate and convert optional parameter default expressions during binding and expose them on parameter symbols
- allow invocation binding and overload resolution to supply omitted arguments using stored defaults
- add semantic coverage to ensure optional parameter defaults are respected

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: UsingDeclarationTests reports diagnostics and triggers TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_68d642e49994832f80f98f1ba6bae278