### PR TITLE
Fix incremental parsing fallback

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/LanguageParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/LanguageParser.cs
@@ -40,7 +40,14 @@ internal class LanguageParser
         _lexer = new Lexer(textReader, position);
         var parseContext = new BaseParseContext(_lexer, position);
 
-        return ParseRequestedType(parseContext, requestedSyntaxType);
+        try
+        {
+            return ParseRequestedType(parseContext, requestedSyntaxType);
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
     }
 
     private SyntaxNode? ParseRequestedType(BaseParseContext context, Type requestedSyntaxType)
@@ -70,7 +77,7 @@ internal class LanguageParser
             return new NameSyntaxParser(context).ParseSimpleName();
         }
 
-        throw new NotSupportedException("Syntax not supported");
+        return null;
     }
 
     public StatementSyntax ParseStatement(SourceText sourceText, int offset = 0, bool consumeFullText = true)

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNodeReflectionExtensions.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNodeReflectionExtensions.cs
@@ -26,13 +26,18 @@ public static class SyntaxNodeReflectionExtensions
             // Handle lists: check if childNode is contained within a SyntaxList<T> or SeparatedSyntaxList<T>
             if (propertyValue is IEnumerable<object> collection)
             {
-                if (collection.Cast<SyntaxNode>().Contains(childNode))
+                foreach (var item in collection)
                 {
-                    // Extract the generic type parameter from the list type
-                    var propertyType = property.PropertyType;
-                    if (propertyType.IsGenericType)
+                    if (item is SyntaxNode nodeItem && nodeItem == childNode)
                     {
-                        return propertyType.GetGenericArguments().FirstOrDefault();
+                        // Extract the generic type parameter from the list type
+                        var propertyType = property.PropertyType;
+                        if (propertyType.IsGenericType)
+                        {
+                            return propertyType.GetGenericArguments().FirstOrDefault();
+                        }
+
+                        break;
                     }
                 }
             }

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxTree.cs
@@ -90,9 +90,9 @@ public class SyntaxTree
     }
 
 
-    internal static SyntaxTree Create(SourceText sourceText, CompilationUnitSyntax compilationUnit, ParseOptions options)
+    internal static SyntaxTree Create(SourceText sourceText, CompilationUnitSyntax compilationUnit, ParseOptions options, string? filePath = null)
     {
-        var syntaxTree = new SyntaxTree(sourceText, string.Empty, options);
+        var syntaxTree = new SyntaxTree(sourceText, filePath ?? string.Empty, options);
 
         compilationUnit = compilationUnit
             .WithSyntaxTree(syntaxTree);
@@ -231,7 +231,7 @@ public class SyntaxTree
             return ParseText(newText, _options, FilePath);
         }
 
-        return Create(newCompilationUnit, _options, Encoding, FilePath);
+        return Create(newText, newCompilationUnit, _options, FilePath);
     }
 
     private SyntaxNode? ParseNodeFromText(TextSpan changeSpan, SourceText newText, SyntaxNode nodeToReplace)
@@ -246,7 +246,12 @@ public class SyntaxTree
         {
             var parent = nodeToReplace.Parent;
 
-            if (parent is BlockStatementSyntax block)
+            if (parent is null)
+            {
+                return null;
+            }
+
+            if (parent is BlockStatementSyntax)
             {
                 //block.ReplaceNode(nodeToReplace, );
 
@@ -262,7 +267,9 @@ public class SyntaxTree
 
         var parser = new InternalSyntax.Parser.LanguageParser(string.Empty, _options);
 
-        return parser.ParseSyntax(requestedSyntaxType, newText, position)!.CreateRed();
+        var greenNode = parser.ParseSyntax(requestedSyntaxType, newText, position);
+
+        return greenNode?.CreateRed();
     }
 }
 

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/IncrementalSyntaxTreeUpdatesTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/IncrementalSyntaxTreeUpdatesTest.cs
@@ -149,5 +149,73 @@ public class IncrementalSyntaxTreeUpdatesTest
 
         AssertIncrementalParse(sourceText, changedSourceText);
     }
+
+    [Fact]
+    public void ApplyChangedTextToSyntaxTree6()
+    {
+        var sourceText = SourceText.From(
+            """
+            if (foo)  {
+                return 0;
+            } else if (bar ) {
+                return 1;
+            }
+            """);
+
+        var changedSourceText = SourceText.From(
+            """
+            if (foo)  {
+                return 0;
+            } else {
+                return 1;
+            }
+            """);
+
+        AssertIncrementalParse(sourceText, changedSourceText);
+    }
+
+    [Fact]
+    public void ApplyChangedTextToSyntaxTree7()
+    {
+        var sourceText = SourceText.From(
+            """
+            try {
+                return 0;
+            } catch (Foo ex) {
+                return 1;
+            }
+            """);
+
+        var changedSourceText = SourceText.From(
+            """
+            try {
+                return 0;
+            } catch (Bar ex) {
+                return 1;
+            }
+            """);
+
+        AssertIncrementalParse(sourceText, changedSourceText);
+    }
+
+    [Fact]
+    public void ApplyChangedTextToSyntaxTree_AddParameter()
+    {
+        var sourceText = SourceText.From(
+            """
+            fn add(a:int) {
+                return a;
+            }
+            """);
+
+        var changedSourceText = SourceText.From(
+            """
+            fn add(a:int, b:int) {
+                return a + b;
+            }
+            """);
+
+        AssertIncrementalParse(sourceText, changedSourceText);
+    }
 }
 


### PR DESCRIPTION
## Summary
- ensure `LanguageParser.ParseSyntax` gracefully returns null for unsupported syntax requests so `SyntaxTree.WithChangedText` can fall back to a full reparse
- persist the updated source text when creating a new tree and guard against missing parents when determining the node to reparse
- harden `GetPropertyTypeForChild` against mixed node collections and add incremental parsing regression tests for else chains, try/catch, and parameter insertions

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter IncrementalSyntaxTreeUpdatesTest

------
https://chatgpt.com/codex/tasks/task_e_68d66634b314832f80d383fb8fee0c77