### PR TITLE
Handle co- and contravariant interface conversions

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -937,10 +937,9 @@ public class Compilation
         }
 
         if (destination is INamedTypeSymbol destinationNamed &&
-            destinationNamed.TypeKind == TypeKind.Interface &&
-            source is INamedTypeSymbol sourceNamed)
+            destinationNamed.TypeKind == TypeKind.Interface)
         {
-            if (sourceNamed.AllInterfaces.Contains(destinationNamed, SymbolEqualityComparer.Default))
+            if (SemanticFacts.ImplementsInterface(source, destinationNamed, SymbolEqualityComparer.Default))
                 return true;
         }
 

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -428,6 +428,13 @@ public enum TypeParameterConstraintKind
     TypeConstraint = 1 << 2,
 }
 
+public enum VarianceKind
+{
+    None,
+    Out,
+    In
+}
+
 public interface INamedTypeSymbol : ITypeSymbol
 {
     int Arity { get; }
@@ -468,6 +475,8 @@ public interface ITypeParameterSymbol : ITypeSymbol
     TypeParameterConstraintKind ConstraintKind { get; }
 
     ImmutableArray<ITypeSymbol> ConstraintTypes { get; }
+
+    VarianceKind Variance { get; }
 }
 
 public interface ILocalSymbol : ISymbol

--- a/src/Raven.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
@@ -71,14 +71,13 @@ internal sealed partial class PETypeParameterSymbol : Symbol, ITypeParameterSymb
     //public bool HasReferenceTypeConstraint => (_type.GenericParameterAttributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
     //public bool HasValueTypeConstraint => (_type.GenericParameterAttributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
 
-    /*
     public VarianceKind Variance =>
         (_type.GenericParameterAttributes & GenericParameterAttributes.VarianceMask) switch
         {
             GenericParameterAttributes.Covariant => VarianceKind.Out,
             GenericParameterAttributes.Contravariant => VarianceKind.In,
             _ => VarianceKind.None
-        };*/
+        };
 
     /*
 public ImmutableArray<ITypeSymbol> ConstraintTypes =>

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -71,6 +71,8 @@ internal sealed class SourceTypeParameterSymbol : Symbol, ITypeParameterSymbol
     public ImmutableArray<ITypeSymbol> ConstraintTypes =>
         _constraintTypes.IsDefault ? ImmutableArray<ITypeSymbol>.Empty : _constraintTypes;
 
+    public VarianceKind Variance => VarianceKind.None;
+
     internal void SetConstraintTypes(ImmutableArray<ITypeSymbol> constraintTypes)
     {
         _constraintTypes = constraintTypes.IsDefault

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
@@ -190,6 +190,54 @@ class Foo : IDisposable {
     }
 
     [Fact]
+    public void ReferenceConversion_HandlesInterfaceCovariance()
+    {
+        var compilation = CreateCompilation();
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        var objectType = compilation.GetSpecialType(SpecialType.System_Object);
+
+        var listDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.Generic.List`1")!;
+        var listOfString = (INamedTypeSymbol)listDefinition.Construct(stringType);
+        var enumerableDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1")!;
+        var enumerableOfObject = (INamedTypeSymbol)enumerableDefinition.Construct(objectType);
+
+        var conversion = compilation.ClassifyConversion(listOfString, enumerableOfObject);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.True(conversion.IsReference);
+    }
+
+    [Fact]
+    public void ReferenceConversion_HandlesInterfaceContravariance()
+    {
+        var source = """
+import System.Collections.Generic
+
+class Comparer : IComparer<object>
+{
+    init() {}
+
+    Compare(x: object?, y: object?) -> int => 0
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        Assert.Empty(compilation.GetDiagnostics());
+        var model = compilation.GetSemanticModel(tree);
+        var comparerDeclaration = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+        var comparer = (INamedTypeSymbol)model.GetDeclaredSymbol(comparerDeclaration)!;
+        var comparerDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.Generic.IComparer`1")!;
+        var comparerOfString = (INamedTypeSymbol)comparerDefinition.Construct(compilation.GetSpecialType(SpecialType.System_String));
+
+        var conversion = compilation.ClassifyConversion(comparer, comparerOfString);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.True(conversion.IsReference);
+    }
+
+    [Fact]
     public void BoxingConversion_ValueTypeToObject_IsImplicit()
     {
         var compilation = CreateCompilation();


### PR DESCRIPTION
## Summary
- add a variance kind enum and expose it from type parameter symbols
- teach SemanticFacts and reference conversion classification to honor interface variance
- cover covariant and contravariant interface scenarios with new semantic and conversion tests

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: CodeGeneratorTests.Emit_WithMultipleValidMainMethods_FailsWithAmbiguousEntryPointDiagnostic, CodeGeneratorTests.Emit_ExplicitInterfaceImplementation_EmitsPrivateOverride)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b493c298832fa36f8c9bc837fe79