### PR TITLE
Handle comparison operators in expression emitter

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1488,8 +1488,9 @@ internal class ExpressionGenerator : Generator
         EmitExpression(binaryExpression.Right);
 
         var op = binaryExpression.Operator;
+        var operatorKind = op.OperatorKind & ~(BinaryOperatorKind.Lifted | BinaryOperatorKind.Checked);
 
-        switch (op.OperatorKind)
+        switch (operatorKind)
         {
             case BinaryOperatorKind.Addition:
                 ILGenerator.Emit(OpCodes.Add);
@@ -1511,8 +1512,38 @@ internal class ExpressionGenerator : Generator
             //    ILGenerator.Emit(OpCodes.Rem);
             //    break;
 
+            case BinaryOperatorKind.Equality:
+                ILGenerator.Emit(OpCodes.Ceq);
+                break;
+
+            case BinaryOperatorKind.Inequality:
+                ILGenerator.Emit(OpCodes.Ceq);
+                ILGenerator.Emit(OpCodes.Ldc_I4_0);
+                ILGenerator.Emit(OpCodes.Ceq);
+                break;
+
+            case BinaryOperatorKind.GreaterThan:
+                ILGenerator.Emit(OpCodes.Cgt);
+                break;
+
+            case BinaryOperatorKind.LessThan:
+                ILGenerator.Emit(OpCodes.Clt);
+                break;
+
+            case BinaryOperatorKind.GreaterThanOrEqual:
+                ILGenerator.Emit(OpCodes.Clt);
+                ILGenerator.Emit(OpCodes.Ldc_I4_0);
+                ILGenerator.Emit(OpCodes.Ceq);
+                break;
+
+            case BinaryOperatorKind.LessThanOrEqual:
+                ILGenerator.Emit(OpCodes.Cgt);
+                ILGenerator.Emit(OpCodes.Ldc_I4_0);
+                ILGenerator.Emit(OpCodes.Ceq);
+                break;
+
             default:
-                throw new InvalidOperationException("Invalid operator kind");
+                throw new InvalidOperationException($"Invalid operator kind '{op.OperatorKind}'");
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the expression emitter handles equality and relational binary operators
- add a lambda code generation regression test that exercises a boolean comparison

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "Lambda_ComparisonExpression_ReturnsExpectedResults"

------
https://chatgpt.com/codex/tasks/task_e_68d84348b210832fb36370a8aeb1a5eb