### PR TITLE
Report diagnostics for reserved label identifiers

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -737,6 +737,13 @@ partial class BlockBinder : Binder
         if (identifier.IsMissing)
             return CreateLabelSymbol(string.Empty, identifier.GetLocation(), labeledStatement.GetReference());
 
+        if (SyntaxFacts.IsReservedWordKind(identifier.Kind))
+        {
+            var identifierName = identifier.ValueText;
+            _diagnostics.ReportReservedWordCannotBeLabel(identifierName, identifier.GetLocation());
+            return CreateLabelSymbol(string.Empty, identifier.GetLocation(), labeledStatement.GetReference());
+        }
+
         var name = identifier.ValueText;
 
         if (_labelsByName.TryGetValue(name, out var conflict))
@@ -775,6 +782,16 @@ partial class BlockBinder : Binder
         var identifier = gotoStatement.Identifier;
         if (identifier.IsMissing)
         {
+            var errorSymbol = CreateLabelSymbol(string.Empty, identifier.GetLocation(), gotoStatement.GetReference());
+            var boundError = new BoundGotoStatement(errorSymbol);
+            CacheBoundNode(gotoStatement, boundError);
+            return boundError;
+        }
+
+        if (SyntaxFacts.IsReservedWordKind(identifier.Kind))
+        {
+            var identifierName = identifier.ValueText;
+            _diagnostics.ReportReservedWordCannotBeLabel(identifierName, identifier.GetLocation());
             var errorSymbol = CreateLabelSymbol(string.Empty, identifier.GetLocation(), gotoStatement.GetReference());
             var boundError = new BoundGotoStatement(errorSymbol);
             CacheBoundNode(gotoStatement, boundError);

--- a/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
+++ b/src/Raven.CodeAnalysis/CompilerDiagnostics.g.cs
@@ -91,6 +91,7 @@ internal static partial class CompilerDiagnostics
     private static DiagnosticDescriptor? _noOverloadMatchesDelegate;
     private static DiagnosticDescriptor? _labelAlreadyDefined;
     private static DiagnosticDescriptor? _labelNotFound;
+    private static DiagnosticDescriptor? _reservedWordCannotBeLabel;
     private static DiagnosticDescriptor? _breakStatementNotWithinLoop;
     private static DiagnosticDescriptor? _continueStatementNotWithinLoop;
 
@@ -1200,6 +1201,19 @@ internal static partial class CompilerDiagnostics
         isEnabledByDefault: true);
 
     /// <summary>
+    /// RAV2502: The identifier '{0}' is a reserved word and cannot be used as a label
+    /// </summary>
+    public static DiagnosticDescriptor ReservedWordCannotBeLabel => _reservedWordCannotBeLabel ??= DiagnosticDescriptor.Create(
+        id: "RAV2502",
+        title: "Reserved word cannot be used as a label",
+        description: "",
+        helpLinkUri: "",
+        messageFormat: "The identifier '{0}' is a reserved word and cannot be used as a label",
+        category: "compiler",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// RAV2600: Break statements are only valid inside loops
     /// </summary>
     public static DiagnosticDescriptor BreakStatementNotWithinLoop => _breakStatementNotWithinLoop ??= DiagnosticDescriptor.Create(
@@ -1312,6 +1326,7 @@ internal static partial class CompilerDiagnostics
         NoOverloadMatchesDelegate,
         LabelAlreadyDefined,
         LabelNotFound,
+        ReservedWordCannotBeLabel,
         BreakStatementNotWithinLoop,
         ContinueStatementNotWithinLoop,
     ];
@@ -1403,6 +1418,7 @@ internal static partial class CompilerDiagnostics
         "RAV2203" => NoOverloadMatchesDelegate,
         "RAV2500" => LabelAlreadyDefined,
         "RAV2501" => LabelNotFound,
+        "RAV2502" => ReservedWordCannotBeLabel,
         "RAV2600" => BreakStatementNotWithinLoop,
         "RAV2601" => ContinueStatementNotWithinLoop,
         _ => null

--- a/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
+++ b/src/Raven.CodeAnalysis/DiagnosticBagExtensions.g.cs
@@ -260,6 +260,9 @@ public static partial class DiagnosticBagExtensions
     public static void ReportLabelNotFound(this DiagnosticBag diagnostics, object? name, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.LabelNotFound, location, name));
 
