### PR TITLE
Fix overload resolution for byref parameters

### DIFF
--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -239,8 +239,19 @@ internal sealed class OverloadResolver
         {
             if (argument is not BoundAddressOfExpression addr ||
                 addr.Type is not ByRefTypeSymbol argByRef ||
-                !SymbolEqualityComparer.Default.Equals(argByRef.ElementType, parameter.Type) ||
                 argType.SpecialType == SpecialType.System_Void)
+            {
+                return false;
+            }
+
+            var parameterType = parameter.Type;
+
+            if (parameterType is ByRefTypeSymbol paramByRef)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(argByRef.ElementType, paramByRef.ElementType))
+                    return false;
+            }
+            else if (!SymbolEqualityComparer.Default.Equals(argByRef.ElementType, parameterType))
             {
                 return false;
             }


### PR DESCRIPTION
## Summary
- allow overload resolution to accept byref parameters regardless of how metadata reports the parameter type
- add a regression test that covers invoking System.Int32.TryParse with an address-of argument

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter ResolveOverload_SystemInt32TryParse_WithOutArgument_Succeeds *(fails: build stops because generated syntax files require explicit #nullable directives)*
- dotnet run --project src/Raven.Compiler -- samples/test.rav -s group -o test.dll *(fails: build stops because generated syntax files require explicit #nullable directives)*

------
https://chatgpt.com/codex/tasks/task_e_68d6593029a4832fa66fd918714b762d