### PR TITLE
Fix typeof namespace binding and delegate creation

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -2312,6 +2312,13 @@ partial class BlockBinder : Binder
     {
         var symbol = LookupType(name);
 
+        if (symbol is null && typeArguments.IsEmpty)
+        {
+            var namespaceSymbol = LookupNamespace(name);
+            if (namespaceSymbol is not null)
+                return new BoundNamespaceExpression(namespaceSymbol);
+        }
+
         if (symbol is ITypeSymbol type && type is INamedTypeSymbol named)
         {
             // If the resolved symbol is already a constructed generic type (e.g., from an alias
@@ -2349,9 +2356,6 @@ partial class BlockBinder : Binder
             var constructed = TryConstructGeneric(definition, typeArguments, definition.Arity) ?? definition;
             return new BoundTypeExpression(constructed);
         }
-
-        if (symbol is INamespaceSymbol ns)
-            return new BoundNamespaceExpression(ns);
 
         var alternate = FindAccessibleNamedType(name, typeArguments.Length);
         if (alternate is not null)


### PR DESCRIPTION
## Summary
- allow BindTypeName to resolve namespace identifiers without type arguments
- build captured lambda delegates using the standard constructor instead of Delegate.CreateDelegate

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter TypeOfExpression_EmitsSystemType`


------
https://chatgpt.com/codex/tasks/task_e_68d823ac7254832fa5b3793aaf76600f