### PR TITLE
Add documentation for lowering approaches

### DIFF
--- a/docs/compiler/design/lowering.md
+++ b/docs/compiler/design/lowering.md
@@ -1,0 +1,56 @@
+# Lowering
+
+Lowering converts high-level Raven syntax into simpler, semantically explicit constructs that the binder and emitter can analyze uniformly. This document captures the goals of the lowering pipeline, when it should be applied, and the options we have for implementing new lowerings.
+
+## Goals
+
+* Normalize the surface syntax so downstream stages see a consistent shape (for example, desugaring `if let`, pattern matching sugar, or implicit conversions).
+* Preserve source spans and diagnostic context whenever possible to keep error reporting precise.
+* Avoid losing semantic information that later phases depend on (e.g., definite assignment or flow analysis facts).
+* Keep the transformation composable so that feature-specific rewriters can be combined without observing each other's intermediate state.
+
+## When to add a lowering step
+
+Add a lowering pass when:
+
+* A feature is easier to specify in terms of existing language primitives.
+* Semantic analysis would otherwise have to special-case the surface syntax.
+* The emitter requires a canonical construct (e.g., loops rewritten into `while` forms).
+
+Prefer leaving syntax untouched when:
+
+* The feature introduces genuinely new semantics that require binder support.
+* The syntax tree must be preserved for tooling scenarios (source generators, analyzers) and no normalized form exists yet.
+
+## Approaches
+
+### Syntax-tree rewriting
+
+The simplest approach rewrites the bound tree using visitors. Each rewriter focuses on one feature—such as converting pattern-based `switch` statements into cascaded `if`/`else` checks—and produces a new tree that reuses existing bound nodes. This approach works well for:
+
+* One-to-one desugarings where the lowered structure is still expressible with current bound node types.
+* Maintaining direct mappings back to the original syntax nodes for diagnostics.
+
+### Intermediate representations
+
+For complex control-flow features, consider lowering into a dedicated intermediate representation (IR) before code generation. An IR can model constructs like exception regions, temporaries, or SSA form explicitly. In Raven, we reserve this approach for features that require:
+
+* Non-structured control flow (e.g., `goto`, iterator rewriting).
+* Aggressive optimization or analysis that is difficult on syntax-shaped trees.
+
+### Hybrid lowering
+
+Some features benefit from a staged pipeline. For example, we can first rewrite syntax into a minimal bound tree, then emit an IR for code generation. This keeps the binder simple while allowing the backend to perform targeted transformations.
+
+When building hybrid pipelines:
+
+1. Keep each stage pure—no mutation in place—to align with the compiler's immutability goals.
+2. Clearly document the invariants each stage guarantees (e.g., all `foreach` nodes eliminated).
+3. Make the transitions explicit in the diagnostics so future contributors know where to hook in.
+
+## Implementation tips
+
+* Place lowering visitors under `Raven.CodeAnalysis.Lowering` and favor small, composable classes over monolithic rewriters.
+* Cover new lowerings with unit tests that inspect both the lowered tree and emitted IL when relevant.
+* Update the language specification when lowering changes observable behavior (e.g., order of evaluation).
+* Keep diagnostic IDs stable—if a lowering introduces new error conditions, add them to `DiagnosticDescriptors.xml` instead of reusing existing IDs.

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -26,6 +26,8 @@
       href: design/parser.md
     - name: Semantic analysis
       href: design/semantic-analysis.md
+    - name: Lowering
+      href: design/lowering.md
     - name: Symbols
       href: design/symbols.md
     - name: Spans


### PR DESCRIPTION
## Summary
- add a design note describing lowering goals, triggers, and implementation tips
- document the available lowering strategies for Raven contributors
- link the new lowering page into the compiler design table of contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b79a5e28832fa7bb8c5cfbf36e3f