### PR TITLE
Adjust using declaration tests for updated diagnostics

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/UsingDeclarationCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/UsingDeclarationCodeGenTests.cs
@@ -16,14 +16,14 @@ public class UsingDeclarationCodeGenTests
         var code = """
 import System.*
 
+using let foo = Foo()
+foo.Do()
+
 class Foo : IDisposable {
     public init() => Console.WriteLine("Init")
     public Do() => Console.WriteLine("Do")
     public Dispose() -> unit => Console.WriteLine("Dispose")
 }
-
-using let foo = Foo()
-foo.Do()
 """;
 
         var syntaxTree = SyntaxTree.ParseText(code);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/UsingDeclarationTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/UsingDeclarationTests.cs
@@ -40,7 +40,7 @@ using let foo = Foo()
             [
                 new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id)
                     .WithSpan(5, 17, 5, 22)
-                    .WithArguments("Foo", "System.IDisposable")
+                    .WithArguments("Foo", "IDisposable")
             ]);
 
         verifier.Verify();
@@ -65,7 +65,7 @@ using let foo: object = Foo()
             [
                 new DiagnosticResult(CompilerDiagnostics.CannotConvertFromTypeToType.Id)
                     .WithSpan(8, 11, 8, 14)
-                    .WithArguments("object", "System.IDisposable")
+                    .WithArguments("object", "IDisposable")
             ]);
 
         verifier.Verify();


### PR DESCRIPTION
## Summary
- update the using declaration semantic tests to expect the new `IDisposable` display names
- reorder the using declaration codegen sample so its top-level statements appear before declarations

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter Using

------
https://chatgpt.com/codex/tasks/task_e_68d66b732574832f810ba11ab6df1202