### PR TITLE
Leverage ITypeSymbol interfaces during constraint checks

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -810,26 +810,30 @@ internal abstract class Binder
 
     private bool SatisfiesNamedTypeConstraint(ITypeSymbol typeArgument, INamedTypeSymbol constraintType)
     {
-        if (typeArgument is INamedTypeSymbol namedArgument)
+        if (SymbolEqualityComparer.Default.Equals(typeArgument, constraintType))
+            return true;
+
+        if (constraintType.TypeKind == TypeKind.Interface)
         {
-            if (SymbolEqualityComparer.Default.Equals(namedArgument, constraintType))
-                return true;
-
-            if (constraintType.TypeKind == TypeKind.Interface)
+            if (typeArgument is INamedTypeSymbol namedArgument &&
+                namedArgument.TypeKind == TypeKind.Interface &&
+                SymbolEqualityComparer.Default.Equals(namedArgument, constraintType))
             {
-                if (namedArgument.TypeKind == TypeKind.Interface && SymbolEqualityComparer.Default.Equals(namedArgument, constraintType))
-                    return true;
-
-                foreach (var implemented in namedArgument.AllInterfaces)
-                {
-                    if (SymbolEqualityComparer.Default.Equals(implemented, constraintType))
-                        return true;
-                }
-
-                return false;
+                return true;
             }
 
-            for (var current = namedArgument; current is not null; current = current.BaseType)
+            foreach (var implemented in typeArgument.AllInterfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(implemented, constraintType))
+                    return true;
+            }
+
+            return false;
+        }
+
+        if (typeArgument is INamedTypeSymbol namedType)
+        {
+            for (var current = namedType; current is not null; current = current.BaseType)
             {
                 if (SymbolEqualityComparer.Default.Equals(current, constraintType))
                     return true;

--- a/src/Raven.CodeAnalysis/SemanticFacts.cs
+++ b/src/Raven.CodeAnalysis/SemanticFacts.cs
@@ -119,16 +119,7 @@ public static class SemanticFacts
         return false;
     }
 
-    private static IEnumerable<INamedTypeSymbol> GetAllInterfaces(ITypeSymbol type)
-    {
-        if (type is INamedTypeSymbol named)
-            return named.AllInterfaces;
-
-        if (type is ArrayTypeSymbol array)
-            return array.AllInterfaces;
-
-        return Array.Empty<INamedTypeSymbol>();
-    }
+    private static IEnumerable<INamedTypeSymbol> GetAllInterfaces(ITypeSymbol type) => type.AllInterfaces;
 
     private static HashSet<ISymbol> CreateVisitedSet(SymbolEqualityComparer comparer)
         => new(SymbolEqualityComparerAdapter.Get(comparer));

--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -120,6 +120,10 @@ internal sealed class AliasNamedTypeSymbol : AliasSymbol, INamedTypeSymbol
 
     public bool IsUnion => _type.IsUnion;
 
+    public ImmutableArray<INamedTypeSymbol> Interfaces => _type.Interfaces;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces => _type.AllInterfaces;
+
     public int Arity => _type.Arity;
 
     public ImmutableArray<IMethodSymbol> Constructors => _type.Constructors;
@@ -143,10 +147,6 @@ internal sealed class AliasNamedTypeSymbol : AliasSymbol, INamedTypeSymbol
     public bool IsGenericType => _type.IsGenericType;
 
     public bool IsUnboundGenericType => _type.IsUnboundGenericType;
-
-    public ImmutableArray<INamedTypeSymbol> Interfaces => _type.Interfaces;
-
-    public ImmutableArray<INamedTypeSymbol> AllInterfaces => _type.AllInterfaces;
 
     public ITypeSymbol Construct(params ITypeSymbol[] typeArguments) => _type.Construct(typeArguments);
 }
@@ -186,6 +186,10 @@ internal sealed class AliasUnionTypeSymbol : AliasSymbol, IUnionTypeSymbol
     public bool IsValueType => _type.IsValueType;
 
     public IEnumerable<ITypeSymbol> Types => _type.Types;
+
+    public ImmutableArray<INamedTypeSymbol> Interfaces => _type.Interfaces;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces => _type.AllInterfaces;
 }
 
 internal sealed class AliasLiteralTypeSymbol : AliasSymbol, ITypeSymbol
@@ -221,6 +225,10 @@ internal sealed class AliasLiteralTypeSymbol : AliasSymbol, ITypeSymbol
     public bool IsReferenceType => _type.IsReferenceType;
 
     public bool IsValueType => _type.IsValueType;
