### PR TITLE
Improve output formatting for symbols

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@
 **Before building/tests** (run from repo root):
 
 ```bash
-# Refresh generated code when inputs change
-cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f && cd ../../..
-cd src/Raven.CodeAnalysis      && dotnet run --project ../../tools/BoundNodeGenerator -- -f && cd ../..
-cd src/Raven.CodeAnalysis      && dotnet run --project ../../tools/DiagnosticsGenerator -- -f && cd ../..
+# Refresh generated code once before `dotnet build`
+(cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f)
+(cd src/Raven.CodeAnalysis      && dotnet run --project ../../tools/BoundNodeGenerator -- -f)
+(cd src/Raven.CodeAnalysis      && dotnet run --project ../../tools/DiagnosticsGenerator -- -f)
 
 # Build and test
 dotnet build


### PR DESCRIPTION
## Summary
- clarify the repository instructions so code generators are run once before invoking dotnet build
- simplify the generator commands by using subshells instead of chained directory changes

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7cc869e14832f87bcdc5c7901a774