### PR TITLE
Emit custom attributes during code generation

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -139,6 +139,8 @@ internal class MethodGenerator
         if (nullableReturnAttr is not null)
             returnParamBuilder.SetCustomAttribute(nullableReturnAttr);
 
+        TypeGenerator.CodeGen.ApplyCustomAttributes(MethodSymbol.GetReturnTypeAttributes(), attribute => returnParamBuilder.SetCustomAttribute(attribute));
+
         int i = 1;
 
         if (_lambdaClosure is not null)
@@ -176,9 +178,20 @@ internal class MethodGenerator
             if (nullableAttr is not null)
                 parameterBuilder.SetCustomAttribute(nullableAttr);
 
+            TypeGenerator.CodeGen.ApplyCustomAttributes(parameterSymbol.GetAttributes(), attribute => parameterBuilder.SetCustomAttribute(attribute));
+
             _parameterBuilders[parameterSymbol] = parameterBuilder;
             i++;
         }
+
+        Action<CustomAttributeBuilder> applyMethodAttribute = MethodBase switch
+        {
+            MethodBuilder methodBuilder => methodBuilder.SetCustomAttribute,
+            ConstructorBuilder constructorBuilder => constructorBuilder.SetCustomAttribute,
+            _ => throw new InvalidOperationException("Unexpected method base type for attribute emission.")
+        };
+
+        TypeGenerator.CodeGen.ApplyCustomAttributes(MethodSymbol.GetAttributes(), applyMethodAttribute);
 
         if (TypeGenerator.CodeGen.Compilation.IsEntryPointCandidate(MethodSymbol))
         {

--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -47,6 +47,7 @@ internal class TypeGenerator
                     accessibilityAttributes | TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AutoClass | TypeAttributes.AnsiClass,
                     ResolveClrType(named.BaseType));
                 DefineTypeGenericParameters(named);
+                CodeGen.ApplyCustomAttributes(TypeSymbol.GetAttributes(), attribute => TypeBuilder!.SetCustomAttribute(attribute));
                 return;
             }
 
@@ -81,6 +82,7 @@ internal class TypeGenerator
                 FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName
             );
 
+            CodeGen.ApplyCustomAttributes(TypeSymbol.GetAttributes(), attribute => TypeBuilder!.SetCustomAttribute(attribute));
             return;
         }
 
@@ -100,6 +102,7 @@ internal class TypeGenerator
                         TypeBuilder.AddInterfaceImplementation(ResolveClrType(iface));
                 }
 
+                CodeGen.ApplyCustomAttributes(TypeSymbol.GetAttributes(), attribute => TypeBuilder!.SetCustomAttribute(attribute));
                 return;
             }
 
@@ -120,6 +123,8 @@ internal class TypeGenerator
             foreach (var iface in nt2.Interfaces)
                 TypeBuilder.AddInterfaceImplementation(ResolveClrType(iface));
         }
+
+        CodeGen.ApplyCustomAttributes(TypeSymbol.GetAttributes(), attribute => TypeBuilder!.SetCustomAttribute(attribute));
     }
 
     private void DefineTypeGenericParameters(INamedTypeSymbol namedType)
@@ -198,6 +203,7 @@ internal class TypeGenerator
                 fieldBuilder.SetConstant(fieldSymbol.GetConstantValue());
 
                 CodeGen.AddMemberBuilder((SourceSymbol)fieldSymbol, fieldBuilder);
+                CodeGen.ApplyCustomAttributes(fieldSymbol.GetAttributes(), attribute => fieldBuilder.SetCustomAttribute(attribute));
             }
 
             return;
@@ -245,6 +251,7 @@ internal class TypeGenerator
                         var nullableAttr = CodeGen.CreateNullableAttribute(fieldSymbol.Type);
                         if (nullableAttr is not null)
                             fieldBuilder.SetCustomAttribute(nullableAttr);
+                        CodeGen.ApplyCustomAttributes(fieldSymbol.GetAttributes(), attribute => fieldBuilder.SetCustomAttribute(attribute));
                         _fieldBuilders[fieldSymbol] = fieldBuilder;
 
                         CodeGen.AddMemberBuilder((SourceSymbol)fieldSymbol, fieldBuilder);
