### PR TITLE
Fix NullReferenceException when binding for expressions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1882,7 +1882,9 @@ partial class BlockBinder : Binder
 
         var body = loopBinder.BindExpressionInLoop(forExpression.Body, _allowReturnsInExpression) as BoundExpression;
 
-        return new BoundForExpression(local, collection, body!);
+        var unitType = Compilation.GetSpecialType(SpecialType.System_Unit);
+
+        return new BoundForExpression(local, collection, body!, unitType);
     }
 
     private BoundExpression BindMemberAccessExpression(MemberAccessExpressionSyntax memberAccess)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundForExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundForExpression.cs
@@ -8,8 +8,8 @@ internal partial class BoundForExpression : BoundExpression
     public BoundExpression Collection { get; }
     public BoundExpression Body { get; }
 
-    public BoundForExpression(ILocalSymbol local, BoundExpression collection, BoundExpression body)
-        : base((collection.Type.GetElementType() ?? collection.Type).ContainingAssembly.GetTypeByMetadataName("System.Unit"), null, BoundExpressionReason.None)
+    public BoundForExpression(ILocalSymbol local, BoundExpression collection, BoundExpression body, ITypeSymbol unitType)
+        : base(unitType, null, BoundExpressionReason.None)
     {
         Local = local;
         Collection = collection;


### PR DESCRIPTION
## Summary
- avoid deriving the `System.Unit` type for `BoundForExpression` from the collection's assembly
- provide the compilation's unit type from the binder when creating a `BoundForExpression`

## Testing
- dotnet run --project src/Raven.Compiler -- samples/linq.rav -o test.dll *(fails: existing build errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8751cd774832f90d29a2d1c5f20af