### PR TITLE
Fix overload inference for non-generic named types

### DIFF
--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -239,6 +239,12 @@ internal sealed class OverloadResolver
             var paramArguments = parameterNamed.TypeArguments;
             var argArguments = argumentNamed.TypeArguments;
 
+            if (paramArguments.IsDefault)
+                paramArguments = ImmutableArray<ITypeSymbol>.Empty;
+
+            if (argArguments.IsDefault)
+                argArguments = ImmutableArray<ITypeSymbol>.Empty;
+
             if (paramArguments.Length != argArguments.Length)
                 return false;
 


### PR DESCRIPTION
## Summary
- guard overload inference against named types that expose a default type argument array

## Testing
- `dotnet run --project src/Raven.Compiler -- samples/linq.rav -o test.dll -d pretty` *(fails: Input file '/workspace/raven/samples/linq.rav' doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68d8363b1b64832f84c49e4138b6abe9