### PR TITLE
Handle member access in bound tree rewriter

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -80,6 +80,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundBlockExpression block => (BoundExpression)VisitBlockExpression(block)!,
             BoundAssignmentExpression assignment => (BoundExpression)VisitAssignmentExpression(assignment)!,
             BoundFieldAccess fieldAccess => (BoundExpression)VisitFieldAccess(fieldAccess)!,
+            BoundMemberAccessExpression memberAccess => (BoundExpression)VisitMemberAccessExpression(memberAccess)!,
             BoundCastExpression cast => (BoundExpression)VisitCastExpression(cast)!,
             BoundAsExpression asExpr => (BoundExpression)VisitAsExpression(asExpr)!,
             BoundDelegateCreationExpression delegateCreation => (BoundExpression)VisitDelegateCreationExpression(delegateCreation)!,


### PR DESCRIPTION
## Summary
- teach `BoundTreeRewriter` to dispatch `BoundMemberAccessExpression` nodes to the generated visitor

## Testing
- `dotnet build --property WarningLevel=0`
- `dotnet test test/Raven.CodeAnalysis.Tests /p:WarningLevel=0` *(fails: existing lambda code generation issue in `Lambda_CapturedLocalSharesMutations`)*

------
https://chatgpt.com/codex/tasks/task_e_68d83a4d2740832f9f30ebfe7a565517