### PR TITLE
feat: support attributes on type declarations

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/AttributeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/AttributeDeclarationParser.cs
@@ -1,0 +1,60 @@
+namespace Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+
+using System.Collections.Generic;
+
+using Raven.CodeAnalysis.Syntax.InternalSyntax;
+
+using static SyntaxFactory;
+
+internal static class AttributeDeclarationParser
+{
+    public static SyntaxList ParseAttributeLists(SyntaxParser parser)
+    {
+        if (!parser.PeekToken().IsKind(SyntaxKind.OpenBracketToken))
+            return SyntaxList.Empty;
+
+        var attributeLists = new List<GreenNode>();
+
+        while (parser.PeekToken().IsKind(SyntaxKind.OpenBracketToken))
+        {
+            attributeLists.Add(ParseAttributeList(parser));
+        }
+
+        return List(attributeLists);
+    }
+
+    private static AttributeListSyntax ParseAttributeList(SyntaxParser parser)
+    {
+        var openBracket = parser.ReadToken();
+
+        var attributes = new List<GreenNode>();
+        while (true)
+        {
+            attributes.Add(ParseAttribute(parser));
+
+            var separator = parser.PeekToken();
+            if (!separator.IsKind(SyntaxKind.CommaToken))
+                break;
+
+            parser.ReadToken();
+            attributes.Add(separator);
+        }
+
+        parser.ConsumeTokenOrMissing(SyntaxKind.CloseBracketToken, out var closeBracket);
+
+        return AttributeList(openBracket, List(attributes), closeBracket);
+    }
+
+    private static AttributeSyntax ParseAttribute(SyntaxParser parser)
+    {
+        var name = new NameSyntaxParser(parser).ParseName();
+
+        ArgumentListSyntax? argumentList = null;
+        if (parser.PeekToken().IsKind(SyntaxKind.OpenParenToken))
+        {
+            argumentList = new ExpressionSyntaxParser(parser).ParseArgumentListSyntax();
+        }
+
+        return Attribute(name, argumentList);
+    }
+}

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
@@ -13,6 +13,9 @@ internal class EnumDeclarationParser : SyntaxParser
 
     internal EnumDeclarationSyntax Parse()
     {
+        var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
+        var modifiers = ParseModifiers();
+
         var enumKeyword = ReadToken();
 
         SyntaxToken identifier;
@@ -52,7 +55,7 @@ internal class EnumDeclarationParser : SyntaxParser
 
         TryConsumeTerminator(out var terminatorToken);
 
-        return EnumDeclaration(SyntaxList.Empty, enumKeyword, identifier, openBraceToken, List(parameterList), closeBraceToken, terminatorToken);
+        return EnumDeclaration(attributeLists, modifiers, enumKeyword, identifier, openBraceToken, List(parameterList), closeBraceToken, terminatorToken);
     }
 
     private GreenNode ParseMember()
@@ -68,5 +71,36 @@ internal class EnumDeclarationParser : SyntaxParser
         }
 
         return EnumMemberDeclaration(SyntaxList.Empty, identifier, null);
