### PR TITLE
Add CLI flag for highlighted diagnostics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Options:
 - `--refs <path>` &ndash; additional metadata reference (repeatable)
 - `-o <path>` &ndash; output assembly path
 - `-s` &ndash; display the syntax tree (single file only)
-- `-d` &ndash; dump syntax with highlighting (single file only)
+- `-d [plain|pretty[:no-diagnostics]]` &ndash; dump syntax (`plain` for raw text, `pretty` for highlighted syntax; append `:no-diagnostics` to skip underlines, single file only)
+- `--highlight` &ndash; display diagnostics with highlighted source snippets
 - `-r` &ndash; print the raw source (single file only)
 - `-b` &ndash; print the binder tree (single file only)
 - `-bt` &ndash; print the binder and bound tree (single file only)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ Options:
 - `-o <path>` &ndash; output assembly path
 - `-s` &ndash; display the syntax tree (single file only)
 - `-d [plain|pretty[:no-diagnostics]]` &ndash; dump syntax (`plain` for raw text, `pretty` for highlighted syntax; append `:no-diagnostics` to skip underlines, single file only)
-- `--highlight` &ndash; display diagnostics with highlighted source snippets
+- `--highlight` &ndash; display diagnostics with highlighted source snippets and severity-coloured underlines (covers
+  compiler, analyzer, and emit diagnostics)
 - `-r` &ndash; print the raw source (single file only)
 - `-b` &ndash; print the binder tree (single file only)
 - `-bt` &ndash; print the binder and bound tree (single file only)

--- a/docs/compiler/raven-compiler.md
+++ b/docs/compiler/raven-compiler.md
@@ -17,7 +17,8 @@ dotnet run --project src/Raven.Compiler -- [options] <source-files>
 - `-o <path>` &ndash; output assembly path
 - `-s` &ndash; display the syntax tree (single file only)
 - `-d [plain|pretty[:no-diagnostics]]` &ndash; dump syntax (`plain` writes the source text, `pretty` emits highlighted syntax; append `:no-diagnostics` to skip diagnostic underlines, single file only)
-- `--highlight` &ndash; display diagnostics with highlighted source snippets
+- `--highlight` &ndash; display diagnostics with highlighted source snippets and severity-coloured underlines (covers
+  compiler, analyzer, and emit diagnostics)
 - `-r` &ndash; print the raw source (single file only)
 - `-b` &ndash; print the binder tree (single file only)
 - `-bt` &ndash; print the binder and bound tree (single file only)

--- a/docs/compiler/raven-compiler.md
+++ b/docs/compiler/raven-compiler.md
@@ -16,7 +16,8 @@ dotnet run --project src/Raven.Compiler -- [options] <source-files>
 - `--refs <path>` &ndash; additional metadata reference (repeatable)
 - `-o <path>` &ndash; output assembly path
 - `-s` &ndash; display the syntax tree (single file only)
-- `-d` &ndash; dump syntax with highlighting (single file only)
+- `-d [plain|pretty[:no-diagnostics]]` &ndash; dump syntax (`plain` writes the source text, `pretty` emits highlighted syntax; append `:no-diagnostics` to skip diagnostic underlines, single file only)
+- `--highlight` &ndash; display diagnostics with highlighted source snippets
 - `-r` &ndash; print the raw source (single file only)
 - `-b` &ndash; print the binder tree (single file only)
 - `-bt` &ndash; print the binder and bound tree (single file only)

--- a/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
+++ b/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
@@ -180,8 +180,26 @@ public static class ConsoleSyntaxHighlighter
             }
 
             var start = span.StartLinePosition;
-            sb.AppendLine(
-                $"{filePath}({start.Line + 1},{start.Character + 1}): {diagnostic.Severity.ToString().ToLowerInvariant()} {diagnostic.Descriptor.Id}: {diagnostic.GetMessage()}");
+            var severityColor = GetColorForSeverity(diagnostic.Severity);
+            var severityAnsi = GetAnsiColor(severityColor);
+            var resetAnsi = GetAnsiColor(AnsiColor.Reset);
+            var severityText = diagnostic.Severity.ToString().ToLowerInvariant();
+
+            sb.Append(filePath);
+            sb.Append('(');
+            sb.Append(start.Line + 1);
+            sb.Append(',');
+            sb.Append(start.Character + 1);
+            sb.Append("):");
+            sb.Append(' ');
+            sb.Append(severityAnsi);
+            sb.Append(severityText);
+            sb.Append(' ');
+            sb.Append(diagnostic.Descriptor.Id);
+            sb.Append(resetAnsi);
+            sb.Append(':');
+            sb.Append(' ');
+            sb.AppendLine(diagnostic.GetMessage());
             sb.AppendLine();
 
             var end = span.EndLinePosition;

