### PR TITLE
Improve lambda inference for LINQ Where on arrays

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ArrayTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ArrayTypeSymbol.cs
@@ -111,7 +111,10 @@ internal partial class ArrayTypeSymbol : PESymbol, IArrayTypeSymbol
 
         var builder = ImmutableArray.CreateBuilder<INamedTypeSymbol>();
 
+        AddConstructedInterface(builder, "System.Collections.Generic.IEnumerable`1");
+        AddConstructedInterface(builder, "System.Collections.Generic.ICollection`1");
         AddConstructedInterface(builder, "System.Collections.Generic.IList`1");
+        AddConstructedInterface(builder, "System.Collections.Generic.IReadOnlyCollection`1");
         AddConstructedInterface(builder, "System.Collections.Generic.IReadOnlyList`1");
 
         _arraySpecificInterfaces = builder.ToImmutable();


### PR DESCRIPTION
## Summary
- refine overload resolution to reuse array element types when inferring generic arguments for extension methods such as Enumerable.Where
- filter invocation candidates whose delegate signatures do not match the lambda’s parameter count so lambda target types can be inferred
- expose additional generic collection interfaces on array symbols and add a regression test covering Where on collection expressions

## Testing
- dotnet run --project src/Raven.Compiler --property WarningLevel=0 -- samples/linq.rav -o test.dll -d pretty


------
https://chatgpt.com/codex/tasks/task_e_68d82bd54c38832faaf7862af175e374