### PR TITLE
Allow member access on literal expressions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1717,9 +1717,11 @@ partial class BlockBinder : Binder
 
         if (receiver.Type is not null)
         {
+            var receiverType = receiver.Type.UnwrapLiteralType() ?? receiver.Type;
+
             var methodCandidates = ImmutableArray<IMethodSymbol>.Empty;
 
-            var instanceMethods = new SymbolQuery(name, receiver.Type, IsStatic: false)
+            var instanceMethods = new SymbolQuery(name, receiverType, IsStatic: false)
                 .LookupMethods(this)
                 .ToImmutableArray();
 
@@ -1728,7 +1730,7 @@ partial class BlockBinder : Binder
 
             if (IsExtensionReceiver(receiver))
             {
-                var extensionMethods = LookupExtensionMethods(name, receiver.Type)
+                var extensionMethods = LookupExtensionMethods(name, receiverType)
                     .ToImmutableArray();
 
                 if (!extensionMethods.IsDefaultOrEmpty)
@@ -1753,7 +1755,7 @@ partial class BlockBinder : Binder
                 }
             }
 
-            var instanceMember = new SymbolQuery(name, receiver.Type, IsStatic: false)
+            var instanceMember = new SymbolQuery(name, receiverType, IsStatic: false)
                 .Lookup(this)
                 .FirstOrDefault();
 
@@ -2974,9 +2976,11 @@ partial class BlockBinder : Binder
             case MemberBindingExpressionSyntax memberBinding:
                 {
                     var name = memberBinding.Name.Identifier.Text;
-                    var member = receiver.Type is null
+                    var receiverType = receiver.Type.UnwrapLiteralType() ?? receiver.Type;
+
+                    var member = receiverType is null
                         ? null
-                        : new SymbolQuery(name, receiver.Type, IsStatic: false).Lookup(this).FirstOrDefault();
+                        : new SymbolQuery(name, receiverType, IsStatic: false).Lookup(this).FirstOrDefault();
 
                     if (member is null)
                     {
@@ -3002,9 +3006,11 @@ partial class BlockBinder : Binder
                     var name = memberBinding.Name.Identifier.Text;
                     var boundArguments = invocation.ArgumentList.Arguments.Select(a => BindExpression(a.Expression)).ToArray();
 
-                    var candidates = receiver.Type is null
+                    var receiverType = receiver.Type.UnwrapLiteralType() ?? receiver.Type;
+
+                    var candidates = receiverType is null
                         ? ImmutableArray<IMethodSymbol>.Empty
-                        : new SymbolQuery(name, receiver.Type, IsStatic: false).LookupMethods(this).ToImmutableArray();
+                        : new SymbolQuery(name, receiverType, IsStatic: false).LookupMethods(this).ToImmutableArray();
 
                     if (candidates.IsDefaultOrEmpty)
                     {

--- a/src/Raven.CodeAnalysis/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/SymbolExtensions.cs
@@ -1,5 +1,7 @@
 using System.IO.Pipelines;
 
+using Raven.CodeAnalysis.Symbols;
+
 namespace Raven.CodeAnalysis;
 
 public static partial class SymbolExtensions
@@ -68,4 +70,7 @@ public static partial class SymbolExtensions
 
         return symbol.Name; // fallback för andra symboltyper
     }
+
+    public static ITypeSymbol? UnwrapLiteralType(this ITypeSymbol? type)
+        => type is LiteralTypeSymbol literal ? literal.UnderlyingType : type;
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
@@ -171,12 +171,26 @@ internal class Lexer : ILexer
                         // Decimal point
                         if (PeekChar(out ch) && ch == '.')
                         {
-                            hasDecimal = true;
-                            ReadChar(); _stringBuilder.Append('.');
-                            while (PeekChar(out ch) && (char.IsDigit(ch) || ch == '_'))
+                            var decimalCheckpoint = _currentPosition;
+                            _textSource.PushPosition();
+                            ReadChar();
+
+                            if (PeekChar(out ch) && char.IsDigit(ch))
                             {
-                                ReadChar();
-                                _stringBuilder.Append(ch);
+                                _textSource.PopPosition();
+                                hasDecimal = true;
+                                _stringBuilder.Append('.');
+                                do
+                                {
+                                    ReadChar();
+                                    _stringBuilder.Append(ch);
+                                }
+                                while (PeekChar(out ch) && (char.IsDigit(ch) || ch == '_'));
+                            }
+                            else
+                            {
+                                _textSource.PopAndRestorePosition();
+                                _currentPosition = decimalCheckpoint;
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- ensure binder unwraps literal receiver types when resolving instance members and extension methods
- update the lexer to keep the member-access dot after numeric literals when no fractional digits follow
- add semantic tests covering literal expression member access and helper assertions for System.Int32

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter MemberAccess_OnLiteralExpression_MethodLookup_ResolvesToString
- dotnet test test/Raven.CodeAnalysis.Tests --filter MemberAccess_OnLiteralExpression_UsesUnderlyingMembers
- dotnet test test/Raven.CodeAnalysis.Tests --filter Int32_ProvidesToString

------
https://chatgpt.com/codex/tasks/task_e_68d68cad6cf4832fa32f1b81a8909ccc