### PR TITLE
Format diagnostics-only syntax dump like VB.NET

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
@@ -192,6 +192,8 @@ Console.WriteLine("Bar")
         var text = root.WriteNodeToText(compilation, includeDiagnostics: true, diagnosticsOnly: true);
         var plain = text.StripAnsiCodes();
 
+        Assert.Contains("file(", plain);
+        Assert.Contains(": error ", plain);
         Assert.Contains("Console.WriteLine2(\"Foo\")", plain);
         Assert.DoesNotContain("import System.*", plain);
         Assert.DoesNotContain("Console.WriteLine(\"Bar\")", plain);


### PR DESCRIPTION
## Summary
- add a diagnostics-only writer that emits VB-style diagnostic headers followed by the highlighted source lines
- ensure syntax dump generation orders diagnostics deterministically and normalizes file paths
- update the diagnostics-only highlighting test to expect the new diagnostic header output

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing InvalidCastException in ExtensionMethodSemanticTests and subsequent TerminalLogger crash)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f36410e8832f9f4cdd54ec35f6de