### PR TITLE
Fix LINQ Where overload resolution for typed lambdas

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
@@ -246,6 +246,26 @@ let result = numbers.Where(func (value) => value == 2)
     }
 
     [Fact]
+    public void MemberAccess_LinqWhereWithExplicitLambdaType_BindsSuccessfully()
+    {
+        const string source = """
+import System.*
+import System.Collections.Generic.*
+import System.Linq.*
+
+let numbers = [1, 2, 3]
+let result = numbers.Where(func (value: int) -> bool => value == 2)
+""";
+
+        var (compilation, _) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+    }
+
+    [Fact]
     public void MemberAccess_WithSourceExtensionAndAdditionalParameters_BindsInvocationArguments()
     {
         const string source = """


### PR DESCRIPTION
## Summary
- ensure overload resolution skips duplicate candidates and ignores delegate overloads that cannot accept the provided lambda
- add a regression test covering LINQ Where with an explicitly typed lambda parameter

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~MemberAccess_LinqWhereWithExplicitLambdaType_BindsSuccessfully
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Raven.CodeAnalysis.Tests.GotoStatementCodeGenTests.GotoStatement_JumpsToLabel)*

------
https://chatgpt.com/codex/tasks/task_e_68d837c3ea68832f8704f0dbd734c350