### PR TITLE
feat: add semantic facts helpers

### DIFF
--- a/docs/compiler/api/semantic-analysis.md
+++ b/docs/compiler/api/semantic-analysis.md
@@ -54,6 +54,14 @@ These APIs cooperate with the binder hierarchy described in the semantic binding
 architecture notes. Binders chain by scope so lookups naturally fall back to
 parent contexts while preserving local information.【F:docs/compiler/architecture/semantic-binding.md†L1-L64】
 
+### Symbol facts helpers
+
+The compiler exposes relationship helpers in `SemanticFacts` for advanced
+analysis scenarios. `IsDerivedFrom` walks base types (including type-parameter
+constraints) while `ImplementsInterface` traverses the interface closure, and
+both accept optional `SymbolEqualityComparer` instances so tooling can align
+with Roslyn's equality semantics when desired.【F:src/Raven.CodeAnalysis/SemanticFacts.cs†L1-L146】
+
 ## Operations
 
 For syntax-agnostic analysis, call `SemanticModel.GetOperation`. The semantic

--- a/docs/compiler/api/semantic-analysis.md
+++ b/docs/compiler/api/semantic-analysis.md
@@ -58,9 +58,10 @@ parent contexts while preserving local information.【F:docs/compiler/architectu
 
 The compiler exposes relationship helpers in `SemanticFacts` for advanced
 analysis scenarios. `IsDerivedFrom` walks base types (including type-parameter
-constraints) while `ImplementsInterface` traverses the interface closure, and
-both accept optional `SymbolEqualityComparer` instances so tooling can align
-with Roslyn's equality semantics when desired.【F:src/Raven.CodeAnalysis/SemanticFacts.cs†L1-L146】
+constraints) while `ImplementsInterface` traverses the interface closure (and
+considers interface identity), and both accept optional
+`SymbolEqualityComparer` instances so tooling can align with Roslyn's equality
+semantics when desired.【F:src/Raven.CodeAnalysis/SemanticFacts.cs†L1-L150】
 
 ## Operations
 

--- a/docs/compiler/api/semantic-analysis.md
+++ b/docs/compiler/api/semantic-analysis.md
@@ -61,7 +61,9 @@ analysis scenarios. `IsDerivedFrom` walks base types (including type-parameter
 constraints) while `ImplementsInterface` traverses the interface closure (and
 considers interface identity), and both accept optional
 `SymbolEqualityComparer` instances so tooling can align with Roslyn's equality
-semantics when desired.【F:src/Raven.CodeAnalysis/SemanticFacts.cs†L1-L150】
+semantics when desired. Array types mirror Roslyn's behavior by mapping their
+single-dimensional interfaces (`IEnumerable<T>`, `IList<T>`, etc.) to
+constructed interface instances using the array's element type.【F:src/Raven.CodeAnalysis/SemanticFacts.cs†L1-L180】
 
 ## Operations
 

--- a/docs/compiler/api/semantic-analysis.md
+++ b/docs/compiler/api/semantic-analysis.md
@@ -61,9 +61,10 @@ analysis scenarios. `IsDerivedFrom` walks base types (including type-parameter
 constraints) while `ImplementsInterface` traverses the interface closure (and
 considers interface identity), and both accept optional
 `SymbolEqualityComparer` instances so tooling can align with Roslyn's equality
-semantics when desired. Array types mirror Roslyn's behavior by mapping their
-single-dimensional interfaces (`IEnumerable<T>`, `IList<T>`, etc.) to
-constructed interface instances using the array's element type.【F:src/Raven.CodeAnalysis/SemanticFacts.cs†L1-L180】
+semantics when desired. Array types mirror Roslyn's behavior by surfacing their
+single-dimensional `IList<T>`/`IReadOnlyList<T>` contracts directly on the array
+symbol, letting the helpers observe Roslyn-style constructed interfaces via the
+array's element type.【F:src/Raven.CodeAnalysis/SemanticFacts.cs†L1-L120】【F:src/Raven.CodeAnalysis/Symbols/Constructed/ArrayTypeSymbol.cs†L1-L137】
 
 ## Operations
 

--- a/src/Raven.CodeAnalysis/SemanticFacts.cs
+++ b/src/Raven.CodeAnalysis/SemanticFacts.cs
@@ -44,9 +44,6 @@ public static class SemanticFacts
         if (comparer.Equals(type, interfaceType))
             return true;
 
