### PR TITLE
Support attribute lookup without explicit suffix

### DIFF
--- a/src/Raven.CodeAnalysis/AttributeDataFactory.cs
+++ b/src/Raven.CodeAnalysis/AttributeDataFactory.cs
@@ -24,7 +24,7 @@ internal static class AttributeDataFactory
         return new AttributeData(
             attributeType,
             ctor,
-            argumentConstants.MoveToImmutable(),
+            argumentConstants.ToImmutable(),
             ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty,
             attribute.GetReference());
     }


### PR DESCRIPTION
## Summary
- allow the attribute binder to resolve attribute identifiers without requiring the `Attribute` suffix, including qualified names
- adjust attribute data materialization to avoid ImmutableArray builder issues when capturing constructor arguments
- add a semantic model test that verifies `[Lib.Export]` binds to `Lib.ExportAttribute`

## Testing
- `dotnet build --property WarningLevel=0`
- `dotnet test test/Raven.CodeAnalysis.Tests --no-build --filter AttributeSemanticModelTests --logger "console;verbosity=minimal"`


------
https://chatgpt.com/codex/tasks/task_e_68d81c1095d0832fb2ea970706b72cf8