+    }
+
+    private SyntaxList ParseModifiers()
+    {
+        SyntaxList modifiers = SyntaxList.Empty;
+
+        while (true)
+        {
+            var kind = PeekToken().Kind;
+
+            if (kind is SyntaxKind.PublicKeyword or
+                     SyntaxKind.PrivateKeyword or
+                     SyntaxKind.InternalKeyword or
+                     SyntaxKind.ProtectedKeyword or
+                     SyntaxKind.StaticKeyword or
+                     SyntaxKind.AbstractKeyword or
+                     SyntaxKind.SealedKeyword or
+                     SyntaxKind.PartialKeyword or
+                     SyntaxKind.VirtualKeyword or
+                     SyntaxKind.OpenKeyword or
+                     SyntaxKind.OverrideKeyword)
+            {
+                modifiers = modifiers.Add(ReadToken());
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return modifiers;
     }
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
@@ -127,24 +127,43 @@ internal class NamespaceDeclarationParser : SyntaxParser
             memberDeclarations.Add(namespaceDeclaration);
             order = MemberOrder.Members;
         }
-        else if (nextToken.IsKind(SyntaxKind.EnumKeyword))
-        {
-            var enumDeclaration = new EnumDeclarationParser(this).Parse();
-
-            memberDeclarations.Add(enumDeclaration);
-            order = MemberOrder.Members;
-        }
-        else if (nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword) || nextToken.IsKind(SyntaxKind.InterfaceKeyword) ||
+        else if (nextToken.IsKind(SyntaxKind.EnumKeyword) ||
+                 nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword) || nextToken.IsKind(SyntaxKind.InterfaceKeyword) ||
                  nextToken.IsKind(SyntaxKind.PublicKeyword) || nextToken.IsKind(SyntaxKind.PrivateKeyword) ||
                  nextToken.IsKind(SyntaxKind.InternalKeyword) || nextToken.IsKind(SyntaxKind.ProtectedKeyword) ||
                  nextToken.IsKind(SyntaxKind.StaticKeyword) || nextToken.IsKind(SyntaxKind.AbstractKeyword) ||
                  nextToken.IsKind(SyntaxKind.SealedKeyword) || nextToken.IsKind(SyntaxKind.OpenKeyword) ||
-                 nextToken.IsKind(SyntaxKind.PartialKeyword) || nextToken.IsKind(SyntaxKind.OverrideKeyword))
+                 nextToken.IsKind(SyntaxKind.PartialKeyword) || nextToken.IsKind(SyntaxKind.OverrideKeyword) ||
+                 nextToken.IsKind(SyntaxKind.OpenBracketToken))
         {
-            var typeDeclaration = new TypeDeclarationParser(this).Parse();
+            var typeKeywordKind = TypeDeclarationParser.PeekTypeKeyword(this);
 
-            memberDeclarations.Add(typeDeclaration);
-            order = MemberOrder.Members;
+            if (typeKeywordKind == SyntaxKind.EnumKeyword)
+            {
+                var enumDeclaration = new EnumDeclarationParser(this).Parse();
+
+                memberDeclarations.Add(enumDeclaration);
+                order = MemberOrder.Members;
+            }
+            else if (typeKeywordKind is SyntaxKind.ClassKeyword or SyntaxKind.InterfaceKeyword)
+            {
+                var typeDeclaration = new TypeDeclarationParser(this).Parse();
+
+                memberDeclarations.Add(typeDeclaration);
+                order = MemberOrder.Members;
+            }
+            else
+            {
+                var statement = new StatementSyntaxParser(this).ParseStatement();
+
+                if (statement is null)
+                    return;
+
+                var globalStatement = GlobalStatement(SyntaxList.Empty, statement);
+
+                memberDeclarations.Add(globalStatement);
+                order = MemberOrder.Members;
+            }
         }
         else
         {

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -91,6 +91,7 @@
     <Slot Name="SelfKeyword" Type="Token" />
   </Node>
   <Node Name="ClassDeclaration" Inherits="TypeDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Keyword" Type="Token" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
@@ -107,6 +108,7 @@
     <Slot Name="Types" Type="SeparatedList" ElementType="Type" />
   </Node>
   <Node Name="InterfaceDeclaration" Inherits="TypeDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Keyword" Type="Token" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
@@ -153,6 +155,7 @@
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BaseTypeDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsAbstract="true" />
     <Slot Name="Identifier" Type="Token" IsAbstract="true" />
     <Slot Name="OpenBraceToken" Type="Token" IsAbstract="true" />
     <Slot Name="CloseBraceToken" Type="Token" IsAbstract="true" />
@@ -478,6 +481,7 @@
     <Slot Name="Designation" Type="VariableDesignation" />
   </Node>
   <Node Name="EnumDeclaration" Inherits="BaseTypeDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="EnumKeyword" Type="Token" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
@@ -513,6 +517,15 @@
     <Slot Name="OpenParenToken" Type="Token" />
     <Slot Name="Arguments" Type="SeparatedList" ElementType="Argument" />
     <Slot Name="CloseParenToken" Type="Token" />
+  </Node>
+  <Node Name="AttributeList" Inherits="Node">
+    <Slot Name="OpenBracketToken" Type="Token" />
+    <Slot Name="Attributes" Type="SeparatedList" ElementType="Attribute" />
+    <Slot Name="CloseBracketToken" Type="Token" />
+  </Node>
+  <Node Name="Attribute" Inherits="Node">
+    <Slot Name="Name" Type="Name" />
+    <Slot Name="ArgumentList" Type="ArgumentList" IsNullable="true" />
   </Node>
   <Node Name="TypeArgument" Inherits="Node">
     <Slot Name="Type" Type="Type" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
@@ -112,4 +112,21 @@ public class ClassDeclarationParserTests : DiagnosticTestBase
 
         Assert.Empty(tree.GetDiagnostics());
     }
+
+    [Fact]
+    public void ClassDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        var source = "[Obsolete] class Widget {}";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var declaration = Assert.IsType<ClassDeclarationSyntax>(Assert.Single(root.Members));
+
+        var attributeList = Assert.Single(declaration.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Obsolete", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/EnumDeclarationParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/EnumDeclarationParserTests.cs
@@ -1,0 +1,25 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class EnumDeclarationParserTests
+{
+    [Fact]
+    public void EnumDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        var source = "[Flags] enum Colors { Red }";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var declaration = Assert.IsType<EnumDeclarationSyntax>(Assert.Single(root.Members));
+
+        var attributeList = Assert.Single(declaration.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Flags", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterfaceDeclarationParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterfaceDeclarationParserTests.cs
@@ -40,4 +40,21 @@ public class InterfaceDeclarationParserTests
 
         Assert.Empty(tree.GetDiagnostics());
     }
+
+    [Fact]
+    public void InterfaceDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        var source = "[Service] interface IService {}";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var declaration = Assert.IsType<InterfaceDeclarationSyntax>(Assert.Single(root.Members));
+
+        var attributeList = Assert.Single(declaration.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Service", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
 }


### PR DESCRIPTION
## Summary
- add attribute list support to the syntax model for classes, interfaces, and enums
- parse attribute lists via a shared parser and update namespace and compilation unit parsing to detect attribute-prefixed type declarations
- add new syntax tests covering attribute lists on type declarations

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: test host stack overflow in existing lambda analyzer path)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b0461b84832fbe9b8799c3be0877