### PR TITLE
Add array interface compatibility tests

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
@@ -209,6 +209,22 @@ class Foo : IDisposable {
     }
 
     [Fact]
+    public void ReferenceConversion_ArrayToGenericIEnumerable_IsImplicit()
+    {
+        var compilation = CreateCompilation();
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var arrayType = compilation.CreateArrayTypeSymbol(intType);
+        var enumerableDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1")!;
+        var enumerableOfInt = (INamedTypeSymbol)enumerableDefinition.Construct(intType);
+
+        var conversion = compilation.ClassifyConversion(arrayType, enumerableOfInt);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.True(conversion.IsReference);
+    }
+
+    [Fact]
     public void ReferenceConversion_SourceInterfaceVariance_IsImplicit()
     {
         var source = """

--- a/test/Raven.CodeAnalysis.Tests/Symbols/TypeSymbolInterfacesTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/TypeSymbolInterfacesTests.cs
@@ -21,6 +21,28 @@ public class TypeSymbolInterfacesTests
     }
 
     [Fact]
+    public void Array_AllInterfaces_IncludesIEnumerableT()
+    {
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var array = compilation.CreateArrayTypeSymbol(intType);
+
+        Assert.Contains(
+            array.AllInterfaces,
+            i =>
+            {
+                var typeArguments = i.TypeArguments;
+                return i.Name == "IEnumerable"
+                    && !typeArguments.IsDefault
+                    && typeArguments.Length == 1
+                    && SymbolEqualityComparer.Default.Equals(typeArguments[0], intType);
+            });
+        Assert.NotEmpty(array.Interfaces);
+    }
+
+    [Fact]
     public void Interfaces_ExcludeInheritedInterfaces()
     {
         var source = @"interface IA {} interface IB : IA {} class C : IB {}";


### PR DESCRIPTION
## Summary
- add a unit test ensuring array type symbols expose the generic IEnumerable interface
- add a conversion test verifying arrays are implicitly convertible to IEnumerable<T>

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~TypeSymbolInterfacesTests
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~ReferenceConversion_ArrayToGenericIEnumerable_IsImplicit

------
https://chatgpt.com/codex/tasks/task_e_68d8eccb30f0832f8dd4f0e86c9f5213