### PR TITLE
Teach lambda inference about extension receivers

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -2130,6 +2130,7 @@ partial class BlockBinder : Binder
                             }
 
                             IMethodSymbol? targetMethod = null;
+                            var targetUsesImplicitExtension = false;
                             var argumentExpression = arg.Expression;
 
                             if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
@@ -2137,16 +2138,25 @@ partial class BlockBinder : Binder
                                 var boundMember = BindMemberAccessExpression(memberAccess);
                                 if (boundMember is BoundMethodGroupExpression methodGroup)
                                 {
-                                    var methods = FilterMethodsForLambda(methodGroup.Methods, index, argumentExpression);
-                                    RecordLambdaTargets(argumentExpression, methods, index);
+                                    var extensionReceiverImplicit = methodGroup.Receiver is not null && IsExtensionReceiver(methodGroup.Receiver);
+                                    var methods = FilterMethodsForLambda(methodGroup.Methods, index, argumentExpression, extensionReceiverImplicit);
+                                    RecordLambdaTargets(argumentExpression, methods, index, extensionReceiverImplicit);
                                     if (methods.Length == 1)
+                                    {
                                         targetMethod = methods[0];
-                                    else if (!methods.IsDefaultOrEmpty && TryGetCommonParameterType(methods, index) is ITypeSymbol common)
+                                        targetUsesImplicitExtension = extensionReceiverImplicit && targetMethod.IsExtensionMethod;
+                                    }
+                                    else if (!methods.IsDefaultOrEmpty && TryGetCommonParameterType(methods, index, extensionReceiverImplicit) is ITypeSymbol common)
                                         return common;
                                 }
-                                else if (boundMember is BoundMemberAccessExpression { Member: IMethodSymbol m })
+                                else if (boundMember is BoundMemberAccessExpression { Receiver: var receiver, Member: IMethodSymbol m })
                                 {
+                                    var extensionReceiverImplicit = receiver is not null && IsExtensionReceiver(receiver);
                                     targetMethod = m;
+                                    targetUsesImplicitExtension = extensionReceiverImplicit && m.IsExtensionMethod;
+                                    RecordLambdaTargets(argumentExpression, ImmutableArray.Create(m), index, extensionReceiverImplicit);
+                                    if (TryGetLambdaParameter(m, index, extensionReceiverImplicit, out var parameter))
+                                        return parameter.Type;
                                 }
                             }
                             else if (invocation.Expression is MemberBindingExpressionSyntax memberBinding)
@@ -2154,16 +2164,25 @@ partial class BlockBinder : Binder
                                 var boundMember = BindMemberBindingExpression(memberBinding);
                                 if (boundMember is BoundMethodGroupExpression methodGroup)
                                 {
-                                    var methods = FilterMethodsForLambda(methodGroup.Methods, index, argumentExpression);
-                                    RecordLambdaTargets(argumentExpression, methods, index);
+                                    var extensionReceiverImplicit = methodGroup.Receiver is not null && IsExtensionReceiver(methodGroup.Receiver);
+                                    var methods = FilterMethodsForLambda(methodGroup.Methods, index, argumentExpression, extensionReceiverImplicit);
+                                    RecordLambdaTargets(argumentExpression, methods, index, extensionReceiverImplicit);
                                     if (methods.Length == 1)
+                                    {
                                         targetMethod = methods[0];
-                                    else if (!methods.IsDefaultOrEmpty && TryGetCommonParameterType(methods, index) is ITypeSymbol common)
+                                        targetUsesImplicitExtension = extensionReceiverImplicit && targetMethod.IsExtensionMethod;
+                                    }
+                                    else if (!methods.IsDefaultOrEmpty && TryGetCommonParameterType(methods, index, extensionReceiverImplicit) is ITypeSymbol common)
                                         return common;
                                 }
-                                else if (boundMember is BoundMemberAccessExpression { Member: IMethodSymbol m })
+                                else if (boundMember is BoundMemberAccessExpression { Receiver: var receiver, Member: IMethodSymbol m })
                                 {
+                                    var extensionReceiverImplicit = receiver is not null && IsExtensionReceiver(receiver);
                                     targetMethod = m;
+                                    targetUsesImplicitExtension = extensionReceiverImplicit && m.IsExtensionMethod;
+                                    RecordLambdaTargets(argumentExpression, ImmutableArray.Create(m), index, extensionReceiverImplicit);
+                                    if (TryGetLambdaParameter(m, index, extensionReceiverImplicit, out var parameter))
+                                        return parameter.Type;
                                 }
                             }
                             else if (invocation.Expression is IdentifierNameSyntax id)
@@ -2174,25 +2193,27 @@ partial class BlockBinder : Binder
                                 var accessible = GetAccessibleMethods(candidates, id.Identifier.GetLocation(), reportIfInaccessible: false);
 
                                 if (!accessible.IsDefaultOrEmpty)
-                                    accessible = FilterMethodsForLambda(accessible, index, argumentExpression);
+                                    accessible = FilterMethodsForLambda(accessible, index, argumentExpression, extensionReceiverImplicit: false);
 
-                                RecordLambdaTargets(argumentExpression, accessible, index);
+                                RecordLambdaTargets(argumentExpression, accessible, index, extensionReceiverImplicit: false);
 
                                 if (accessible.Length == 1)
                                 {
                                     targetMethod = accessible[0];
+                                    targetUsesImplicitExtension = false;
                                 }
                                 else if (!accessible.IsDefaultOrEmpty)
                                 {
-                                    if (TryGetCommonParameterType(accessible, index) is ITypeSymbol common)
+                                    if (TryGetCommonParameterType(accessible, index, extensionReceiverImplicit: false) is ITypeSymbol common)
                                         return common;
                                 }
                             }
 
                             if (targetMethod is not null && targetMethod.Parameters.Length > index)
                             {
-                                RecordLambdaTargets(argumentExpression, ImmutableArray.Create(targetMethod), index);
-                                return targetMethod.Parameters[index].Type;
+                                RecordLambdaTargets(argumentExpression, ImmutableArray.Create(targetMethod), index, targetUsesImplicitExtension);
+                                if (TryGetLambdaParameter(targetMethod, index, targetUsesImplicitExtension, out var parameter))
+                                    return parameter.Type;
                             }
                         }
 
