### PR TITLE
feat: bind parameter and return attributes

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/MethodBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBinder.cs
@@ -42,6 +42,15 @@ class MethodBinder : TypeMemberBinder
             or AccessorDeclarationSyntax)
             return _methodSymbol;
 
+        if (node is ParameterSyntax parameter)
+        {
+            return _methodSymbol.Parameters.FirstOrDefault(p =>
+                p.DeclaringSyntaxReferences.Any(r => r.GetSyntax() == parameter));
+        }
+
+        if (node is ArrowTypeClauseSyntax)
+            return _methodSymbol;
+
         return base.BindDeclaredSymbol(node);
     }
 

--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -281,6 +281,8 @@ internal sealed class AliasMethodSymbol : AliasSymbol, IMethodSymbol
 
     public IMethodSymbol? ConstructedFrom => _method.ConstructedFrom;
 
+    public ImmutableArray<AttributeData> GetReturnTypeAttributes() => _method.GetReturnTypeAttributes();
+
     public IMethodSymbol Construct(params ITypeSymbol[] typeArguments) => _method.Construct(typeArguments);
 }
 

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -55,6 +55,8 @@ internal sealed class ConstructedMethodSymbol : IMethodSymbol
 
     public bool IsConstructor => _definition.IsConstructor;
     public bool IsNamedConstructor => _definition.IsNamedConstructor;
+
+    public ImmutableArray<AttributeData> GetReturnTypeAttributes() => _definition.GetReturnTypeAttributes();
     public override bool Equals(object? obj) => _definition.Equals(obj);
     public override int GetHashCode() => _definition.GetHashCode();
 

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
@@ -164,6 +164,8 @@ internal sealed class SubstitutedMethodSymbol : IMethodSymbol
 
     public ISymbol ContainingSymbol => _constructed;
 
+    public ImmutableArray<AttributeData> GetReturnTypeAttributes() => _original.GetReturnTypeAttributes();
+
     public MethodKind MethodKind => _original.MethodKind;
     public bool IsConstructor => _original.IsConstructor;
     public IMethodSymbol? OriginalDefinition => _original;

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -250,6 +250,7 @@ public interface IMethodSymbol : ISymbol
     MethodKind MethodKind { get; }
     ITypeSymbol ReturnType { get; }
     ImmutableArray<IParameterSymbol> Parameters { get; }
+    ImmutableArray<AttributeData> GetReturnTypeAttributes();
     bool IsConstructor => MethodKind is MethodKind.Constructor;
     bool IsNamedConstructor => false;
     IMethodSymbol? OriginalDefinition { get; }

--- a/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
@@ -136,6 +136,8 @@ internal partial class PEMethodSymbol : PESymbol, IMethodSymbol
         }
     }
 
+    public ImmutableArray<AttributeData> GetReturnTypeAttributes() => ImmutableArray<AttributeData>.Empty;
+
     public override Accessibility DeclaredAccessibility => _accessibility ??= MapAccessibility(_methodInfo);
 
     public override bool IsStatic => _methodInfo.IsStatic;

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
@@ -60,6 +60,8 @@ internal sealed partial class SourceLambdaSymbol : SourceSymbol, ILambdaSymbol
 
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<IMethodSymbol>.Empty;
 
+    public ImmutableArray<AttributeData> GetReturnTypeAttributes() => ImmutableArray<AttributeData>.Empty;
+
     public void SetReturnType(ITypeSymbol returnType)
     {
         ReturnType = returnType;

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceSymbol.cs
@@ -67,7 +67,7 @@ internal abstract class SourceSymbol : Symbol
         return builder.ToImmutable();
     }
 
-    private Compilation? GetDeclaringCompilation()
+    protected Compilation? GetDeclaringCompilation()
     {
         if (this is SourceAssemblySymbol assemblySymbol)
             return assemblySymbol.Compilation;
@@ -91,6 +91,8 @@ internal abstract class SourceSymbol : Symbol
             AccessorDeclarationSyntax accessorDeclaration => accessorDeclaration.AttributeLists,
             FieldDeclarationSyntax fieldDeclaration => fieldDeclaration.AttributeLists,
             VariableDeclaratorSyntax variableDeclarator when variableDeclarator.Parent?.Parent is FieldDeclarationSyntax field => field.AttributeLists,
+            ParameterSyntax parameter => parameter.AttributeLists,
+            ArrowTypeClauseSyntax arrowTypeClause => arrowTypeClause.AttributeLists,
             _ => default
         };
 }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -322,6 +322,7 @@ internal class ExpressionSyntaxParser : SyntaxParser
 
         var returnParameterAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseReturnTypeAnnotation()
             ?? ArrowTypeClause(
+                SyntaxList.Empty,
                 MissingToken(SyntaxKind.ArrowToken),
                 IdentifierName(MissingToken(SyntaxKind.IdentifierToken)));
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -320,6 +320,8 @@ internal class StatementSyntaxParser : SyntaxParser
             if (t.IsKind(SyntaxKind.CloseParenToken))
                 break;
 
+            var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
+
             SyntaxList modifiers = SyntaxList.Empty;
 
             SyntaxToken modifier;
@@ -346,7 +348,7 @@ internal class StatementSyntaxParser : SyntaxParser
                 defaultValue = new EqualsValueClauseSyntaxParser(this).Parse();
             }
 
