### PR TITLE
Fix typeof binding to recognize System.Type

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -142,9 +142,4 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
         return designator.Accept(this);
     }
 
-    public virtual BoundNode? VisitTypeOfExpression(BoundTypeOfExpression node)
-    {
-        return node;
-    }
-
 }

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTypeOfExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTypeOfExpression.cs
@@ -6,7 +6,10 @@ internal partial class BoundTypeOfExpression : BoundExpression
         : base(systemType)
     {
         OperandType = operandType;
+        SystemType = systemType;
     }
 
     public ITypeSymbol OperandType { get; }
+
+    public ITypeSymbol SystemType { get; }
 }

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -1076,6 +1076,10 @@ public class Compilation
         {
             return GetTypeByMetadataName("System.Nullable");
         }
+        else if (specialType is SpecialType.System_Type)
+        {
+            return GetTypeByMetadataName("System.Type");
+        }
 
         throw new InvalidOperationException("Special type is not supported.");
     }

--- a/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
@@ -140,6 +140,8 @@ internal partial class PENamedTypeSymbol : PESymbol, INamedTypeSymbol
                 return SpecialType.System_IntPtr;
             if (type.FullName == "System.UIntPtr")
                 return SpecialType.System_UIntPtr;
+            if (type.FullName == "System.Type")
+                return SpecialType.System_Type;
 
             if (type.Namespace == "System" && type.Name.StartsWith("ValueTuple`"))
             {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/TypeOfExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TypeOfExpressionTests.cs
@@ -22,4 +22,17 @@ public class TypeOfExpressionTests : CompilationTestBase
         var operandType = model.GetTypeInfo(typeOfExpression.Type).Type;
         Assert.Equal(SpecialType.System_Int32, operandType!.SpecialType);
     }
+
+    [Fact]
+    public void TypeOfExpression_BindsBoundNodeWithOperandType()
+    {
+        var (compilation, tree) = CreateCompilation("let t = typeof(int)");
+        var model = compilation.GetSemanticModel(tree);
+        var typeOfExpression = tree.GetRoot().DescendantNodes().OfType<TypeOfExpressionSyntax>().Single();
+
+        var bound = Assert.IsType<BoundTypeOfExpression>(model.GetBoundNode(typeOfExpression));
+
+        Assert.Equal(SpecialType.System_Type, bound.Type.SpecialType);
+        Assert.Equal(SpecialType.System_Int32, bound.OperandType.SpecialType);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure BoundTypeOfExpression preserves both the operand type and resolved System.Type result
- add System.Type handling to the special type resolution pipeline so typeof() binds successfully
- extend the typeof semantics test suite to cover the bound node output

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter TypeOfExpressionTests

------
https://chatgpt.com/codex/tasks/task_e_68d65ac066cc832fa3dcce2bc2174ea2