### PR TITLE
Fix partial class merging across syntax trees

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -414,10 +414,6 @@ public class Compilation
         if (ns is null)
             return GlobalNamespace;
 
-        var existing = this.GetNamespaceSymbol(ns);
-        if (existing is not null)
-            return existing;
-
         var namespaceParts = ns.Split('.', StringSplitOptions.RemoveEmptyEntries);
         if (namespaceParts.Length == 0)
             return SourceGlobalNamespace;
@@ -446,7 +442,7 @@ public class Compilation
             currentSourceNamespace = next;
         }
 
-        return this.GetNamespaceSymbol(ns);
+        return this.GetNamespaceSymbol(ns) ?? currentSourceNamespace;
     }
 
     private void AnalyzeMemberDeclaration(SyntaxTree syntaxTree, ISymbol declaringSymbol, MemberDeclarationSyntax memberDeclaration)

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -382,6 +382,9 @@ public partial class SemanticModel
         var compilationUnitBinder = new CompilationUnitBinder(parentBinder, this);
         RegisterNamespaceMembers(cu, compilationUnitBinder, targetNamespace);
 
+        foreach (var diagnostic in compilationUnitBinder.Diagnostics.AsEnumerable())
+            importBinder.Diagnostics.Report(diagnostic);
+
         if (fileScopedNamespace is not null)
         {
             foreach (var alias in fileScopedNamespace.Aliases)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/PartialClassTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/PartialClassTests.cs
@@ -44,6 +44,90 @@ partial class Container {
     }
 
     [Fact]
+    public void PartialClassDeclarationsAcrossSyntaxTrees_MergeMembers()
+    {
+        const string sourceA = """
+partial class Container {
+    let x: int = 0;
+};
+""";
+
+        const string sourceB = """
+partial class Container {
+    let y: int = 0;
+};
+""";
+
+        var treeA = SyntaxTree.ParseText(sourceA);
+        var treeB = SyntaxTree.ParseText(sourceB);
+
+        var compilation = CreateCompilation(new[] { treeA, treeB }, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
+
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success);
+
+        var modelA = compilation.GetSemanticModel(treeA);
+        var modelB = compilation.GetSemanticModel(treeB);
+
+        var rootA = treeA.GetRoot();
+        var rootB = treeB.GetRoot();
+
+        var declarationA = Assert.IsType<ClassDeclarationSyntax>(Assert.Single(rootA.Members));
+        var declarationB = Assert.IsType<ClassDeclarationSyntax>(Assert.Single(rootB.Members));
+
+        var symbolA = Assert.IsAssignableFrom<INamedTypeSymbol>(modelA.GetDeclaredSymbol(declarationA));
+        var symbolB = Assert.IsAssignableFrom<INamedTypeSymbol>(modelB.GetDeclaredSymbol(declarationB));
+
+        Assert.Same(symbolA, symbolB);
+        Assert.Single(symbolA.GetMembers("x"));
+        Assert.Single(symbolA.GetMembers("y"));
+    }
+
+    [Fact]
+    public void PartialClassDeclarationsAcrossSyntaxTrees_InMetadataNamespace_MergeMembers()
+    {
+        const string sourceA = """
+namespace System;
+
+partial class Container {
+    let x: int = 0;
+};
+""";
+
+        const string sourceB = """
+namespace System;
+
+partial class Container {
+    let y: int = 0;
+};
+""";
+
+        var treeA = SyntaxTree.ParseText(sourceA);
+        var treeB = SyntaxTree.ParseText(sourceB);
+
+        var compilation = CreateCompilation(new[] { treeA, treeB }, new CompilationOptions(OutputKind.DynamicallyLinkedLibrary), assemblyName: "lib");
+
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success);
+
+        var modelA = compilation.GetSemanticModel(treeA);
+        var modelB = compilation.GetSemanticModel(treeB);
+
+        var declarationA = Assert.IsType<ClassDeclarationSyntax>(Assert.Single(treeA.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()));
+        var declarationB = Assert.IsType<ClassDeclarationSyntax>(Assert.Single(treeB.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()));
+
+        var symbolA = Assert.IsAssignableFrom<INamedTypeSymbol>(modelA.GetDeclaredSymbol(declarationA));
+        var symbolB = Assert.IsAssignableFrom<INamedTypeSymbol>(modelB.GetDeclaredSymbol(declarationB));
+
+        Assert.Same(symbolA, symbolB);
+        Assert.Equal(2, symbolA.DeclaringSyntaxReferences.Length);
+        Assert.Single(symbolA.GetMembers("x"));
+        Assert.Single(symbolA.GetMembers("y"));
+    }
+
+    [Fact]
     public void DuplicateClassDeclarationsWithoutPartial_ProduceDiagnostic()
     {
         const string source = """


### PR DESCRIPTION
## Summary
- ensure GetOrCreateNamespaceSymbol returns the current source namespace when metadata symbols are missing
- propagate diagnostics from the compilation unit binder into the import binder so semantic models capture partial declarations
- add semantic tests covering partial classes spanning multiple syntax trees and metadata namespaces

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter PartialClassTests

------
https://chatgpt.com/codex/tasks/task_e_68d7e35cc970832f99c9a6ca1c66d123