### PR TITLE
Add attribute parsing to namespace and global members

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
@@ -96,34 +96,56 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
                  nextToken.IsKind(SyntaxKind.OverrideKeyword) ||
                  nextToken.IsKind(SyntaxKind.OpenBracketToken))
         {
-            var typeKeywordKind = TypeDeclarationParser.PeekTypeKeyword(this);
+            var checkpoint = CreateCheckpoint();
+            var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
+            var modifiers = ParseModifiers();
+
+            var tokenAfterModifiers = PeekToken();
+
+            if (tokenAfterModifiers.IsKind(SyntaxKind.NamespaceKeyword))
+            {
+                checkpoint.Dispose();
+
+                var namespaceDeclaration = new NamespaceDeclarationParser(this).ParseNamespaceDeclaration();
+
+                memberDeclarations.Add(namespaceDeclaration);
+                order = MemberOrder.Members;
+                return;
+            }
+
+            var typeKeywordKind = tokenAfterModifiers.Kind;
 
             if (typeKeywordKind == SyntaxKind.EnumKeyword)
             {
+                checkpoint.Dispose();
+
                 var enumDeclaration = new EnumDeclarationParser(this).Parse();
 
                 memberDeclarations.Add(enumDeclaration);
                 order = MemberOrder.Members;
+                return;
             }
-            else if (typeKeywordKind is SyntaxKind.ClassKeyword or SyntaxKind.InterfaceKeyword)
+
+            if (typeKeywordKind is SyntaxKind.ClassKeyword or SyntaxKind.InterfaceKeyword or SyntaxKind.StructKeyword)
             {
+                checkpoint.Dispose();
+
                 var typeDeclaration = new TypeDeclarationParser(this).Parse();
 
                 memberDeclarations.Add(typeDeclaration);
                 order = MemberOrder.Members;
+                return;
             }
-            else
-            {
-                var statement = new StatementSyntaxParser(this).ParseStatement();
 
-                if (statement is null)
-                    return;
+            var statement = new StatementSyntaxParser(this).ParseStatement();
 
-                var globalStatement = GlobalStatement(SyntaxList.Empty, statement);
+            if (statement is null)
+                return;
 
-                memberDeclarations.Add(globalStatement);
-                order = MemberOrder.Members;
-            }
+            var globalStatement = GlobalStatement(attributeLists, modifiers, statement, Diagnostics);
+
+            memberDeclarations.Add(globalStatement);
+            order = MemberOrder.Members;
         }
         else
         {
@@ -134,10 +156,41 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
             if (statement is null)
                 return;
 
-            var globalStatement = GlobalStatement(SyntaxList.Empty, statement);
+            var globalStatement = GlobalStatement(SyntaxList.Empty, SyntaxList.Empty, statement, Diagnostics);
 
             memberDeclarations.Add(globalStatement);
             order = MemberOrder.Members;
         }
