### PR TITLE
Implement break and continue code generation

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -104,6 +104,8 @@ BracketedParameterList   ::= '[' ParameterList? ']' ;
 
 Statement                ::= LocalDeclaration
                            | ReturnStatement
+                           | BreakStatement
+                           | ContinueStatement
                            | FunctionStatement
                            | IfStatement
                            | WhileStatement
@@ -115,6 +117,10 @@ LocalVariableDeclarators ::= LocalVariableDeclarator {',' LocalVariableDeclarato
 LocalVariableDeclarator  ::= Identifier (':' Type)? '=' Expression ;
 
 ReturnStatement          ::= 'return' Expression? ;
+
+BreakStatement           ::= 'break' ;
+
+ContinueStatement        ::= 'continue' ;
 
 FunctionStatement        ::= 'func' Identifier '(' ParameterList? ')' ReturnTypeClause? Block ;
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -238,6 +238,39 @@ func log(msg: string) {
 }
 ```
 
+### `break` statements
+
+`break` exits the innermost enclosing loop statement immediately. Execution resumes at the statement following that loop.
+
+```raven
+var i = 0
+while true {
+    if i == 10 {
+        break
+    }
+
+    i += 1
+}
+```
+
+A `break` statement must appear within a `while` or `for` *statement*. Placing `break` in any expression context, including the bodies of `if`, `while`, or `for` expressions, produces diagnostic `RAV1902`. Using `break` outside a loop reports diagnostic `RAV2600`.
+
+### `continue` statements
+
+`continue` skips the remainder of the current loop iteration and jumps to the loop's re-check point.
+
+```raven
+for each value in values {
+    if value.isOdd {
+        continue
+    }
+
+    print(value)
+}
+```
+
+`continue` follows the same placement rules as `break`: it may only appear inside `while` or `for` statements. Using it from an expression context results in diagnostic `RAV1903`, and placing it outside a loop reports diagnostic `RAV2601`.
+
 ### Labeled statements
 
 A **labeled statement** prefixes another statement with an identifier followed by a colon:

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs
@@ -10,6 +10,10 @@ class Scope : Generator
 {
     private readonly IDictionary<ISymbol, LocalBuilder> _localBuilders = new Dictionary<ISymbol, LocalBuilder>(SymbolEqualityComparer.Default);
     private readonly ImmutableArray<ILocalSymbol> _localsToDispose;
+    private bool _hasBreakLabel;
+    private Label _breakLabel;
+    private bool _hasContinueLabel;
+    private Label _continueLabel;
 
     public Scope(Generator parent) : this(parent, ImmutableArray<ILocalSymbol>.Empty)
     {
@@ -47,4 +51,38 @@ class Scope : Generator
     }
 
     public ImmutableArray<ILocalSymbol> LocalsToDispose => _localsToDispose;
+
+    public bool IsLoopScope => _hasBreakLabel || _hasContinueLabel;
+
+    public void SetLoopTargets(Label breakLabel, Label continueLabel)
+    {
+        _breakLabel = breakLabel;
+        _continueLabel = continueLabel;
+        _hasBreakLabel = true;
+        _hasContinueLabel = true;
+    }
+
+    public bool TryGetBreakLabel(out Label label)
+    {
+        if (_hasBreakLabel)
+        {
+            label = _breakLabel;
+            return true;
+        }
+
+        label = default;
+        return false;
+    }
+
+    public bool TryGetContinueLabel(out Label label)
+    {
+        if (_hasContinueLabel)
+        {
+            label = _continueLabel;
+            return true;
+        }
+
+        label = default;
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary
- track break and continue targets on loop scopes so statements can find the appropriate labels
- extend statement generation to dispose locals and branch for bound break/continue statements
- mark continue labels in for/while loops so continue statements land at the correct re-check points

## Testing
- dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/Generators/ScopeGenerator.cs,src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
- dotnet build *(fails: BoundNodePartialGenerator ArgumentNullException in upstream generator)*
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: BoundNodePartialGenerator ArgumentNullException in upstream generator)*

------
https://chatgpt.com/codex/tasks/task_e_68d7035550e0832fbd12b107b6dfb901