### PR TITLE
Add syntax tree and semantic analysis API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,6 +410,12 @@ _site
 api
 *.log
 
+# Keep hand-written compiler API docs
+!docs/
+!docs/compiler/
+!docs/compiler/api/
+!docs/compiler/api/*.md
+
 # Generated files
 *.g.cs
 *.stamp

--- a/docs/compiler/api/README.md
+++ b/docs/compiler/api/README.md
@@ -6,7 +6,7 @@ This document outlines the API of the Raven compiler, providing guidance on synt
 
 ## Syntax Analysis
 
-This section covers the basics of syntax analysis, including parsing source code, transforming syntax trees, and visualizing syntax hierarchies.
+This section covers the basics of syntax analysis, including parsing source code, transforming syntax trees, and visualizing syntax hierarchies. For a structured tour of the public surface, see the [Syntax Tree API](syntax-tree.md).
 
 ### Parsing Source Code into a Syntax Tree
 
@@ -265,7 +265,7 @@ A `Compilation` encapsulates all components required for compiling, including sy
 
 ### Semantic Analysis
 
-Retrieve symbol information using the `Compilation` and `SemanticModel` classes.
+Retrieve symbol information using the `Compilation` and `SemanticModel` classes. The [Semantic Analysis API](semantic-analysis.md) dives deeper into compilation construction, diagnostics, symbol binding, and the operations surface.
 
 #### Example
 

--- a/docs/compiler/api/semantic-analysis.md
+++ b/docs/compiler/api/semantic-analysis.md
@@ -1,0 +1,63 @@
+# Semantic Analysis API
+
+Semantic analysis is orchestrated by the `Compilation` and its per-tree
+`SemanticModel`. Together they resolve symbols, infer types, track diagnostics,
+and expose higher-level views such as operations.
+
+---
+
+## Building a compilation
+
+Create a `Compilation` by supplying syntax trees (and optional references):
+
+```csharp
+var tree = SyntaxTree.ParseText(source);
+var compilation = Compilation.Create("App", [tree]);
+```
+
+Compilations are immutable—`AddSyntaxTrees`, `AddReferences`, and
+`WithAssemblyName` return new instances that share existing state. Each
+compilation manages a binder factory, declaration table, and synthesized symbols
+for features such as delegates and the entry point.【F:src/Raven.CodeAnalysis/Compilation.cs†L1-L130】
+
+## Accessing semantic models
+
+`GetSemanticModel` materializes a `SemanticModel` for a specific tree. The
+compilation caches models so repeated calls return the same instance. Models are
+created eagerly when diagnostics or symbol queries require them, ensuring binder
+state is populated before answering questions.【F:src/Raven.CodeAnalysis/Compilation.cs†L82-L123】
+
+Each semantic model wires up the binder chain for the tree's root during
+construction. `EnsureDiagnosticsCollected` walks the syntax tree and binds
+expressions and statements on demand so later queries operate on cached bound
+nodes.【F:src/Raven.CodeAnalysis/SemanticModel.cs†L1-L71】
+
+## Diagnostics
+
+`SemanticModel.GetDiagnostics` consolidates binder diagnostics, deduplicates
+entries, and caches the resulting immutable array. It triggers binding for the
+current tree if diagnostics have not yet been collected.【F:src/Raven.CodeAnalysis/SemanticModel.cs†L23-L45】
+
+At the tree level, `SyntaxTree.GetDiagnostics` provides parser diagnostics. A
+compilation's `Emit` and `GetEntryPoint` flows also surface aggregated
+information when generating IL or determining the program entry point.【F:src/Raven.CodeAnalysis/Syntax/SyntaxTree.cs†L46-L67】【F:src/Raven.CodeAnalysis/Compilation.cs†L124-L206】
+
+## Symbol and type queries
+
+`GetSymbolInfo` retrieves the symbol associated with a syntax node by binding the
+node (or using cached results). For declarations, `GetDeclaredSymbol` resolves
+keys from the declaration table and uses the symbol factory to return the
+canonical symbol. `GetTypeInfo` has overloads for expressions and type syntax,
+returning both the inferred and converted types when available.【F:src/Raven.CodeAnalysis/SemanticModel.cs†L47-L143】
+
+These APIs cooperate with the binder hierarchy described in the semantic binding
+architecture notes. Binders chain by scope so lookups naturally fall back to
+parent contexts while preserving local information.【F:docs/compiler/architecture/semantic-binding.md†L1-L64】
+
+## Operations
+
+For syntax-agnostic analysis, call `SemanticModel.GetOperation`. The semantic
+model caches realized operations and uses `OperationFactory` to translate bound
+nodes into `IOperation` instances that mirror Roslyn's shape. The dedicated
+[Operations API](operations.md) document covers the available kinds, caching
+behavior, and current limitations.【F:src/Raven.CodeAnalysis/SemanticModel.Operations.cs†L1-L45】【F:docs/compiler/api/operations.md†L1-L55】

--- a/docs/compiler/api/syntax-tree.md
+++ b/docs/compiler/api/syntax-tree.md
@@ -1,0 +1,60 @@
+# Syntax Tree API
+
+The syntax tree API exposes the immutable structure produced by the parser. It
+follows the familiar Roslyn split between a compact "green" tree and a richer
+"red" tree so callers can efficiently inspect and transform source code without
+sacrificing reuse.
+
+---
+
+## Creating syntax trees
+
+The entry point is `SyntaxTree.ParseText`, which accepts raw text or a
+`SourceText` instance. Parsing returns a `SyntaxTree` whose root is a
+`CompilationUnitSyntax` node:
+
+```csharp
+var tree = SyntaxTree.ParseText(source);
+var root = tree.GetRoot();
+```
+
+`SyntaxTree.Create` performs the inverse: it wraps an existing red root (for
+example, one produced by a rewriter) back into a tree so it can participate in a
+`Compilation`.
+
+Each tree retains its original `SourceText`. Calls to `GetText` and
+`TryGetText` either return the parsed text or lazily reconstruct it from the
+current root when the source was produced from a red tree.【F:src/Raven.CodeAnalysis/Syntax/SyntaxTree.cs†L8-L104】
+
+## Navigating nodes and tokens
+
+Red `SyntaxNode` and `SyntaxToken` instances expose parents, spans, and helpers
+such as `DescendantNodes`/`DescendantTokens`. The `SyntaxTree` surface adds
+convenience methods for locating nodes: `GetNodesInSpan` returns the innermost
+nodes that cover a `TextSpan`, `GetNodeForSpan` gives the first match, and
+`GetNodeToReplace` normalizes zero-width insertions to the containing node.
+`GetLocation` turns a span into a `Location` tied to the tree for diagnostics.
+Tree-level `GetDiagnostics` overloads aggregate parser diagnostics for the whole
+file, a particular node/token, or a span.【F:src/Raven.CodeAnalysis/Syntax/SyntaxTree.cs†L46-L139】
+
+For inspection and tooling, syntax trees can be printed using the `PrintSyntaxTree`
+extension showcased in the API README. That routine walks the red tree and emits
+kind names, spans, and trivia so callers can visualize structure.
+
+## Visitors and rewriters
+
+The compiler ships source-generated visitor bases that align with Roslyn's
+patterns. `SyntaxVisitor` and `SyntaxVisitor<T>` offer traversal hooks for every
+node type, while `SyntaxRewriter` enables immutable transformations by producing
+updated nodes. The generator maintains these APIs so consumers can override only
+the members they care about and rely on default traversal for the rest.【F:docs/compiler/architecture/visitors-and-rewriters.md†L1-L40】
+
+## Incremental updates
+
+`WithChangedText` rebuilds a tree from edited source and shares unchanged green
+nodes where possible. The API exposes text changes via `GetChanges`, allowing
+callers to diff old and new trees or integrate with workspace features.【F:src/Raven.CodeAnalysis/Syntax/SyntaxTree.cs†L68-L93】【F:src/Raven.CodeAnalysis/Syntax/SyntaxTree.cs†L141-L178】
+
+When used with `Compilation.With...` helpers, new syntax trees can be swapped in
+without mutating existing compilations. This workflow underpins the compiler's
+incremental model and keeps tree operations predictable for IDE scenarios.


### PR DESCRIPTION
## Summary
- add dedicated syntax tree API reference covering tree creation, navigation, visitors, and incremental updates
- document the semantic analysis API across compilation, diagnostics, symbol/type queries, and the operations surface
- update compiler API README cross-links and adjust .gitignore to keep the hand-written docs tracked

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d664dac628832fa877fb4c304ef10a