+    }
+
+    private SyntaxList ParseModifiers()
+    {
+        SyntaxList modifiers = SyntaxList.Empty;
+
+        while (true)
+        {
+            var kind = PeekToken().Kind;
+
+            if (kind is SyntaxKind.PublicKeyword or
+                     SyntaxKind.PrivateKeyword or
+                     SyntaxKind.InternalKeyword or
+                     SyntaxKind.ProtectedKeyword or
+                     SyntaxKind.StaticKeyword or
+                     SyntaxKind.AbstractKeyword or
+                     SyntaxKind.SealedKeyword or
+                     SyntaxKind.PartialKeyword or
+                     SyntaxKind.VirtualKeyword or
+                     SyntaxKind.OpenKeyword or
+                     SyntaxKind.OverrideKeyword)
+            {
+                modifiers = modifiers.Add(ReadToken());
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return modifiers;
     }
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
@@ -60,6 +60,8 @@ internal class EnumDeclarationParser : SyntaxParser
 
     private GreenNode ParseMember()
     {
+        var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
+
         SyntaxToken identifier;
         if (CanTokenBeIdentifier(PeekToken()))
         {
@@ -70,7 +72,7 @@ internal class EnumDeclarationParser : SyntaxParser
             identifier = ExpectToken(SyntaxKind.IdentifierToken);
         }
 
-        return EnumMemberDeclaration(SyntaxList.Empty, identifier, null);
+        return EnumMemberDeclaration(attributeLists, SyntaxList.Empty, identifier);
     }
 
     private SyntaxList ParseModifiers()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -11,6 +11,7 @@
     <Slot Name="CloseBraceToken" Type="Token" />
   </Node>
   <Node Name="FileScopedNamespaceDeclaration" Inherits="BaseNamespaceDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="NamespaceKeyword" Type="Token" />
     <Slot Name="Name" Type="Name" IsInherited="true" />
@@ -69,6 +70,7 @@
     <Slot Name="Expression" Type="Expression" />
   </Node>
   <Node Name="NamespaceDeclaration" Inherits="BaseNamespaceDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="NamespaceKeyword" Type="Token" />
     <Slot Name="Name" Type="Name" IsInherited="true" />
@@ -155,7 +157,6 @@
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BaseTypeDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
-    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsAbstract="true" />
     <Slot Name="Identifier" Type="Token" IsAbstract="true" />
     <Slot Name="OpenBraceToken" Type="Token" IsAbstract="true" />
     <Slot Name="CloseBraceToken" Type="Token" IsAbstract="true" />
@@ -192,6 +193,7 @@
     <Slot Name="TerminatorToken" Type="Token" IsAbstract="true" />
   </Node>
   <Node Name="ConstructorDeclaration" Inherits="BaseConstructorDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="InitKeyword" Type="Token" IsInherited="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsInherited="true" />
@@ -201,6 +203,7 @@
     <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
   <Node Name="NamedConstructorDeclaration" Inherits="BaseConstructorDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="InitKeyword" Type="Token" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" />
@@ -268,6 +271,8 @@
     <Slot Name="CloseBraceToken" Type="Token" />
   </Node>
   <Node Name="BaseNamespaceDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
+    <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Name" Type="Name" IsAbstract="true" />
     <Slot Name="Imports" Type="List" ElementType="ImportDirective" IsAbstract="true" />
     <Slot Name="Aliases" Type="List" ElementType="AliasDirective" IsAbstract="true" />
@@ -331,6 +336,7 @@
     <Slot Name="CloseBraceToken" Type="Token" />
   </Node>
   <Node Name="MemberDeclaration" Inherits="Node" IsAbstract="true">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsAbstract="true" />
     <Slot Name="Modifiers" Type="TokenList" IsAbstract="true" />
   </Node>
   <Node Name="ParenthesizedExpression" Inherits="Expression">
@@ -432,11 +438,14 @@
     <Slot Name="Expression" Type="Expression" />
   </Node>
   <Node Name="FieldDeclaration" Inherits="MemberDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Declaration" Type="VariableDeclaration" />
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BasePropertyDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
+    <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" IsAbstract="true" />
     <Slot Name="Identifier" Type="Token" IsAbstract="true" />
     <Slot Name="Type" Type="TypeAnnotationClause" IsAbstract="true" />
@@ -458,6 +467,7 @@
     <Slot Name="DefaultValue" Type="EqualsValueClause" IsNullable="true" />
   </Node>
   <Node Name="EnumMemberDeclaration" Inherits="MemberDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" />
     <Slot Name="EqualsValueClauseSyntax" Type="EqualsValueClause" IsNullable="true" />
@@ -491,6 +501,7 @@
     <Slot Name="TerminatorToken" Type="Token" IsInherited="true" />
   </Node>
   <Node Name="IndexerDeclaration" Inherits="BasePropertyDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
@@ -531,10 +542,12 @@
     <Slot Name="Type" Type="Type" />
   </Node>
   <Node Name="GlobalStatement" Inherits="MemberDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="Statement" Type="Statement" />
   </Node>
   <Node Name="PropertyDeclaration" Inherits="BasePropertyDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" IsInherited="true" />
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
@@ -588,6 +601,7 @@
     <Slot Name="Identifier" Type="Token" />
   </Node>
   <Node Name="MethodDeclaration" Inherits="BaseMethodDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="ExplicitInterfaceSpecifier" Type="ExplicitInterfaceSpecifier" IsNullable="true" />
     <Slot Name="Identifier" Type="Token" />
@@ -614,6 +628,7 @@
     <Slot Name="Initializer" Type="EqualsValueClause" IsNullable="true" />
   </Node>
   <Node Name="AccessorDeclaration" Inherits="Node" HasExplicitKind="true">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" />
     <Slot Name="Modifiers" Type="TokenList" />
     <Slot Name="Keyword" Type="Token" />
     <Slot Name="Body" Type="BlockStatement" IsNullable="true" />
@@ -621,6 +636,8 @@
     <Slot Name="TerminatorToken" Type="Token" />
   </Node>
   <Node Name="BaseMethodDeclaration" Inherits="MemberDeclaration" IsAbstract="true">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
+    <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
     <Slot Name="ParameterList" Type="ParameterList" IsAbstract="true" />
     <Slot Name="Body" Type="BlockStatement" IsNullable="true" IsAbstract="true" />
     <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" IsAbstract="true" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -215,7 +215,15 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
                 SyntaxFactory.CarriageReturnLineFeed,
                 SyntaxFactory.CarriageReturnLineFeed);
 
-        return node.Update(node.Modifiers, namespaceKeyword, name, terminatorToken, VisitList(node.Imports)!, VisitList(node.Aliases)!, VisitList(node.Members)!);
+        return node.Update(
+            node.AttributeLists,
+            node.Modifiers,
+            namespaceKeyword,
+            name,
+            terminatorToken,
+            VisitList(node.Imports)!,
+            VisitList(node.Aliases)!,
+            VisitList(node.Members)!);
     }
 
     public override SyntaxNode? VisitBinaryExpression(BinaryExpressionSyntax node)
