### PR TITLE
Support assembly attribute syntax

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/CompilationUnitSyntax.cs
+++ b/src/Raven.CodeAnalysis/Syntax/CompilationUnitSyntax.cs
@@ -2,8 +2,14 @@ namespace Raven.CodeAnalysis.Syntax;
 
 public partial class CompilationUnitSyntax : SyntaxNode
 {
-    public CompilationUnitSyntax(SyntaxTree syntaxTree, SyntaxList<ImportDirectiveSyntax> imports, SyntaxList<AliasDirectiveSyntax> aliases, SyntaxList<MemberDeclarationSyntax> members, SyntaxToken endOfFileToken)
-        : base(new InternalSyntax.CompilationUnitSyntax(imports.Green, aliases.Green, members.Green, endOfFileToken.Green), syntaxTree)
+    public CompilationUnitSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxList<AttributeListSyntax> attributeLists,
+        SyntaxList<ImportDirectiveSyntax> imports,
+        SyntaxList<AliasDirectiveSyntax> aliases,
+        SyntaxList<MemberDeclarationSyntax> members,
+        SyntaxToken endOfFileToken)
+        : base(new InternalSyntax.CompilationUnitSyntax(attributeLists.Green, imports.Green, aliases.Green, members.Green, endOfFileToken.Green), syntaxTree)
     {
     }
 

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -253,6 +253,7 @@
     <Slot Name="Block" Type="BlockStatement" />
   </Node>
   <Node Name="CompilationUnit" Inherits="Node">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" />
     <Slot Name="Imports" Type="List" ElementType="ImportDirective" />
     <Slot Name="Aliases" Type="List" ElementType="AliasDirective" />
     <Slot Name="Members" Type="List" ElementType="MemberDeclaration" />
@@ -541,12 +542,17 @@
   </Node>
   <Node Name="AttributeList" Inherits="Node">
     <Slot Name="OpenBracketToken" Type="Token" />
+    <Slot Name="Target" Type="AttributeTargetSpecifier" IsNullable="true" />
     <Slot Name="Attributes" Type="SeparatedList" ElementType="Attribute" />
     <Slot Name="CloseBracketToken" Type="Token" />
   </Node>
   <Node Name="Attribute" Inherits="Node">
     <Slot Name="Name" Type="Name" />
     <Slot Name="ArgumentList" Type="ArgumentList" IsNullable="true" />
+  </Node>
+  <Node Name="AttributeTargetSpecifier" Inherits="Node">
+    <Slot Name="Identifier" Type="Token" />
+    <Slot Name="ColonToken" Type="Token" />
   </Node>
   <Node Name="TypeArgument" Inherits="Node">
     <Slot Name="Type" Type="Type" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/AttributeParsingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/AttributeParsingTests.cs
@@ -188,4 +188,25 @@ public class AttributeParsingTests : DiagnosticTestBase
         Assert.Equal("MyNamespace", name.Identifier.Text);
         Assert.Empty(tree.GetDiagnostics());
     }
+
+    [Fact]
+    public void CompilationUnit_WithAssemblyAttribute_ParsesTarget()
+    {
+        const string code = """
+            [assembly: MyAttr]
+            import System
+            """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+
+        var attributeList = Assert.Single(root.AttributeLists);
+        Assert.NotNull(attributeList.Target);
+        Assert.Equal("assembly", attributeList.Target!.Identifier.Text);
+
+        var attribute = Assert.Single(attributeList.Attributes);
+        var name = Assert.IsType<IdentifierNameSyntax>(attribute.Name);
+        Assert.Equal("MyAttr", name.Identifier.Text);
+        Assert.Empty(tree.GetDiagnostics());
+    }
 }


### PR DESCRIPTION
## Summary
- add attribute target specifiers and compilation unit attribute storage to the syntax model
- teach the parser to capture `[assembly: ...]` attribute lists ahead of imports and recognize attribute targets
- verify the new assembly attribute parsing behavior with a syntax test

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter AttributeParsingTests

------
https://chatgpt.com/codex/tasks/task_e_68d6cd5a5efc832f8cb9dcad6b6892db