### PR TITLE
Enforce generic constraints when binding extension methods

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -783,7 +783,7 @@ internal abstract class Binder
         return fallback;
     }
 
-    private static bool SatisfiesReferenceTypeConstraint(ITypeSymbol type)
+    internal static bool SatisfiesReferenceTypeConstraint(ITypeSymbol type)
     {
         if (type.IsReferenceType)
             return true;
@@ -794,7 +794,7 @@ internal abstract class Binder
         return false;
     }
 
-    private bool SatisfiesTypeConstraint(ITypeSymbol typeArgument, ITypeSymbol constraintType)
+    internal static bool SatisfiesTypeConstraint(ITypeSymbol typeArgument, ITypeSymbol constraintType)
     {
         if (typeArgument is IErrorTypeSymbol || constraintType is IErrorTypeSymbol)
             return true;
@@ -808,7 +808,7 @@ internal abstract class Binder
         return true;
     }
 
-    private bool SatisfiesNamedTypeConstraint(ITypeSymbol typeArgument, INamedTypeSymbol constraintType)
+    internal static bool SatisfiesNamedTypeConstraint(ITypeSymbol typeArgument, INamedTypeSymbol constraintType)
     {
         if (SymbolEqualityComparer.Default.Equals(typeArgument, constraintType))
             return true;
@@ -856,7 +856,7 @@ internal abstract class Binder
         return false;
     }
 
-    private static bool SatisfiesValueTypeConstraint(ITypeSymbol type)
+    internal static bool SatisfiesValueTypeConstraint(ITypeSymbol type)
     {
         if (type.TypeKind == TypeKind.Nullable)
             return false;


### PR DESCRIPTION
## Summary
- expose the binder constraint helpers for reuse outside of binder instances
- ensure overload resolution discards candidates whose inferred type arguments violate constraints
- add a regression test covering extension methods with unsatisfied generic constraints

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: Raven.CodeAnalysis.Tests.TypeOfTests.TypeOfExpression_EmitsSystemType)*

------
https://chatgpt.com/codex/tasks/task_e_68d820713458832f83a6345658425a3c