### PR TITLE
Handle escaped identifiers in completion service

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Completion/CompletionServiceTests.cs
@@ -499,7 +499,7 @@ ST.
         var code = """
 func main() {
 label:
-    goto 
+    goto
 }
 """;
 
@@ -516,5 +516,29 @@ label:
         var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
 
         Assert.Contains(items, i => i.DisplayText == "label");
+    }
+
+    [Fact]
+    public void GetCompletions_ForEscapedIdentifier_UsesEscapedInsertion()
+    {
+        var code = """
+let @if = 0;
+@i
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var compilation = Compilation.Create(
+            "test",
+            [syntaxTree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var service = new CompletionService();
+        var position = code.Length;
+
+        var items = service.GetCompletions(compilation, syntaxTree, position).ToList();
+
+        var escaped = Assert.Single(items.Where(i => i.DisplayText == "@if"));
+        Assert.Equal("@if", escaped.InsertionText);
     }
 }


### PR DESCRIPTION
## Summary
- escape identifier-based completion items so completions display and insert the @-prefixed names when required
- use identifier value text when filtering to surface completions for escaped identifiers across import, alias, and value scopes
- add a regression test covering a local named with an escaped keyword

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing failures in TypeMetadataNameTests.GetClrType_ResolvesConstructedGenericFromMetadata, PartialClassMissingModifier_ProducesDiagnostic, CustomAttributes_AreEmitted, plus TerminalLogger crash)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e32948b4832f97439608bc5a3dad