+
+    public ImmutableArray<INamedTypeSymbol> Interfaces => _type.Interfaces;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces => _type.AllInterfaces;
 }
 
 internal sealed class AliasMethodSymbol : AliasSymbol, IMethodSymbol

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ByRefTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ByRefTypeSymbol.cs
@@ -44,6 +44,10 @@ internal sealed class ByRefTypeSymbol : SourceSymbol, ITypeSymbol
     public override bool IsImplicitlyDeclared => true;
     public override bool IsStatic => false;
 
+    public ImmutableArray<INamedTypeSymbol> Interfaces => ElementType.Interfaces;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces => ElementType.AllInterfaces;
+
     public ImmutableArray<ISymbol> GetMembers() => ElementType.GetMembers();
     public ImmutableArray<ISymbol> GetMembers(string name) => ElementType.GetMembers(name);
     public IEnumerable<ISymbol> ResolveMembers(string name) => ElementType.ResolveMembers(name);

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs
@@ -31,6 +31,10 @@ internal sealed class NullableTypeSymbol : SourceSymbol, ITypeSymbol
 
     public ITypeSymbol? OriginalDefinition { get; }
 
+    public ImmutableArray<INamedTypeSymbol> Interfaces => UnderlyingType.Interfaces;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces => UnderlyingType.AllInterfaces;
+
     public ImmutableArray<ISymbol> GetMembers() => BaseType!.GetMembers();
 
     public ImmutableArray<ISymbol> GetMembers(string name) => BaseType!.GetMembers(name);

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/UnionTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/UnionTypeSymbol.cs
@@ -34,6 +34,12 @@ internal partial class UnionTypeSymbol : SourceSymbol, IUnionTypeSymbol
 
     public ITypeSymbol? OriginalDefinition { get; }
 
+    public ImmutableArray<INamedTypeSymbol> Interfaces =>
+        BaseType?.Interfaces ?? ImmutableArray<INamedTypeSymbol>.Empty;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces =>
+        BaseType?.AllInterfaces ?? ImmutableArray<INamedTypeSymbol>.Empty;
+
     public ImmutableArray<ISymbol> GetMembers()
     {
         return BaseType?.GetMembers() ?? ImmutableArray<ISymbol>.Empty;

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -340,6 +340,10 @@ public interface ITypeSymbol : INamespaceOrTypeSymbol
 
     TypeKind TypeKind { get; }
 
+    ImmutableArray<INamedTypeSymbol> Interfaces { get; }
+
+    ImmutableArray<INamedTypeSymbol> AllInterfaces { get; }
+
     public string ToFullyQualifiedMetadataName()
     {
         string typeName;
@@ -426,9 +430,6 @@ public interface INamedTypeSymbol : ITypeSymbol
     bool IsSealed { get; }
     bool IsGenericType { get; }
     bool IsUnboundGenericType { get; }
-
-    ImmutableArray<INamedTypeSymbol> Interfaces { get; }
-    ImmutableArray<INamedTypeSymbol> AllInterfaces { get; }
 
     ITypeSymbol Construct(params ITypeSymbol[] typeArguments);
 }

--- a/src/Raven.CodeAnalysis/Symbols/LiteralTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/LiteralTypeSymbol.cs
@@ -42,6 +42,10 @@ internal sealed class LiteralTypeSymbol : SourceSymbol, ITypeSymbol
 
     public bool IsReferenceType => UnderlyingType.IsReferenceType;
 
+    public ImmutableArray<INamedTypeSymbol> Interfaces => UnderlyingType.Interfaces;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces => UnderlyingType.AllInterfaces;
+
     public ImmutableArray<ISymbol> GetMembers() => UnderlyingType.GetMembers();
 
     public ImmutableArray<ISymbol> GetMembers(string name) => UnderlyingType.GetMembers(name);

--- a/src/Raven.CodeAnalysis/Symbols/NullTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/NullTypeSymbol.cs
@@ -27,6 +27,10 @@ internal sealed class NullTypeSymbol : SourceSymbol, ITypeSymbol
 
     public ITypeSymbol? OriginalDefinition => null;
 
+    public ImmutableArray<INamedTypeSymbol> Interfaces => BaseType?.Interfaces ?? ImmutableArray<INamedTypeSymbol>.Empty;
+
+    public ImmutableArray<INamedTypeSymbol> AllInterfaces => BaseType?.AllInterfaces ?? ImmutableArray<INamedTypeSymbol>.Empty;
+
     public ImmutableArray<ISymbol> GetMembers() => [];
 
     public ImmutableArray<ISymbol> GetMembers(string name) => [];


### PR DESCRIPTION
## Summary
- ensure interface constraints are validated through `ITypeSymbol.AllInterfaces` so every type kind contributes to satisfaction checks
- retain named-type base traversal for class constraints while relying on the new shared interface surface

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing MethodReferenceCodeGenTests and TerminalLogger crash)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a022a0ac832fbb2c62b2dd0a4c0e