### PR TITLE
Lower extension method invocations

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
@@ -207,7 +207,15 @@ class MethodBodyBinder : BlockBinder
         {
             var receiver = RewriteReceiver(node.Receiver, node.Method);
             var args = node.Arguments.Select(a => (BoundExpression)Visit(a)!).ToArray();
-            return new BoundInvocationExpression(node.Method, args, receiver);
+            BoundExpression? extensionReceiver = null;
+            if (node.ExtensionReceiver is not null)
+            {
+                extensionReceiver = ReferenceEquals(node.ExtensionReceiver, node.Receiver)
+                    ? receiver
+                    : (BoundExpression?)Visit(node.ExtensionReceiver);
+            }
+
+            return new BoundInvocationExpression(node.Method, args, receiver, extensionReceiver);
         }
 
         public override BoundNode? VisitFieldAccess(BoundFieldAccess node)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundInvocationExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundInvocationExpression.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+using System.Linq;
 
 namespace Raven.CodeAnalysis;
 
@@ -7,13 +7,19 @@ internal partial class BoundInvocationExpression : BoundExpression
     public IMethodSymbol Method { get; }
     public IEnumerable<BoundExpression> Arguments { get; }
     public BoundExpression? Receiver { get; }
+    public BoundExpression? ExtensionReceiver { get; }
 
-    public BoundInvocationExpression(IMethodSymbol method, IEnumerable<BoundExpression> arguments, BoundExpression? receiver = null)
+    public BoundInvocationExpression(
+        IMethodSymbol method,
+        IEnumerable<BoundExpression> arguments,
+        BoundExpression? receiver = null,
+        BoundExpression? extensionReceiver = null)
            : base(method.ReturnType, method, BoundExpressionReason.None)
     {
         Method = method;
         Arguments = arguments;
         Receiver = receiver;
+        ExtensionReceiver = extensionReceiver;
     }
 
     public override string ToString()

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -197,6 +197,8 @@ internal class BoundTreeWalker : BoundTreeVisitor
     {
         if (node.Receiver is not null)
             VisitExpression(node.Receiver);
+        if (node.ExtensionReceiver is not null && !ReferenceEquals(node.ExtensionReceiver, node.Receiver))
+            VisitExpression(node.ExtensionReceiver);
         foreach (var arg in node.Arguments)
             VisitExpression(arg);
     }

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Raven.CodeAnalysis.Symbols;
 
@@ -38,6 +39,30 @@ internal sealed class Lowerer : BoundTreeRewriter
         }
 
         return new BoundBlockStatement(statements, node.LocalsToDispose);
+    }
+
+    public override BoundNode? VisitInvocationExpression(BoundInvocationExpression node)
+    {
+        var receiver = (BoundExpression?)VisitExpression(node.Receiver);
+        var arguments = node.Arguments.Select(a => (BoundExpression)VisitExpression(a)!).ToArray();
+
+        BoundExpression? extensionReceiver = null;
+        if (node.ExtensionReceiver is not null)
+        {
+            extensionReceiver = ReferenceEquals(node.ExtensionReceiver, node.Receiver)
+                ? receiver
+                : (BoundExpression?)VisitExpression(node.ExtensionReceiver);
+        }
+
+        if (node.Method.IsExtensionMethod && extensionReceiver is not null)
+        {
+            var loweredArguments = new BoundExpression[arguments.Length + 1];
+            loweredArguments[0] = extensionReceiver;
+            Array.Copy(arguments, 0, loweredArguments, 1, arguments.Length);
+            return new BoundInvocationExpression(node.Method, loweredArguments, receiver: null);
+        }
+
+        return new BoundInvocationExpression(node.Method, arguments, receiver, extensionReceiver);
     }
 
     public override BoundNode? VisitIfStatement(BoundIfStatement node)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 
+using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
 
@@ -44,9 +45,10 @@ class Query {
             boundWhere.Method.ContainingType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
 
         var whereArguments = boundWhere.Arguments.ToArray();
-        Assert.Equal(2, whereArguments.Length);
-        Assert.Same(boundWhere.Receiver, whereArguments[0]);
-        Assert.IsType<BoundLambdaExpression>(whereArguments[1]);
+        Assert.Equal(boundWhere.Method.Parameters.Length - 1, whereArguments.Length);
+        Assert.NotNull(boundWhere.ExtensionReceiver);
+        Assert.Equal(boundWhere.Method.Parameters[0].Type, boundWhere.ExtensionReceiver!.Type);
+        Assert.IsType<BoundLambdaExpression>(whereArguments[0]);
 
         var countInvocation = tree.GetRoot()
             .DescendantNodes()
@@ -58,6 +60,8 @@ class Query {
         Assert.Equal(
             "global::System.Linq.Enumerable",
             boundCount.Method.ContainingType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        Assert.NotNull(boundCount.ExtensionReceiver);
+        Assert.Equal(boundCount.Method.Parameters[0].Type, boundCount.ExtensionReceiver!.Type);
     }
 
     [Fact]
@@ -89,5 +93,50 @@ let hasItems = items.Any()
         Assert.Equal(
             "global::System.Linq.Enumerable",
             boundAny.Method.ContainingType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        Assert.NotNull(boundAny.ExtensionReceiver);
+        Assert.Equal(boundAny.Method.Parameters[0].Type, boundAny.ExtensionReceiver!.Type);
+    }
+
+    [Fact]
+    public void Lowerer_RewritesExtensionInvocation()
+    {
+        const string source = """
+import System.Collections.Generic.*
+import System.Linq.*
+
+class Query {
+    Run() -> int {
+        let items = List<int>()
+        return items.Count()
+    }
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var methodSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.Text == "Run");
+
+        var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(methodSyntax)!;
+        var boundBody = (BoundBlockStatement)model.GetBoundNode(methodSyntax.Body!)!;
+
+        var lowered = Lowerer.LowerBlock(methodSymbol, boundBody);
+
+        var returnStatement = Assert.IsType<BoundReturnStatement>(lowered.Statements.Last());
+        var invocation = Assert.IsType<BoundInvocationExpression>(returnStatement.Expression);
+
+        Assert.True(invocation.Method.IsExtensionMethod);
+        Assert.Null(invocation.Receiver);
+
+        var arguments = invocation.Arguments.ToArray();
+        Assert.Equal(invocation.Method.Parameters.Length, arguments.Length);
+        Assert.IsType<BoundLocalAccess>(arguments[0]);
     }
 }


### PR DESCRIPTION
## Summary
- keep the original extension receiver on bound invocation nodes instead of eagerly lowering in the binder
- teach the lowering pass to rewrite extension invocations into static calls and update semantic tests accordingly
- add a regression test that verifies the lowered call shape for an imported extension

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: SemanticFactsTests.ImplementsInterface_HandlesContravariantInterfaceArguments))*

------
https://chatgpt.com/codex/tasks/task_e_68d7eb9075a4832fab99ab28d600762e