### PR TITLE
Update generator spec guidance for optional tokens

### DIFF
--- a/docs/compiler/architecture/generator-specification.md
+++ b/docs/compiler/architecture/generator-specification.md
@@ -214,7 +214,8 @@ control which parameters are elided:
 
 * `IsOptionalToken="true"` marks token slots whose minimal overload should create a missing token via
   `SyntaxFactory.Token(SyntaxKind.None)`. This keeps the factory convenient without forcing callers to supply placeholder
-  tokens.
+  tokens. Optional token slots should generally use `IsOptionalToken` instead of `IsNullable`, ensuring callers interact with
+  `SyntaxToken` (rather than `SyntaxToken?`) while the generator fills in the missing token automatically.
 * `DefaultToken="TokenName"` marks token slots whose minimal overload should call
   `SyntaxFactory.Token(SyntaxKind.TokenName)`. This covers punctuation and fixed keywords so consumers receive a syntactically
   valid tree by default.


### PR DESCRIPTION
## Summary
- clarify that optional token slots in Model.xml should use IsOptionalToken rather than IsNullable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b93b2d10832f9ba4c8ff98d3066d