### PR TITLE
Skip error-typed arguments during overload inference

### DIFF
--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -129,6 +129,9 @@ internal sealed class OverloadResolver
             if (argumentType is null)
                 continue;
 
+            if (argumentType.TypeKind == TypeKind.Error)
+                continue;
+
             if (!TryInferFromTypes(compilation, parameters[parameterIndex].Type, argumentType, substitutions))
                 return null;
         }


### PR DESCRIPTION
## Summary
- avoid feeding error-typed invocation arguments into generic method inference so extension methods can be resolved correctly

## Testing
- dotnet run --project src/Raven.Compiler -- samples/linq.rav -o test.dll
- dotnet build *(fails: Raven.CodeAnalysis.Tests/ClassifyConversionTests references undefined intType)*

------
https://chatgpt.com/codex/tasks/task_e_68d8efaec4d4832fba794a438a86bbc7