### PR TITLE
Fix recursion in Symbol.Equals to prevent stack overflow

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Symbol.cs
@@ -165,7 +165,7 @@ internal abstract class Symbol : ISymbol
             return false;
         }
 
-        return Equals((ISymbol)other);
+        return Equals(other, SymbolEqualityComparer.Default);
     }
 
     private string GetDebuggerDisplay()


### PR DESCRIPTION
## Summary
- update the Symbol.Equals implementation to delegate to SymbolEqualityComparer.Default instead of recursing

## Testing
- dotnet run --project src/Raven.Compiler -- samples/main.rav -o test.dll

------
https://chatgpt.com/codex/tasks/task_e_68d7c994b968832fa8ca305b54f025fe