@@ -2221,7 +2242,11 @@ partial class BlockBinder : Binder
         return ImmutableArray<INamedTypeSymbol>.Empty;
     }
 
-    private void RecordLambdaTargets(ExpressionSyntax argumentExpression, ImmutableArray<IMethodSymbol> methods, int parameterIndex)
+    private void RecordLambdaTargets(
+        ExpressionSyntax argumentExpression,
+        ImmutableArray<IMethodSymbol> methods,
+        int parameterIndex,
+        bool extensionReceiverImplicit = false)
     {
         if (argumentExpression is not LambdaExpressionSyntax lambda || methods.IsDefaultOrEmpty)
         {
@@ -2234,10 +2259,10 @@ partial class BlockBinder : Binder
 
         foreach (var method in methods)
         {
-            if (method.Parameters.Length <= parameterIndex)
+            if (!TryGetLambdaParameter(method, parameterIndex, extensionReceiverImplicit, out var parameter))
                 continue;
 
-            if (method.Parameters[parameterIndex].Type is INamedTypeSymbol delegateType && delegateType.TypeKind == TypeKind.Delegate)
+            if (parameter.Type is INamedTypeSymbol delegateType && delegateType.TypeKind == TypeKind.Delegate)
             {
                 if (!builder.Any(existing => SymbolEqualityComparer.Default.Equals(existing, delegateType)))
                     builder.Add(delegateType);
@@ -3191,7 +3216,39 @@ partial class BlockBinder : Binder
         return new BoundErrorExpression(Compilation.ErrorTypeSymbol, null, BoundExpressionReason.OverloadResolutionFailed);
     }
 
-    private ITypeSymbol? TryGetCommonParameterType(ImmutableArray<IMethodSymbol> candidates, int index)
+    private static bool TryGetLambdaParameter(
+        IMethodSymbol method,
+        int argumentIndex,
+        bool extensionReceiverImplicit,
+        out IParameterSymbol? parameter)
+    {
+        var parameterIndex = GetLambdaParameterIndex(method, argumentIndex, extensionReceiverImplicit);
+
+        if (parameterIndex < 0 || parameterIndex >= method.Parameters.Length)
+        {
+            parameter = null;
+            return false;
+        }
+
+        parameter = method.Parameters[parameterIndex];
+        return true;
+    }
+
+    private static int GetLambdaParameterIndex(
+        IMethodSymbol method,
+        int argumentIndex,
+        bool extensionReceiverImplicit)
+    {
+        if (method.IsExtensionMethod && extensionReceiverImplicit)
+            return argumentIndex + 1;
+
+        return argumentIndex;
+    }
+
+    private ITypeSymbol? TryGetCommonParameterType(
+        ImmutableArray<IMethodSymbol> candidates,
+        int index,
+        bool extensionReceiverImplicit = false)
     {
         if (candidates.IsDefaultOrEmpty)
             return null;
@@ -3200,10 +3257,10 @@ partial class BlockBinder : Binder
 
         foreach (var candidate in candidates)
         {
-            if (candidate.Parameters.Length <= index)
+            if (!TryGetLambdaParameter(candidate, index, extensionReceiverImplicit, out var parameter))
                 return null;
 
-            var candidateType = candidate.Parameters[index].Type;
+            var candidateType = parameter.Type;
 
             if (parameterType is null)
             {
@@ -3221,7 +3278,8 @@ partial class BlockBinder : Binder
     private ImmutableArray<IMethodSymbol> FilterMethodsForLambda(
         ImmutableArray<IMethodSymbol> methods,
         int parameterIndex,
-        ExpressionSyntax argumentExpression)
+        ExpressionSyntax argumentExpression,
+        bool extensionReceiverImplicit)
     {
         if (methods.IsDefaultOrEmpty)
             return methods;
@@ -3240,10 +3298,10 @@ partial class BlockBinder : Binder
 
         foreach (var method in methods)
         {
-            if (method.Parameters.Length <= parameterIndex)
+            if (!TryGetLambdaParameter(method, parameterIndex, extensionReceiverImplicit, out var parameter))
                 continue;
 
-            var parameterType = method.Parameters[parameterIndex].Type;
+            var parameterType = parameter.Type;
             if (parameterType is INamedTypeSymbol delegateType && delegateType.TypeKind == TypeKind.Delegate)
             {
                 var invoke = delegateType.GetDelegateInvokeMethod();


### PR DESCRIPTION
## Summary
- teach `GetTargetType` and the lambda-target cache to account for implicit extension receivers when collecting delegate candidates
- reuse the new helper when filtering, deduplicating, and materializing lambda parameter types so extension methods line up with the user-visible argument order
- add coverage that `Where(value => value > 0)` surfaces the delegate shapes from metadata-only extension methods

## Testing
- (cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f)
- (cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/BoundNodeGenerator -- -f)
- (cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/DiagnosticsGenerator -- -f)
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --logger "console;verbosity=minimal" *(fails: Raven.CodeAnalysis.Semantics.Tests.ObjectCreationTests.InvocationFallsBackToConstructorWhenMethodNotApplicable)*

------
https://chatgpt.com/codex/tasks/task_e_68d874b63cd4832fadcca50d6b4f0e5e