### PR TITLE
Add base-type receiver extension lookup test

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
@@ -135,6 +135,43 @@ public static class Extensions {
     }
 
     [Fact]
+    public void MemberAccess_WithSourceExtensionAndBaseTypeReceiver_BindsExtensionInvocation()
+    {
+        const string source = """
+import System.Runtime.CompilerServices.*
+
+let x = "test"
+let result = x.Test()
+
+public static class Extensions {
+    [ExtensionAttribute]
+    public static Test(x: object) -> int {
+        return 42
+    }
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocationSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single();
+
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocationSyntax));
+        Assert.True(boundInvocation.Method.IsExtensionMethod);
+        Assert.Equal("Test", boundInvocation.Method.Name);
+        Assert.Equal("Extensions", boundInvocation.Method.ContainingType?.Name);
+        Assert.NotNull(boundInvocation.ExtensionReceiver);
+        Assert.Equal(boundInvocation.Method.Parameters[0].Type, boundInvocation.ExtensionReceiver!.Type);
+    }
+
+    [Fact]
     public void MemberAccess_WithSourceExtensionAndAdditionalParameters_BindsInvocationArguments()
     {
         const string source = """


### PR DESCRIPTION
## Summary
- add a regression test that ensures extension methods defined on `object` are resolved for string receivers

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter ExtensionMethodSemanticTests` *(fails: System.InvalidCastException in existing extension method tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d80d4ee36c832fb3ae4f8241b7a0ee