### PR TITLE
Add diagnostics-only mode to console syntax highlighter

### DIFF
--- a/src/Raven.CodeAnalysis/Text/AnsiExtensions.cs
+++ b/src/Raven.CodeAnalysis/Text/AnsiExtensions.cs
@@ -4,7 +4,7 @@ namespace Raven.CodeAnalysis.Text;
 
 public static partial class AnsiExtensions
 {
-    private static readonly Regex s_ansiRegex = new("\u001B\\[[0-9;]*m", RegexOptions.Compiled);
+    private static readonly Regex s_ansiRegex = new("\u001B\\[[0-9;:]*m", RegexOptions.Compiled);
 
     public static string StripAnsiCodes(this string text)
         => s_ansiRegex.Replace(text, string.Empty);


### PR DESCRIPTION
## Summary
- add an optional diagnostics-only rendering path to the console syntax highlighter
- expose the new mode through the `ravenc -d pretty:diagnostics-only` flag
- update ANSI stripping and add unit tests covering the focused diagnostic output

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter ConsoleSyntaxHighlighterTests

------
https://chatgpt.com/codex/tasks/task_e_68d7f10abacc832f8280d28b22947f0b