### PR TITLE
Include binders in bound tree output

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Options:
 - `-d` &ndash; dump syntax with highlighting (single file only)
 - `-r` &ndash; print the raw source (single file only)
 - `-b` &ndash; print the binder tree (single file only)
-- `-bt` &ndash; print the bound tree (single file only)
+- `-bt` &ndash; print the binder and bound tree (single file only)
 - `--symbols [list|hierarchy]` &ndash; inspect source symbols (`list` dumps properties, `hierarchy` prints the tree)
 - `-h`, `--help` &ndash; show help
 

--- a/docs/compiler/raven-compiler.md
+++ b/docs/compiler/raven-compiler.md
@@ -19,7 +19,7 @@ dotnet run --project src/Raven.Compiler -- [options] <source-files>
 - `-d` &ndash; dump syntax with highlighting (single file only)
 - `-r` &ndash; print the raw source (single file only)
 - `-b` &ndash; print the binder tree (single file only)
-- `-bt` &ndash; print the bound tree (single file only)
+- `-bt` &ndash; print the binder and bound tree (single file only)
 - `-h`, `--help` &ndash; show help
 
 Creating a `.debug/` directory in the current or parent folder causes the

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -23,7 +23,7 @@ var stopwatch = Stopwatch.StartNew();
 // -d [plain|pretty[:no-diagnostics|diagnostics-only]] - dump syntax (single file only)
 // -r                - print the source (single file only)
 // -b                - print binder tree (single file only)
-// -bt               - print bound tree (single file only)
+// -bt               - print binder and bound tree (single file only)
 // --symbols [list|hierarchy] - inspect symbols produced from source
 // --no-emit         - skip emitting the output assembly
 // -h, --help        - display help
@@ -305,18 +305,27 @@ if (allowConsoleOutput)
         }
     }
 
-    if (printBinders)
+    if (printBinders || printBoundTree)
     {
         var semanticModel = compilation.GetSemanticModel(syntaxTree);
-        semanticModel.PrintBinderTree();
-        Console.WriteLine();
-    }
 
-    if (printBoundTree)
-    {
-        var semanticModel = compilation.GetSemanticModel(syntaxTree);
-        semanticModel.PrintBoundTree();
-        Console.WriteLine();
+        if (printBinders)
+        {
+            semanticModel.PrintBinderTree();
+            Console.WriteLine();
+        }
+
+        if (printBoundTree)
+        {
+            if (!printBinders)
+            {
+                semanticModel.PrintBinderTree();
+                Console.WriteLine();
+            }
+
+            semanticModel.PrintBoundTree();
+            Console.WriteLine();
+        }
     }
 }
 else if (printRawSyntax || printSyntaxTree || printSyntax || printBinders || printBoundTree)
@@ -408,7 +417,7 @@ static void PrintHelp()
     Console.WriteLine("                     Append ':diagnostics-only' to show only lines containing diagnostics.");
     Console.WriteLine("  -r                 Print the source (single file only)");
     Console.WriteLine("  -b                 Print binder tree (single file only)");
-    Console.WriteLine("  -bt                Print bound tree (single file only)");
+    Console.WriteLine("  -bt                Print binder and bound tree (single file only)");
     Console.WriteLine("  --symbols [list|hierarchy]");
     Console.WriteLine("                     Inspect symbols produced from source.");
     Console.WriteLine("                     'list' dumps properties, 'hierarchy' prints the tree.");


### PR DESCRIPTION
## Summary
- ensure the `-bt` option prints the binder tree before the bound tree so the combined view is available from the CLI
- refresh the CLI help text and docs to describe that the bound tree dump now includes binders

## Testing
- dotnet build Raven.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7f5afe7c0832facb02fb769a54d7f