--- a/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
+++ b/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
@@ -81,7 +81,7 @@ public static class ConsoleSyntaxHighlighter
     public static ColorScheme ColorScheme { get; set; } = ColorScheme.Dark;
 
     public static string WriteNodeToText(this SyntaxNode node, Compilation compilation, bool includeDiagnostics = false,
-        bool diagnosticsOnly = false)
+        bool diagnosticsOnly = false, IEnumerable<Diagnostic>? diagnostics = null)
     {
         var syntaxTree = node.SyntaxTree ?? throw new InvalidOperationException("Node is not associated with a syntax tree.");
 
@@ -115,10 +115,12 @@ public static class ConsoleSyntaxHighlighter
             AddTriviaSpan(lineTokens, lines, sourceText, kvp.Key.Span, kvp.Value);
         }
 
-        var diagnosticsForTree = Array.Empty<Diagnostic>();
+        IReadOnlyList<Diagnostic> diagnosticsForTree = Array.Empty<Diagnostic>();
         if (includeDiagnostics)
         {
-            diagnosticsForTree = compilation.GetDiagnostics()
+            var sourceDiagnostics = diagnostics ?? compilation.GetDiagnostics();
+
+            diagnosticsForTree = sourceDiagnostics
                 .Where(d => d.Location.SourceTree == syntaxTree)
                 .OrderBy(d => d.Location.SourceSpan.Start)
                 .ThenBy(d => d.Location.SourceSpan.Length)

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -239,7 +239,9 @@ if (debugDir is not null)
         File.WriteAllText(Path.Combine(debugDir, $"{name}.syntax-tree.txt"), treeText);
 
         ConsoleSyntaxHighlighter.ColorScheme = ColorScheme.Light;
-        var syntax = root.WriteNodeToText(compilation, includeDiagnostics: true).StripAnsiCodes();
+        var syntaxDiagnostics = diagnostics.Where(d => d.Location.SourceTree == syntaxTree);
+        var syntax = root.WriteNodeToText(compilation, includeDiagnostics: true, diagnostics: syntaxDiagnostics)
+            .StripAnsiCodes();
         File.WriteAllText(Path.Combine(debugDir, $"{name}.syntax.txt"), syntax);
 
         var semanticModel = compilation.GetSemanticModel(syntaxTree);
@@ -295,7 +297,11 @@ if (allowConsoleOutput)
     if (printSyntax)
     {
         ConsoleSyntaxHighlighter.ColorScheme = ColorScheme.Light;
-        var highlighted = root.WriteNodeToText(compilation, includeDiagnostics: prettyIncludeDiagnostics);
+        var prettyDiagnostics = prettyIncludeDiagnostics
+            ? diagnostics.Where(d => d.Location.SourceTree == syntaxTree)
+            : null;
+        var highlighted = root.WriteNodeToText(compilation, includeDiagnostics: prettyIncludeDiagnostics,
+            diagnostics: prettyDiagnostics);
         if (highlighted.Length > 0)
         {
             Console.WriteLine(highlighted);

--- a/src/Raven.Compiler/Program.cs
+++ b/src/Raven.Compiler/Program.cs
@@ -26,6 +26,7 @@ var stopwatch = Stopwatch.StartNew();
 // -bt               - print binder and bound tree (single file only)
 // --symbols [list|hierarchy] - inspect symbols produced from source
 // --no-emit         - skip emitting the output assembly
+// --highlight       - display diagnostics with highlighted source
 // -h, --help        - display help
 
 var sourceFiles = new List<string>();
@@ -45,6 +46,7 @@ var symbolDumpMode = SymbolDumpMode.None;
 var showHelp = false;
 var noEmit = false;
 var hasInvalidOption = false;
+var highlightDiagnostics = false;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -107,6 +109,9 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--no-emit":
             noEmit = true;
+            break;
+        case "--highlight":
+            highlightDiagnostics = true;
             break;
         case "--ref":
         case "--refs":
@@ -362,7 +367,7 @@ if (symbolDumpMode != SymbolDumpMode.None)
 
 if (diagnostics.Length > 0)
 {
-    PrintDiagnostics(diagnostics);
+    PrintDiagnostics(diagnostics, compilation, highlightDiagnostics);
     Console.WriteLine();
 }
 
@@ -421,6 +426,7 @@ static void PrintHelp()
     Console.WriteLine("  --symbols [list|hierarchy]");
     Console.WriteLine("                     Inspect symbols produced from source.");
     Console.WriteLine("                     'list' dumps properties, 'hierarchy' prints the tree.");
+    Console.WriteLine("  --highlight       Display diagnostics with highlighted source snippets");
     Console.WriteLine("  --no-emit        Skip emitting the output assembly");
     Console.WriteLine("  -h, --help         Display help");
 }


### PR DESCRIPTION
## Summary
- add a `--highlight` switch to ravenc to toggle highlighted diagnostic output and document the option in the CLI help
- update the diagnostic printer to emit syntax-highlighted sections when requested while falling back to the existing list output as needed

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d7f8381428832fb6ea02b89485c67f