### PR TITLE
fix: skip extension lookup for error receivers

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/ImportBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/ImportBinder.cs
@@ -123,18 +123,21 @@ class ImportBinder : Binder
 
     public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
     {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            yield break;
+
         var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
 
         foreach (var scope in _namespaceOrTypeScopeImports)
         {
-            foreach (var method in GetExtensionMethodsFromScope(scope, name, includePartialMatches))
+            foreach (var method in GetExtensionMethodsFromScope(scope, name, receiverType, includePartialMatches))
                 if (seen.Add(method))
                     yield return method;
         }
 
         foreach (var type in _typeImports)
         {
-            foreach (var method in GetExtensionMethodsFromScope(type, name, includePartialMatches))
+            foreach (var method in GetExtensionMethodsFromScope(type, name, receiverType, includePartialMatches))
                 if (seen.Add(method))
                     yield return method;
         }

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
 
@@ -36,9 +37,12 @@ class NamespaceBinder : Binder
 
     public override IEnumerable<IMethodSymbol> LookupExtensionMethods(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
     {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            yield break;
+
         var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
 
-        foreach (var method in GetExtensionMethodsFromScope(_namespaceSymbol, name, includePartialMatches))
+        foreach (var method in GetExtensionMethodsFromScope(_namespaceSymbol, name, receiverType, includePartialMatches))
             if (seen.Add(method))
                 yield return method;
 


### PR DESCRIPTION
## Summary
- avoid enumerating extension methods when the receiver type is the compiler's error symbol to prevent runaway completion lookups
- thread the receiver type through the extension lookup helper so nested scopes honor the early exit

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/Binder.cs --include src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs --include src/Raven.CodeAnalysis/Binder/ImportBinder.cs
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d683b7cd3c832fae90a89207c503d1