+    public static void ReportReservedWordCannotBeLabel(this DiagnosticBag diagnostics, object? name, Location location)
+        => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.ReservedWordCannotBeLabel, location, name));
+
     public static void ReportBreakStatementNotWithinLoop(this DiagnosticBag diagnostics, Location location)
         => diagnostics.Report(Diagnostic.Create(CompilerDiagnostics.BreakStatementNotWithinLoop, location));
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -306,6 +306,9 @@
   <Descriptor Id="RAV2501" Identifier="LabelNotFound" Title="Label not found"
     Message="The label '{name}' does not exist in the current context" Category="compiler" Severity="Error"
     EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV2502" Identifier="ReservedWordCannotBeLabel" Title="Reserved word cannot be used as a label"
+    Message="The identifier '{name}' is a reserved word and cannot be used as a label" Category="compiler" Severity="Error"
+    EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV2600" Identifier="BreakStatementNotWithinLoop" Title="Break statement not within loop"
     Message="Break statements are only valid inside loops" Category="compiler" Severity="Error" EnabledByDefault="true"
     Description="" HelpLinkUri="" />

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -81,7 +81,10 @@ internal class StatementSyntaxParser : SyntaxParser
     {
         if (!CanTokenBeIdentifier(token))
         {
-            return false;
+            if (!global::Raven.CodeAnalysis.Syntax.SyntaxFacts.IsReservedWordKind(token.Kind))
+            {
+                return false;
+            }
         }
 
         var colonCandidate = PeekToken(1);
@@ -90,7 +93,15 @@ internal class StatementSyntaxParser : SyntaxParser
 
     private LabeledStatementSyntax ParseLabeledStatementSyntax()
     {
-        var identifier = ReadIdentifierToken();
+        SyntaxToken identifier;
+        if (global::Raven.CodeAnalysis.Syntax.SyntaxFacts.IsReservedWordKind(PeekToken().Kind))
+        {
+            identifier = ReadToken();
+        }
+        else
+        {
+            identifier = ReadIdentifierToken();
+        }
         var colonToken = ExpectToken(SyntaxKind.ColonToken);
 
         StatementSyntax statement;
@@ -132,9 +143,14 @@ internal class StatementSyntaxParser : SyntaxParser
         var gotoKeyword = ReadToken();
 
         SyntaxToken identifier;
-        if (CanTokenBeIdentifier(PeekToken()))
+        var next = PeekToken();
+        if (CanTokenBeIdentifier(next))
         {
             identifier = ReadIdentifierToken();
+        }
+        else if (global::Raven.CodeAnalysis.Syntax.SyntaxFacts.IsReservedWordKind(next.Kind))
+        {
+            identifier = ReadToken();
         }
         else
         {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/GotoStatementTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/GotoStatementTests.cs
@@ -46,6 +46,41 @@ func main() {
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void LabelUsingReservedWord_ReportsDiagnostic()
+    {
+        var code = """
+func main() {
+    int:
+        return
+}
+""";
+
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV2502").WithSpan(2, 5, 2, 8).WithArguments("int")
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void GotoUsingReservedWord_ReportsDiagnostic()
+    {
+        var code = """
+func main() {
+    goto int
+}
+""";
+
+        var verifier = CreateVerifier(code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV2502").WithSpan(2, 10, 2, 13).WithArguments("int")
+            ]);
+
+        verifier.Verify();
+    }
 }
 
 public class GotoStatementSemanticTests : CompilationTestBase


### PR DESCRIPTION
## Summary
- allow the parser to capture reserved keywords used as labels or goto targets so they can be analyzed
- report a new ReservedWordCannotBeLabel diagnostic when label declarations or goto statements use reserved identifiers
- add tests covering reserved keyword usage in labels and goto statements

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter GotoStatementDiagnosticsTests

------
https://chatgpt.com/codex/tasks/task_e_68d7ea8a6c20832fb55c6c3bfcff3314