-            parameterList.Add(Parameter(modifiers, name, typeAnnotation, defaultValue));
+            parameterList.Add(Parameter(attributeLists, modifiers, name, typeAnnotation, defaultValue));
 
             var commaToken = PeekToken();
             if (commaToken.IsKind(SyntaxKind.CommaToken))

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeAnnotationSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeAnnotationSyntaxParser.cs
@@ -22,9 +22,11 @@ internal class TypeAnnotationClauseSyntaxParser : SyntaxParser
     {
         if (ConsumeToken(SyntaxKind.ArrowToken, out var arrowToken))
         {
+            var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
+
             TypeSyntax type = new NameSyntaxParser(this).ParseTypeName();
 
-            return SyntaxFactory.ArrowTypeClause(arrowToken, type);
+            return SyntaxFactory.ArrowTypeClause(attributeLists, arrowToken, type);
         }
 
         return null;

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -580,7 +580,6 @@ internal class TypeDeclarationParser : SyntaxParser
             if (t.IsKind(SyntaxKind.CloseBraceToken))
                 break;
 
-            var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
             SyntaxList modifiers = SyntaxList.Empty;
 
             SyntaxToken modifier;
@@ -654,6 +653,8 @@ internal class TypeDeclarationParser : SyntaxParser
             if (t.IsKind(SyntaxKind.CloseParenToken))
                 break;
 
+            var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
+
             SyntaxList modifiers = SyntaxList.Empty;
 
             SyntaxToken modifier;
@@ -680,7 +681,7 @@ internal class TypeDeclarationParser : SyntaxParser
                 defaultValue = new EqualsValueClauseSyntaxParser(this).Parse();
             }
 
-            parameterList.Add(Parameter(modifiers, name, typeAnnotation, defaultValue));
+            parameterList.Add(Parameter(attributeLists, modifiers, name, typeAnnotation, defaultValue));
 
             var commaToken = PeekToken();
             if (commaToken.IsKind(SyntaxKind.CommaToken))

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -86,6 +86,7 @@
     <Slot Name="Expression" Type="Expression" />
   </Node>
   <Node Name="ArrowTypeClause" Inherits="Node">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" />
     <Slot Name="ArrowToken" Type="Token" />
     <Slot Name="Type" Type="Type" />
   </Node>
@@ -480,6 +481,7 @@
     <Slot Name="ExpressionBody" Type="Expression" IsAbstract="true" />
   </Node>
   <Node Name="Parameter" Inherits="Node">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" />
     <Slot Name="Modifiers" Type="TokenList" />
     <Slot Name="Identifier" Type="Token" />
     <Slot Name="TypeAnnotation" Type="TypeAnnotationClause" IsNullable="true" />

--- a/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/SyntaxNormalizer.cs
@@ -327,7 +327,7 @@ public sealed class SyntaxNormalizer : SyntaxRewriter
             ? (EqualsValueClauseSyntax?)VisitEqualsValueClause(node.DefaultValue)
             : null;
 
-        return node.Update(node.Modifiers, identifier, typeAnnotation, defaultValue);
+        return node.Update(node.AttributeLists, node.Modifiers, identifier, typeAnnotation, defaultValue);
     }
 
     public override SyntaxNode? VisitTypeAnnotationClause(TypeAnnotationClauseSyntax node)

--- a/test/Raven.CodeAnalysis.Tests/Syntax/SeparatedListSyntaxTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/SeparatedListSyntaxTest.cs
@@ -16,7 +16,7 @@ public class SeparatedListSyntaxTest(ITestOutputHelper testOutputHelper)
     public void Create_WithOneNode()
     {
         var separatedSyntaxList = SeparatedList<ParameterSyntax>([
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
+            SyntaxFactory.Parameter(EmptyList<AttributeListSyntax>(), SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
         ]);
 
         separatedSyntaxList.Count.ShouldBe(1);
@@ -28,7 +28,7 @@ public class SeparatedListSyntaxTest(ITestOutputHelper testOutputHelper)
     public void Create_WithOneNodeAndOneSeparator()
     {
         var separatedSyntaxList = SeparatedList<ParameterSyntax>([
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
+            SyntaxFactory.Parameter(EmptyList<AttributeListSyntax>(), SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
             CommaToken
         ]);
 
@@ -41,9 +41,9 @@ public class SeparatedListSyntaxTest(ITestOutputHelper testOutputHelper)
     public void Create_WithTwoNodesAndOneSeparator()
     {
         var separatedSyntaxList = SeparatedList<ParameterSyntax>([
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
+            SyntaxFactory.Parameter(EmptyList<AttributeListSyntax>(), SyntaxTokenList.Empty, IdentifierToken("a"), null, null),
             CommaToken,
-            SyntaxFactory.Parameter(SyntaxTokenList.Empty, IdentifierToken("b"), null, null)
+            SyntaxFactory.Parameter(EmptyList<AttributeListSyntax>(), SyntaxTokenList.Empty, IdentifierToken("b"), null, null)
         ]);
 
         separatedSyntaxList.Count.ShouldBe(2);


### PR DESCRIPTION
## Summary
- teach the binder and attribute pipeline to recognize parameter attribute lists and identify return arrow clauses as belonging to the containing method
- expose `GetReturnTypeAttributes()` on method symbols, compute return attributes for source methods, and propagate the API through alias/constructed/metadata implementations

## Testing
- dotnet build src/Raven.CodeAnalysis/Raven.CodeAnalysis.csproj *(fails: generator project cannot find emitted syntax types yet; numerous CS0246 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f0347128832f96857c8d1bb90ba6