@@ -313,6 +320,8 @@ internal class TypeGenerator
                         var nullableAttr = CodeGen.CreateNullableAttribute(propertySymbol.Type);
                         if (nullableAttr is not null)
                             propBuilder.SetCustomAttribute(nullableAttr);
+
+                        CodeGen.ApplyCustomAttributes(propertySymbol.GetAttributes(), attribute => propBuilder.SetCustomAttribute(attribute));
 
                         CodeGen.AddMemberBuilder((SourceSymbol)propertySymbol, propBuilder);
                         break;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/CustomAttributeEmissionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/CustomAttributeEmissionTests.cs
@@ -1,0 +1,78 @@
+using System.IO;
+using System.Reflection;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Tests;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class CustomAttributeEmissionTests
+{
+    [Fact]
+    public void CustomAttributes_AreEmitted()
+    {
+        const string source = """
+class InfoAttribute : System.Attribute
+{
+    public init(name: string, type: System.Type) {}
+}
+
+[Info(name: "Widget", type: typeof(int))]
+class Widget
+{
+    [Info(name: "Field", type: typeof(string))]
+    public var field: string
+
+    [Info(name: "Property", type: typeof(bool))]
+    public Value: string { get; set; }
+
+    [Info(name: "Method", type: typeof(double))]
+    public M([Info(name: "Parameter", type: typeof(long))] x: string) -> string
+    {
+        return x
+    }
+}
+""";
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("lib", [tree], new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(TestMetadataReferences.Default);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success);
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var widgetType = assembly.GetType("Widget", throwOnError: true)!;
+
+        var typeAttribute = Assert.Single(widgetType.GetCustomAttributesData(), a => a.AttributeType.Name == "InfoAttribute");
+        Assert.Equal("Widget", typeAttribute.ConstructorArguments[0].Value);
+        Assert.Equal(typeof(int), typeAttribute.ConstructorArguments[1].Value);
+
+        var field = widgetType.GetField("field", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var fieldAttribute = Assert.Single(field!.GetCustomAttributesData(), a => a.AttributeType.Name == "InfoAttribute");
+        Assert.Equal("Field", fieldAttribute.ConstructorArguments[0].Value);
+        Assert.Equal(typeof(string), fieldAttribute.ConstructorArguments[1].Value);
+
+        var property = widgetType.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(property);
+        var propertyAttribute = Assert.Single(property!.GetCustomAttributesData(), a => a.AttributeType.Name == "InfoAttribute");
+        Assert.Equal("Property", propertyAttribute.ConstructorArguments[0].Value);
+        Assert.Equal(typeof(bool), propertyAttribute.ConstructorArguments[1].Value);
+
+        var method = widgetType.GetMethod("M", BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(method);
+        var methodAttribute = Assert.Single(method!.GetCustomAttributesData(), a => a.AttributeType.Name == "InfoAttribute");
+        Assert.Equal("Method", methodAttribute.ConstructorArguments[0].Value);
+        Assert.Equal(typeof(double), methodAttribute.ConstructorArguments[1].Value);
+
+        var parameter = Assert.Single(method.GetParameters());
+        var parameterAttribute = Assert.Single(parameter.GetCustomAttributesData(), a => a.AttributeType.Name == "InfoAttribute");
+        Assert.Equal("Parameter", parameterAttribute.ConstructorArguments[0].Value);
+        Assert.Equal(typeof(long), parameterAttribute.ConstructorArguments[1].Value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a helper that turns `AttributeData` instances into `CustomAttributeBuilder`s for code generation
- apply source custom attributes to emitted types, members, and parameter metadata alongside nullable/union shims
- add a unit test that verifies user-defined attributes survive emission and can be read via reflection

## Testing
- `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs,src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs,src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs,test/Raven.CodeAnalysis.Tests/Semantics/CustomAttributeEmissionTests.cs`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: build stops on pre-existing CS8669 warnings in generated sources)*

------
https://chatgpt.com/codex/tasks/task_e_68d7127a3034832fac0423a7fbbdc357