### PR TITLE
Add root namespace option to compiler

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -91,7 +91,7 @@ partial class BlockBinder : Binder
                 return new SymbolInfo(entryPoint);
             }
         }
-        return new SymbolInfo(Compilation.SourceGlobalNamespace);
+        return new SymbolInfo(Compilation.SourceRootNamespace);
     }
 
     private BoundLocalDeclarationStatement BindLocalDeclaration(VariableDeclaratorSyntax variableDeclarator)

--- a/src/Raven.CodeAnalysis/Binder/FunctionBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/FunctionBinder.cs
@@ -31,7 +31,7 @@ class FunctionBinder : Binder
             return _methodSymbol;
 
         //ISymbol container = null; //this.ContainingSymbol;
-        var container = Compilation.SourceGlobalNamespace.LookupType("Program") as INamedTypeSymbol;
+        var container = Compilation.SourceRootNamespace.LookupType("Program") as INamedTypeSymbol;
         if (container is null)
             throw new InvalidOperationException("Synthesized Program type not found.");
 

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -294,7 +294,7 @@ public partial class SemanticModel
         }
         else
         {
-            targetNamespace = Compilation.SourceGlobalNamespace;
+            targetNamespace = Compilation.SourceRootNamespace;
             namespaceBinder = new NamespaceBinder(parentBinder, targetNamespace);
             parentBinder = namespaceBinder;
         }

--- a/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/InfoTypes/ProjectInfo.cs
@@ -25,6 +25,7 @@ public sealed class ProjectInfo
         TargetFramework = targetFramework;
         CompilationOptions = compilationOptions;
         AssemblyName = assemblyName;
+        DefaultNamespace = compilationOptions?.RootNamespace;
     }
 
     public ProjectAttributes Attributes { get; }

--- a/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
+++ b/src/Raven.CodeAnalysis/Workspaces/Persistence/ProjectFile.cs
@@ -41,6 +41,8 @@ internal static class ProjectFile
         if (project.CompilationOptions is { } opts)
         {
             projectElement.Add(new XAttribute("OutputKind", opts.OutputKind));
+            if (!string.IsNullOrEmpty(opts.RootNamespace))
+                projectElement.Add(new XAttribute("RootNamespace", opts.RootNamespace));
         }
 
         foreach (var projRef in project.ProjectReferences)
@@ -70,6 +72,10 @@ internal static class ProjectFile
             options = new CompilationOptions(kind);
         else
             options = new CompilationOptions(OutputKind.ConsoleApplication);
+
+        var rootNamespaceAttr = (string?)root.Attribute("RootNamespace");
+        if (!string.IsNullOrWhiteSpace(rootNamespaceAttr))
+            options = options.WithRootNamespace(rootNamespaceAttr);
         var tempSolutionId = SolutionId.CreateNew();
         var projectId = ProjectId.CreateNew(tempSolutionId);
         var projectDir = Path.GetDirectoryName(filePath)!;


### PR DESCRIPTION
## Summary
- add support for specifying a default root namespace via `CompilationOptions` and the `ravenc` CLI
- wire the compilation pipeline to honor the configured root namespace for synthesized program members and namespace creation
- persist the root namespace on project files and cover the new behavior with semantic tests

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Assignment_NullLiteral_To_NullableReference_PreservesConvertedType, CompletionServiceTests.GetCompletions_InImportDirective_ReturnsNamespacesAndTypesOnly, logger ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bac28d80832f9e9994d4aab39aa9