@@ -263,7 +271,17 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
             returnType = (ArrowTypeClauseSyntax)VisitArrowTypeClause(node.ReturnType)!
                 .WithTrailingTrivia(SyntaxFactory.Space);
 
-        return node.Update(node.Modifiers, explicitInterfaceSpecifier, identifier, typeParameterList, parameterList, returnType, (BlockStatementSyntax?)VisitBlockStatement(node.Body), null, node.TerminatorToken)
+        return node.Update(
+                node.AttributeLists,
+                node.Modifiers,
+                explicitInterfaceSpecifier,
+                identifier,
+                typeParameterList,
+                parameterList,
+                returnType,
+                (BlockStatementSyntax?)VisitBlockStatement(node.Body),
+                null,
+                node.TerminatorToken)
             .WithLeadingTrivia(SyntaxFactory.TriviaList(
                 SyntaxFactory.CarriageReturnLineFeed,
                 SyntaxFactory.CarriageReturnLineFeed

--- a/test/Raven.CodeAnalysis.Tests/Syntax/AttributeParsingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/AttributeParsingTests.cs
@@ -1,0 +1,191 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+public class AttributeParsingTests : DiagnosticTestBase
+{
+    [Fact]
+    public void ConstructorDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            class Widget {
+                [Primary]
+                public init() {}
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var constructor = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<ConstructorDeclarationSyntax>()
+            .Single();
+
+        var attributeList = Assert.Single(constructor.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Primary", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void FieldDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            class Widget {
+                [Field]
+                let value: int = 0
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var field = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<FieldDeclarationSyntax>()
+            .Single();
+
+        var attributeList = Assert.Single(field.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Field", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void PropertyDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            class Widget {
+                [Data]
+                public Value: int { get => 0 }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var property = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single();
+
+        var attributeList = Assert.Single(property.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Data", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void IndexerDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            class Widget {
+                var data: int
+                [Indexed]
+                public self[index: int]: int { get => data }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var indexer = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<IndexerDeclarationSyntax>()
+            .Single();
+
+        var attributeList = Assert.Single(indexer.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Indexed", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void EnumMemberDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            enum Colors {
+                [Primary]
+                Red,
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var member = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<EnumMemberDeclarationSyntax>()
+            .Single();
+
+        var attributeList = Assert.Single(member.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Primary", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void GlobalStatement_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            [Entry]
+            let value: int = 0
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var global = Assert.IsType<GlobalStatementSyntax>(Assert.Single(tree.GetRoot().Members));
+
+        var attributeList = Assert.Single(global.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Entry", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void NamespaceDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            [MyNamespace]
+            namespace Samples {
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var declaration = Assert.IsType<NamespaceDeclarationSyntax>(Assert.Single(tree.GetRoot().Members));
+
+        var attributeList = Assert.Single(declaration.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("MyNamespace", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+
+    [Fact]
+    public void FileScopedNamespaceDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        const string code = """
+            [MyNamespace]
+            namespace Samples;
+            let value: int = 0
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var declaration = Assert.IsType<FileScopedNamespaceDeclarationSyntax>(Assert.Single(tree.GetRoot().Members));
+
+        var attributeList = Assert.Single(declaration.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("MyNamespace", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/ClassDeclarationParserTests.cs
@@ -129,4 +129,25 @@ public class ClassDeclarationParserTests : DiagnosticTestBase
         Assert.Equal("Obsolete", name.Identifier.Text);
         Assert.Empty(tree.GetDiagnostics());
     }
+
+    [Fact]
+    public void MethodDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        var source = """
+            class Widget {
+                [Inline]
+                public Do() -> unit {}
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(source);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+
+        var attributeList = Assert.Single(method.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Inline", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/PropertyDeclarationSyntaxTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/PropertyDeclarationSyntaxTest.cs
@@ -50,4 +50,31 @@ public class PropertyDeclarationSyntaxTest : DiagnosticTestBase
         Assert.Equal("Value", explicitInterface!.Identifier.Text);
         Assert.Equal("IFoo", explicitInterface.Name.ToString());
     }
+
+    [Fact]
+    public void AccessorDeclaration_WithAttributeList_ParsesAttributes()
+    {
+        string testCode =
+            """
+            class Foo {
+                public Value: int {
+                    [Getter]
+                    get => 0
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.ParseText(testCode);
+        var accessor = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<AccessorDeclarationSyntax>()
+            .Single(a => a.Kind == SyntaxKind.GetAccessorDeclaration);
+
+        var attributeList = Assert.Single(accessor.AttributeLists);
+        var attribute = Assert.Single(attributeList.Attributes);
+
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("Getter", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
 }


### PR DESCRIPTION
## Summary
- parse attribute lists and modifiers when walking compilation-unit and namespace members so global statements and nested declarations preserve annotations
- capture attribute lists and modifiers on block and file-scoped namespaces to expose them through the syntax model
- add parser coverage for attributes on constructors, fields, properties, indexers, enum members, global statements, and namespace declarations

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests

------
https://chatgpt.com/codex/tasks/task_e_68d6b6631414832f8d26adcbe0357975