### PR TITLE
Fix goto label binding for escaped identifiers

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -737,7 +737,7 @@ partial class BlockBinder : Binder
         if (identifier.IsMissing)
             return CreateLabelSymbol(string.Empty, identifier.GetLocation(), labeledStatement.GetReference());
 
-        var name = identifier.Text;
+        var name = identifier.ValueText;
 
         if (_labelsByName.TryGetValue(name, out var conflict))
         {
@@ -781,7 +781,7 @@ partial class BlockBinder : Binder
             return boundError;
         }
 
-        var name = identifier.Text;
+        var name = identifier.ValueText;
         if (!_labelsByName.TryGetValue(name, out var label))
         {
             _diagnostics.ReportLabelNotFound(name, identifier.GetLocation());


### PR DESCRIPTION
## Summary
- ensure labels declared in block binding use the identifier ValueText so escaped names bind correctly
- extend goto completion logic to surface label symbols, including escaped identifiers, when editing goto statements
- adjust goto diagnostics/tests to reflect the new binding behavior and add coverage for escaped goto labels

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter GetCompletions_InGotoStatement_IncludesLabels
- dotnet test test/Raven.CodeAnalysis.Tests --filter DuplicateLabel_ReportsDiagnostic
- dotnet test test/Raven.CodeAnalysis.Tests --filter GetSymbolInfo_ForGotoWithEscapedIdentifier_ReturnsLabelSymbol


------
https://chatgpt.com/codex/tasks/task_e_68d7de33a76c832f86869ceba3f52685