### PR TITLE
Add literal union assignment completions

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
@@ -360,4 +360,46 @@ ST.
 
         Assert.Contains(items, i => i.DisplayText == "StringBuilder");
     }
+
+    [Fact]
+    public void GetCompletions_OnLiteralUnionLocal_SuggestsAllMembers()
+    {
+        var code = "let response: \"כן\" | \"לא\" = ";
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var compilation = Compilation.Create(
+            "test",
+            [syntaxTree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var service = new CompletionService();
+        var position = code.Length;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "\"כן\"");
+        Assert.Contains(items, i => i.DisplayText == "\"לא\"");
+    }
+
+    [Fact]
+    public void GetCompletions_OnLiteralUnionAssignment_SuggestsAllMembers()
+    {
+        var code = "let response: \"כן\" | \"לא\" = \"כן\";\nresponse = ";
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var compilation = Compilation.Create(
+            "test",
+            [syntaxTree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var service = new CompletionService();
+        var position = code.Length;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "\"כן\"");
+        Assert.Contains(items, i => i.DisplayText == "\"לא\"");
+    }
 }


### PR DESCRIPTION
## Summary
- add literal and null member suggestions when assigning to union types comprised of literals
- flatten aliases/unions when collecting literal members for completion items
- cover literal union locals and assignments with completion tests

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/CompletionProvider.cs,test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing tests Lambda_WithoutParameterTypes_UsesTargetDelegateSignature and OptionalParameterSemanticTests.Invocation_OmitsOptionalArgument_UsesDefaultValue)*

------
https://chatgpt.com/codex/tasks/task_e_68d6745d2f14832f983acd8b23622e5d