### PR TITLE
Fix string literal parsing for non-ASCII characters

### DIFF
--- a/src/Raven.CodeAnalysis/Text/SourceText.cs
+++ b/src/Raven.CodeAnalysis/Text/SourceText.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Text;
 
@@ -90,10 +91,17 @@ public class SourceText
 
     public TextReader GetTextReader(int position)
     {
-        MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(_text));
-        StreamReader reader = new StreamReader(stream);
-        stream.Seek(position, SeekOrigin.Begin);
-        return reader;
+        if (position <= 0)
+        {
+            return new StringReader(_text);
+        }
+
+        if (position >= _text.Length)
+        {
+            return new StringReader(string.Empty);
+        }
+
+        return new StringReader(_text[position..]);
     }
 
     public IReadOnlyList<TextChange> GetTextChanges(SourceText oldText)

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+using Raven.CodeAnalysis.Text;
 using Xunit;
 
 namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
@@ -84,6 +85,21 @@ public class LexerTests
         Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind);
         var value = Assert.IsType<string>(token.Value);
         Assert.Equal(expected, value);
+    }
+
+    [Fact]
+    public void StringLiteral_SupportsNonAsciiCharacters()
+    {
+        var sourceText = SourceText.From("ああ\"世界\"");
+        using var reader = sourceText.GetTextReader(2);
+        var lexer = new Lexer(reader, 2);
+
+        var token = lexer.ReadToken();
+
+        Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind);
+        Assert.Equal("\"世界\"", token.Text);
+        var value = Assert.IsType<string>(token.Value);
+        Assert.Equal("世界", value);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- adjust SourceText.GetTextReader to return a character-based reader so multi-byte literals remain intact when parsed from offsets
- add a lexer unit test that asserts interpolated Japanese text lexes correctly when parsing from a non-zero position

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter StringLiteral_SupportsNonAsciiCharacters

------
https://chatgpt.com/codex/tasks/task_e_68d67640e5bc832f8df207a7008e8d18