### PR TITLE
docs: mention running generators before solution build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,11 @@ cd src/Raven.CodeAnalysis/Syntax
 dotnet run --project ../../../tools/NodeGenerator -- -f
 cd ../../..
 
+# Generate bound nodes and symbol visitors (run whenever BoundTree/ or Symbols/ inputs change).
+cd src/Raven.CodeAnalysis
+dotnet run --project ../../tools/BoundNodeGenerator -- -f
+cd ../..
+
 # Generate compiler diagnostics (run when DiagnosticDescriptors.xml changes).
 # As above, ensure this generator runs prior to `dotnet build` so the solution sees the latest outputs.
 cd src/Raven.CodeAnalysis


### PR DESCRIPTION
## Summary
- clarify that the generator projects must be run manually before building the full solution when working in Codex

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d79f75a97c832fb62df6e775bb63dd