### PR TITLE
feat: support unicode escapes in strings

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -389,6 +389,12 @@ Console.WriteLine(hello + "World!")
 Console.WriteLine("Hello, " + 2)
 ```
 
+String literals recognize the standard escape sequences (`\"`, `\\`, `\n`, and
+so on) as well as Unicode escapes. Use `\uXXXX` or `\UXXXXXXXX` for fixed-width
+hexadecimal escapes, or `\u{...}` for variable-length scalars up to `0x10_FFFF`.
+Each escape expands to the corresponding UTF-16 sequence, so `"\u{1F600}"`
+produces the 😀 emoji.
+
 ### String interpolation
 
 Embed expressions directly into strings using `${...}` without requiring a prefix.
@@ -399,6 +405,10 @@ let age = 30
 let msg = "Name: ${name}, Age: ${age}"
 Console.WriteLine(msg)
 ```
+
+Escapes inside the literal portions of an interpolated string follow the same
+rules as ordinary string literals, ensuring Unicode escapes work uniformly in
+both forms.
 
 ### Collection expressions
 

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -2207,7 +2207,7 @@ partial class BlockBinder : Binder
             {
                 InterpolatedStringTextSyntax text => new BoundLiteralExpression(
                     BoundLiteralExpressionKind.StringLiteral,
-                    text.Token.Text,
+                    text.Token.ValueText ?? string.Empty,
                     Compilation.GetSpecialType(SpecialType.System_String)),
                 InterpolationSyntax interpolation => BindExpression(interpolation.Expression),
                 _ => throw new InvalidOperationException("Unknown interpolated string content")

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.StringLiterals.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxFacts.StringLiterals.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Text;
+
+namespace Raven.CodeAnalysis.Syntax;
+
+public static partial class SyntaxFacts
+{
+    public static string DecodeStringLiteralContent(ReadOnlySpan<char> text, out bool hadInvalidEscape)
+    {
+        if (text.IsEmpty)
+        {
+            hadInvalidEscape = false;
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        hadInvalidEscape = false;
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            if (ch != '\\')
+            {
+                builder.Append(ch);
+                continue;
+            }
+
+            if (i + 1 >= text.Length)
+            {
+                hadInvalidEscape = true;
+                builder.Append('?');
+                break;
+            }
+
+            var escape = text[++i];
+            switch (escape)
+            {
+                case '\"':
+                    builder.Append('\"');
+                    break;
+                case '\\':
+                    builder.Append('\\');
+                    break;
+                case '\0':
+                    builder.Append('\0');
+                    break;
+                case 'a':
+                    builder.Append('\a');
+                    break;
+                case 'b':
+                    builder.Append('\b');
+                    break;
+                case 'f':
+                    builder.Append('\f');
+                    break;
+                case 'n':
+                    builder.Append('\n');
+                    break;
+                case 'r':
+                    builder.Append('\r');
+                    break;
+                case 't':
+                    builder.Append('\t');
+                    break;
+                case 'v':
+                    builder.Append('\v');
+                    break;
+                case '$':
+                    builder.Append('$');
+                    break;
+                case 'u':
+                {
+                    var remaining = text[(i + 1)..];
+                    if (!TryDecodeUnicodeEscape(remaining, digits: 4, allowBraces: true, out var rune, out var consumed))
+                    {
+                        hadInvalidEscape = true;
+                        builder.Append('?');
+                        i += consumed;
+                    }
+                    else
+                    {
+                        builder.Append(rune.ToString());
+                        i += consumed;
+                    }
+                    break;
+                }
+                case 'U':
+                {
+                    var remaining = text[(i + 1)..];
+                    if (!TryDecodeUnicodeEscape(remaining, digits: 8, allowBraces: false, out var rune, out var consumed))
+                    {
+                        hadInvalidEscape = true;
+                        builder.Append('?');
+                        i += consumed;
+                    }
+                    else
+                    {
+                        builder.Append(rune.ToString());
+                        i += consumed;
+                    }
+                    break;
+                }
+                default:
+                    hadInvalidEscape = true;
+                    builder.Append('?');
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    public static bool TryDecodeUnicodeEscape(
+        ReadOnlySpan<char> text,
+        int digits,
+        bool allowBraces,
+        out Rune rune,
+        out int charsConsumed)
+    {
+        rune = default;
+        charsConsumed = 0;
+
+        if (allowBraces && !text.IsEmpty && text[0] == '{')
+        {
+            var value = 0;
+            var digitCount = 0;
+            for (int i = 1; i < text.Length; i++)
+            {
+                var c = text[i];
+                if (c == '}')
+                {
+                    charsConsumed = i + 1;
+                    if (digitCount == 0)
+                    {
+                        return false;
+                    }
+
+                    return Rune.TryCreate(value, out rune);
+                }
+
+                if (!IsHexDigit(c))
+                {
+                    charsConsumed = i + 1;
+                    return false;
+                }
+
+                value = (value << 4) + GetHexValue(c);
+                if (value > 0x10FFFF)
+                {
+                    charsConsumed = i + 1;
+                    return false;
+                }
+
+                digitCount++;
+                if (digitCount > 8)
+                {
+                    charsConsumed = i + 1;
+                    return false;
+                }
+            }
+
+            charsConsumed = text.Length;
+            return false;
+        }
+
+        if (text.Length < digits)
+        {
+            charsConsumed = text.Length;
+            return false;
+        }
+
+        var scalar = 0;
+        for (int i = 0; i < digits; i++)
+        {
+            var c = text[i];
+            if (!IsHexDigit(c))
+            {
+                charsConsumed = i + 1;
+                return false;
+            }
+
+            scalar = (scalar << 4) + GetHexValue(c);
+        }
+
+        charsConsumed = digits;
+        return Rune.TryCreate(scalar, out rune);
+    }
+
+    public static bool IsHexDigit(char ch)
+    {
+        return (ch >= '0' && ch <= '9') ||
+               (ch >= 'a' && ch <= 'f') ||
+               (ch >= 'A' && ch <= 'F');
+    }
+
+    public static int GetHexValue(char ch)
+    {
+        if (ch >= '0' && ch <= '9')
+            return ch - '0';
+        if (ch >= 'a' && ch <= 'f')
+            return ch - 'a' + 10;
+        if (ch >= 'A' && ch <= 'F')
+            return ch - 'A' + 10;
+
+        throw new ArgumentOutOfRangeException(nameof(ch));
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class InterpolatedStringTests
+{
+    [Fact]
+    public void InterpolatedStringText_DecodesUnicodeEscapes()
+    {
+        var source = "let s = \"Start \\u{1F600} ${name} End\";";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var interpolated = root.DescendantNodes().OfType<InterpolatedStringExpressionSyntax>().Single();
+
+        var leadingText = Assert.IsType<InterpolatedStringTextSyntax>(interpolated.Contents[0]);
+        Assert.Equal("Start \U0001F600 ", leadingText.Token.ValueText);
+    }
+
+    [Fact]
+    public void InterpolatedStringText_TrailingSegmentDecodesUnicode()
+    {
+        var source = "let s = \"${value} \\u0041\";";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var interpolated = root.DescendantNodes().OfType<InterpolatedStringExpressionSyntax>().Single();
+
+        var trailingText = Assert.IsType<InterpolatedStringTextSyntax>(interpolated.Contents[^1]);
+        Assert.Equal(" A", trailingText.Token.ValueText);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTriviaTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTriviaTest.cs
@@ -15,7 +15,7 @@ public class InterpolatedStringTriviaTest
 
         var parser = new ExpressionSyntaxParser(new BaseParseContext(new Lexer(new StringReader(string.Empty))));
         var method = typeof(ExpressionSyntaxParser).GetMethod("ParseInterpolatedStringExpression", BindingFlags.Instance | BindingFlags.NonPublic);
-        var green = (IS.InterpolatedStringExpressionSyntax)method!.Invoke(parser, new object[] { token, "foo{bar}" })!;
+        var green = (IS.InterpolatedStringExpressionSyntax)method!.Invoke(parser, new object[] { token })!;
         var interpolated = (InterpolatedStringExpressionSyntax)green.CreateRed()!;
 
         var startTrivia = interpolated.StringStartToken.LeadingTrivia;

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
@@ -72,6 +72,20 @@ public class LexerTests
         Assert.Equal(1_000, value);
     }
 
+    [Theory]
+    [InlineData("\"\\u0041\"", "A")]
+    [InlineData("\"\\u{1F600}\"", "\U0001F600")]
+    [InlineData("\"\\U0001F642\"", "\U0001F642")]
+    public void StringLiteral_SupportsUnicodeEscapes(string text, string expected)
+    {
+        var lexer = new Lexer(new StringReader(text));
+        var token = lexer.ReadToken();
+
+        Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind);
+        var value = Assert.IsType<string>(token.Value);
+        Assert.Equal(expected, value);
+    }
+
     [Fact]
     public void LineFeed_WithUnifiedNewLineToken_ReturnsNewLineToken()
     {


### PR DESCRIPTION
## Summary
- add shared decoding helpers for string literal escape sequences, including Unicode scalars
- update the lexer, parser, and binder to use decoded string text for literals and interpolated segments
- exercise the new behavior with lexer and parser tests and document the supported escape forms

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Syntax/SyntaxFacts.StringLiterals.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs,src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs,src/Raven.CodeAnalysis/Binder/BlockBinder.cs,test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs,test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTriviaTest.cs,test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTests.cs
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: NullableTypeTests.ReferencedLibrary_NullabilityAnnotations_AreRead, existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68d67300562c832fa515c8dcbf87b186