### PR TITLE
Add conditional self completion and literal coverage

### DIFF
--- a/src/Raven.CodeAnalysis/CompletionProvider.cs
+++ b/src/Raven.CodeAnalysis/CompletionProvider.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
 
@@ -519,7 +521,24 @@ public static class CompletionProvider
         }
 
         // Language keywords
-        var keywords = new[] { "if", "else", "while", "for", "return", "let", "var", "new", "true", "false", "null" };
+        var keywords = new List<string>
+        {
+            "if",
+            "else",
+            "while",
+            "for",
+            "return",
+            "let",
+            "var",
+            "new",
+            "true",
+            "false",
+            "null"
+        };
+
+        if (ShouldOfferSelfKeyword(binder))
+            keywords.Add("self");
+
         foreach (var keyword in keywords.Where(k => string.IsNullOrEmpty(tokenText) || k.StartsWith(tokenText, StringComparison.OrdinalIgnoreCase)))
         {
             if (seen.Add(keyword))
@@ -579,5 +598,16 @@ public static class CompletionProvider
         }
 
         return completions;
+    }
+
+    private static bool ShouldOfferSelfKeyword(Binder? binder)
+    {
+        for (var current = binder; current is not null; current = current.ParentBinder)
+        {
+            if (current.ContainingSymbol is IMethodSymbol method)
+                return !method.IsStatic || method.IsNamedConstructor;
+        }
+
+        return false;
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
@@ -402,4 +402,51 @@ ST.
         Assert.Contains(items, i => i.DisplayText == "\"כן\"");
         Assert.Contains(items, i => i.DisplayText == "\"לא\"");
     }
+
+    [Fact]
+    public void GetCompletions_InInstanceMethod_SuggestsSelfKeyword()
+    {
+        var code = """
+        class Counter {
+            public Increment() -> unit {
+                sel
+            }
+        }
+        """;
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var compilation = Compilation.Create(
+            "test",
+            [syntaxTree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var service = new CompletionService();
+        var position = code.LastIndexOf("sel", StringComparison.Ordinal) + "sel".Length;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "self");
+    }
+
+    [Fact]
+    public void GetCompletions_OnNumericLiteral_SuggestsLiteralValue()
+    {
+        var code = "let value: 100 = ";
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var compilation = Compilation.Create(
+            "test",
+            [syntaxTree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var service = new CompletionService();
+        var position = code.Length;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "100");
+    }
 }


### PR DESCRIPTION
## Summary
- offer the `self` keyword through the completion provider when editing instance methods or named constructors
- add unit tests covering self keyword and numeric literal completions

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~GetCompletions_InInstanceMethod_SuggestsSelfKeyword
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~GetCompletions_OnNumericLiteral_SuggestsLiteralValue

------
https://chatgpt.com/codex/tasks/task_e_68d684014a9c832faddf99959128e6f2