### PR TITLE
Handle BoundFieldAccess in BoundTreeRewriter

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -79,6 +79,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundLambdaExpression lambda => (BoundExpression)VisitLambdaExpression(lambda)!,
             BoundBlockExpression block => (BoundExpression)VisitBlockExpression(block)!,
             BoundAssignmentExpression assignment => (BoundExpression)VisitAssignmentExpression(assignment)!,
+            BoundFieldAccess fieldAccess => (BoundExpression)VisitFieldAccess(fieldAccess)!,
             BoundCastExpression cast => (BoundExpression)VisitCastExpression(cast)!,
             BoundAsExpression asExpr => (BoundExpression)VisitAsExpression(asExpr)!,
             BoundDelegateCreationExpression delegateCreation => (BoundExpression)VisitDelegateCreationExpression(delegateCreation)!,


### PR DESCRIPTION
## Summary
- ensure BoundTreeRewriter dispatches BoundFieldAccess nodes to the generated VisitFieldAccess implementation so they can be lowered

## Testing
- dotnet build -v minimal

------
https://chatgpt.com/codex/tasks/task_e_68d838596924832f9448b1eee0adc254