### PR TITLE
Handle BoundTypeExpression nodes in rewriter

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -84,10 +84,10 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundDelegateCreationExpression delegateCreation => (BoundExpression)VisitDelegateCreationExpression(delegateCreation)!,
             BoundMethodGroupExpression methodGroup => (BoundExpression)VisitMethodGroupExpression(methodGroup)!,
             BoundTypeOfExpression typeOfExpression => (BoundExpression)VisitTypeOfExpression(typeOfExpression)!,
+            BoundTypeExpression typeExpression => (BoundExpression)VisitTypeExpression(typeExpression)!,
             _ => throw new NotImplementedException($"Unhandled expression: {node.GetType().Name}"),
         };
     }
-
     public virtual BoundNode? VisitAssignmentExpression(BoundAssignmentExpression node) => node;
 
     public virtual BoundNode? VisitBreakStatement(BoundBreakStatement node) => node;


### PR DESCRIPTION
## Summary
- ensure the manual BoundTreeRewriter dispatch handles BoundTypeExpression nodes instead of throwing

## Testing
- dotnet run --project src/Raven.Compiler --property WarningLevel=0 -- samples/goto.rav -o test.dll

------
https://chatgpt.com/codex/tasks/task_e_68d82a20ad10832f838b6e58b8615dff