-        if (type is IArrayTypeSymbol array && ImplementsArrayInterface(array, interfaceType, comparer))
-            return true;
-
         if (type is ITypeParameterSymbol typeParameter)
             return ImplementsInterfaceTypeParameter(typeParameter, interfaceType, comparer, CreateVisitedSet(comparer));
 
@@ -127,48 +124,10 @@ public static class SemanticFacts
         if (type is INamedTypeSymbol named)
             return named.AllInterfaces;
 
-        if (type is ArrayTypeSymbol array && array.BaseType is INamedTypeSymbol arrayBase)
-            return arrayBase.AllInterfaces;
+        if (type is ArrayTypeSymbol array)
+            return array.AllInterfaces;
 
         return Array.Empty<INamedTypeSymbol>();
-    }
-
-    private static bool ImplementsArrayInterface(IArrayTypeSymbol array, INamedTypeSymbol interfaceType, SymbolEqualityComparer comparer)
-    {
-        var interfaceDefinition = interfaceType.ConstructedFrom as INamedTypeSymbol ?? interfaceType;
-        var metadataName = interfaceDefinition.ToFullyQualifiedMetadataName();
-
-        return metadataName switch
-        {
-            "System.Collections.IEnumerable" => true,
-            "System.Collections.ICollection" => true,
-            "System.Collections.IList" => true,
-            "System.Collections.Generic.IEnumerable`1" =>
-                array.Rank == 1 && ImplementsArrayGenericInterface(array, interfaceType, comparer),
-            "System.Collections.Generic.ICollection`1" =>
-                array.Rank == 1 && ImplementsArrayGenericInterface(array, interfaceType, comparer),
-            "System.Collections.Generic.IList`1" =>
-                array.Rank == 1 && ImplementsArrayGenericInterface(array, interfaceType, comparer),
-            "System.Collections.Generic.IReadOnlyCollection`1" =>
-                array.Rank == 1 && ImplementsArrayGenericInterface(array, interfaceType, comparer),
-            "System.Collections.Generic.IReadOnlyList`1" =>
-                array.Rank == 1 && ImplementsArrayGenericInterface(array, interfaceType, comparer),
-            _ => false,
-        };
-    }
-
-    private static bool ImplementsArrayGenericInterface(
-        IArrayTypeSymbol array,
-        INamedTypeSymbol interfaceType,
-        SymbolEqualityComparer comparer)
-    {
-        if (interfaceType.TypeArguments.Length != 1)
-            return false;
-
-        var elementType = array.ElementType;
-        var targetArgument = interfaceType.TypeArguments[0];
-
-        return comparer.Equals(elementType, targetArgument);
     }
 
     private static HashSet<ISymbol> CreateVisitedSet(SymbolEqualityComparer comparer)

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ArrayTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ArrayTypeSymbol.cs
@@ -4,7 +4,18 @@ namespace Raven.CodeAnalysis.Symbols;
 
 internal partial class ArrayTypeSymbol : PESymbol, IArrayTypeSymbol
 {
-    public ArrayTypeSymbol(INamedTypeSymbol baseType, ITypeSymbol elementType, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations, int rank = 1)
+    private ImmutableArray<INamedTypeSymbol> _interfaces;
+    private ImmutableArray<INamedTypeSymbol> _allInterfaces;
+    private ImmutableArray<INamedTypeSymbol> _arraySpecificInterfaces;
+
+    public ArrayTypeSymbol(
+        INamedTypeSymbol baseType,
+        ITypeSymbol elementType,
+        ISymbol containingSymbol,
+        INamedTypeSymbol? containingType,
+        INamespaceSymbol? containingNamespace,
+        Location[] locations,
+        int rank = 1)
         : base(containingSymbol, containingType, containingNamespace, locations)
     {
         BaseType = baseType;
@@ -34,28 +45,109 @@ internal partial class ArrayTypeSymbol : PESymbol, IArrayTypeSymbol
 
     public ITypeSymbol? OriginalDefinition { get; }
 
-    public ImmutableArray<ISymbol> GetMembers()
-    {
-        return BaseType!.GetMembers();
-    }
+    public ImmutableArray<INamedTypeSymbol> Interfaces =>
+        !_interfaces.IsDefault ? _interfaces : _interfaces = ComputeInterfaces();
 
-    public ImmutableArray<ISymbol> GetMembers(string name)
-    {
-        return BaseType!.GetMembers(name);
-    }
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces =>
+        !_allInterfaces.IsDefault ? _allInterfaces : _allInterfaces = ComputeAllInterfaces();
+
+    public ImmutableArray<ISymbol> GetMembers() => BaseType!.GetMembers();
+
+    public ImmutableArray<ISymbol> GetMembers(string name) => BaseType!.GetMembers(name);
 
     public ITypeSymbol? LookupType(string name)
     {
         throw new NotImplementedException();
     }
 
-    public override string ToString()
-    {
-        return Name;
-    }
+    public override string ToString() => Name;
 
     public bool IsMemberDefined(string name, out ISymbol? symbol)
     {
         throw new NotSupportedException();
+    }
+
+    private ImmutableArray<INamedTypeSymbol> ComputeInterfaces()
+    {
+        var builder = ImmutableArray.CreateBuilder<INamedTypeSymbol>();
+
+        if (BaseType is INamedTypeSymbol baseType)
+            builder.AddRange(baseType.Interfaces);
+
+        foreach (var arrayInterface in GetArraySpecificInterfaces())
+            AddUnique(builder, arrayInterface);
+
+        return builder.ToImmutable();
+    }
+
+    private ImmutableArray<INamedTypeSymbol> ComputeAllInterfaces()
+    {
+        var builder = ImmutableArray.CreateBuilder<INamedTypeSymbol>();
+
+        if (BaseType is INamedTypeSymbol baseType)
+            builder.AddRange(baseType.AllInterfaces);
+
+        foreach (var arrayInterface in GetArraySpecificInterfaces())
+        {
+            AddUnique(builder, arrayInterface);
+
+            foreach (var inherited in arrayInterface.AllInterfaces)
+                AddUnique(builder, inherited);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private ImmutableArray<INamedTypeSymbol> GetArraySpecificInterfaces()
+    {
+        if (!_arraySpecificInterfaces.IsDefault)
+            return _arraySpecificInterfaces;
+
+        if (Rank != 1)
+        {
+            _arraySpecificInterfaces = ImmutableArray<INamedTypeSymbol>.Empty;
+            return _arraySpecificInterfaces;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<INamedTypeSymbol>();
+
+        AddConstructedInterface(builder, "System.Collections.Generic.IList`1");
+        AddConstructedInterface(builder, "System.Collections.Generic.IReadOnlyList`1");
+
+        _arraySpecificInterfaces = builder.ToImmutable();
+        return _arraySpecificInterfaces;
+    }
+
+    private void AddConstructedInterface(ImmutableArray<INamedTypeSymbol>.Builder builder, string metadataName)
+    {
+        if (TryResolveInterface(metadataName) is not INamedTypeSymbol definition)
+            return;
+
+        if (!definition.IsGenericType || definition.Arity != 1)
+            return;
+
+        if (definition.Construct(ElementType) is not INamedTypeSymbol constructed)
+            return;
+
+        AddUnique(builder, constructed);
+    }
+
+    private INamedTypeSymbol? TryResolveInterface(string metadataName)
+    {
+        if (BaseType?.ContainingAssembly?.GetTypeByMetadataName(metadataName) is INamedTypeSymbol resolved)
+            return resolved;
+
+        return ContainingAssembly?.GetTypeByMetadataName(metadataName);
+    }
+
+    private static void AddUnique(ImmutableArray<INamedTypeSymbol>.Builder builder, INamedTypeSymbol symbol)
+    {
+        foreach (var existing in builder)
+        {
+            if (SymbolEqualityComparer.Default.Equals(existing, symbol))
+                return;
+        }
+
+        builder.Add(symbol);
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
@@ -27,7 +27,7 @@ public class SemanticFactsTests
     [Fact]
     public void IsDerivedFrom_ReturnsTrueForTypeParameterConstraint()
     {
-        var source = "class Base {} class Container<T> where T : Base {}";
+        var source = "class Base {} class Container<T : Base> {}";
         var tree = SyntaxTree.ParseText(source);
         var compilation = Compilation.Create(
             "test",
@@ -62,7 +62,7 @@ public class SemanticFactsTests
     [Fact]
     public void ImplementsInterface_ReturnsTrueForTypeParameterConstraint()
     {
-        var source = "interface IMarker {} class Container<T> where T : IMarker {}";
+        var source = "interface IMarker {} class Container<T : IMarker> {}";
         var tree = SyntaxTree.ParseText(source);
         var compilation = Compilation.Create(
             "test",

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
@@ -1,0 +1,79 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class SemanticFactsTests
+{
+    [Fact]
+    public void IsDerivedFrom_ReturnsTrueForDirectBaseType()
+    {
+        var source = "class Base {} class Derived : Base {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var derived = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Derived")!;
+        var baseType = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Base")!;
+
+        Assert.True(SemanticFacts.IsDerivedFrom(derived, baseType));
+        Assert.False(SemanticFacts.IsDerivedFrom(baseType, derived));
+    }
+
+    [Fact]
+    public void IsDerivedFrom_ReturnsTrueForTypeParameterConstraint()
+    {
+        var source = "class Base {} class Container<T> where T : Base {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container`1")!;
+        var typeParameter = container.TypeParameters[0];
+        var baseType = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Base")!;
+
+        Assert.True(SemanticFacts.IsDerivedFrom(typeParameter, baseType));
+    }
+
+    [Fact]
+    public void ImplementsInterface_ReturnsTrueForClassImplementation()
+    {
+        var source = "interface IMarker {} class Implementation : IMarker {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var implementation = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Implementation")!;
+        var marker = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IMarker")!;
+
+        Assert.True(SemanticFacts.ImplementsInterface(implementation, marker));
+    }
+
+    [Fact]
+    public void ImplementsInterface_ReturnsTrueForTypeParameterConstraint()
+    {
+        var source = "interface IMarker {} class Container<T> where T : IMarker {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container`1")!;
+        var typeParameter = container.TypeParameters[0];
+        var marker = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IMarker")!;
+
+        Assert.True(SemanticFacts.ImplementsInterface(typeParameter, marker));
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
@@ -35,7 +35,7 @@ public class SemanticFactsTests
             TestMetadataReferences.Default,
             new CompilationOptions(OutputKind.ConsoleApplication));
 
-        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container`1")!;
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container")!;
         var typeParameter = container.TypeParameters[0];
         var baseType = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Base")!;
 
@@ -70,11 +70,27 @@ public class SemanticFactsTests
             TestMetadataReferences.Default,
             new CompilationOptions(OutputKind.ConsoleApplication));
 
-        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container`1")!;
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container")!;
         var typeParameter = container.TypeParameters[0];
         var marker = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IMarker")!;
 
         Assert.True(SemanticFacts.ImplementsInterface(typeParameter, marker));
+    }
+
+    [Fact]
+    public void ImplementsInterface_ReturnsTrueForInterfaceItself()
+    {
+        var source = "interface IMarker {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var marker = (INamedTypeSymbol)compilation.GetTypeByMetadataName("IMarker")!;
+
+        Assert.True(SemanticFacts.ImplementsInterface(marker, marker));
     }
 
     [Fact]

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
@@ -109,4 +109,28 @@ public class SemanticFactsTests
 
         Assert.True(SemanticFacts.ImplementsInterface(arrayType, enumerable));
     }
+
+    [Fact]
+    public void ImplementsInterface_ArrayHonorsConstructedGenericInterfaces()
+    {
+        var tree = SyntaxTree.ParseText("class C {}");
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var arrayType = compilation.CreateArrayTypeSymbol(intType);
+
+        var enumerableDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1")!;
+        var enumerableOfInt = (INamedTypeSymbol)enumerableDefinition.Construct(intType);
+        var enumerableOfString = (INamedTypeSymbol)enumerableDefinition.Construct(compilation.GetSpecialType(SpecialType.System_String));
+        var listDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.Generic.IList`1")!;
+        var listOfInt = (INamedTypeSymbol)listDefinition.Construct(intType);
+
+        Assert.True(SemanticFacts.ImplementsInterface(arrayType, enumerableOfInt));
+        Assert.False(SemanticFacts.ImplementsInterface(arrayType, enumerableOfString));
+        Assert.True(SemanticFacts.ImplementsInterface(arrayType, listOfInt));
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
@@ -76,4 +76,21 @@ public class SemanticFactsTests
 
         Assert.True(SemanticFacts.ImplementsInterface(typeParameter, marker));
     }
+
+    [Fact]
+    public void ImplementsInterface_ReturnsTrueForArrayInterfaces()
+    {
+        var tree = SyntaxTree.ParseText("class C {}");
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var arrayType = compilation.CreateArrayTypeSymbol(intType);
+        var enumerable = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.IEnumerable")!;
+
+        Assert.True(SemanticFacts.ImplementsInterface(arrayType, enumerable));
+    }
 }


### PR DESCRIPTION
## Summary
- add a SemanticFacts helper class to query inheritance and interface implementation with optional symbol comparers
- cover the new helpers with semantic unit tests including type parameter constraint scenarios

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: known baseline diagnostics mismatches in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d694c15f14832f977d9d7b49acf2df