### PR TITLE
Add member access completion for literal types

### DIFF
--- a/src/Raven.CodeAnalysis/CompletionProvider.cs
+++ b/src/Raven.CodeAnalysis/CompletionProvider.cs
@@ -427,11 +427,16 @@ public static class CompletionProvider
                     // Accessing a type name: show static members
                     members = typeSymbol.GetMembers().Where(m => m.IsStatic && IsAccessible(m));
                 }
-                else if (type is INamedTypeSymbol instanceType)
+                else if (type is ITypeSymbol instanceType)
                 {
                     // Accessing an instance: show instance members
                     members = instanceType.GetMembers().Where(m => !m.IsStatic && IsAccessible(m));
-                    instanceTypeForExtensions = instanceType;
+                    instanceTypeForExtensions = instanceType switch
+                    {
+                        INamedTypeSymbol named => named,
+                        LiteralTypeSymbol literal => literal.UnderlyingType as INamedTypeSymbol,
+                        _ => null
+                    };
                 }
 
                 if (members is not null)

--- a/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
@@ -80,6 +80,38 @@ text.
     }
 
     [Fact]
+    public void GetCompletions_AfterDot_OnLiteralType_ReturnsInstanceMembers()
+    {
+        var code = """
+import System.*;
+
+let literal: "foo" = "foo";
+literal.
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+
+        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
+        var refAssembliesPath = TargetFrameworkResolver.GetDirectoryPath(version);
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences([
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(refAssembliesPath!, "System.Runtime.InteropServices.dll")),
+                MetadataReference.CreateFromFile(typeof(System.Runtime.InteropServices.Marshal).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+            ]);
+
+        var service = new CompletionService();
+        var position = code.LastIndexOf('.') + 1;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        Assert.Contains(items, i => i.DisplayText == "Length");
+    }
+
+    [Fact]
     public void GetCompletions_AfterDot_OnProperty_ReturnsInstanceMembers()
     {
         var code = """


### PR DESCRIPTION
## Summary
- treat literal type instances like their underlying named types when gathering member completions
- add a completion test that verifies member access on literal-typed locals exposes string members

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: TryStatement_WithoutCatchOrFinally_ReportsDiagnostic and MethodReference_WithRefOutParameters_InvokesTarget)*

------
https://chatgpt.com/codex/tasks/task_e_68d68af8e130832f9b1fd4974fd9d8e5