### PR TITLE
Fix LINQ sample lambda typing

### DIFF
--- a/src/Raven.Compiler/samples/linq.rav
+++ b/src/Raven.Compiler/samples/linq.rav
@@ -3,4 +3,4 @@ import System.Collections.Generic.*
 import System.Linq.*
 
 let numbers = [1, 2, 3]
-let result = numbers.Where(func (x) => x == 2)
+let result = numbers.Where(func (value: int) -> bool => value == 2)


### PR DESCRIPTION
## Summary
- specify an explicit parameter type and return type in the LINQ sample lambda so Where resolves unambiguously

## Testing
- dotnet run --project src/Raven.Compiler -- samples/linq.rav -o test.dll -d pretty *(fails: missing generated syntax files in clean checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68d834d78904832f97f0832760f44136