### PR TITLE
Document LINQ extension lambda failures

### DIFF
--- a/docs/compiler/design/extension-methods-plan.md
+++ b/docs/compiler/design/extension-methods-plan.md
@@ -28,25 +28,27 @@ observed when compiling LINQ-heavy samples.
    pipeline trace, confirming no metadata-only gaps before we attempt
    Raven-authored declarations.【F:docs/compiler/design/extension-methods-metadata-pipeline.md†L1-L33】
 4. 🛑 Blocker: teach lambda binding to surface delegate shapes even when overload
-   resolution has multiple candidates.
-   1. ✅ Extended `GetTargetType` so that lambda arguments keep every viable
+   resolution has multiple candidates. Running
+   `src/Raven.Compiler/samples/linq.rav` still reports `RAV1501` and `RAV2200`,
+   so the delegate replay work has not landed in the CLI yet.【395e77†L1-L7】
+   1. 🛠️ Extend `GetTargetType` so that lambda arguments keep every viable
       delegate candidate even when overload resolution hasn't picked a winner,
       allowing ambiguous extension groups to feed `BindLambdaExpression` the
-      full delegate set.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L2091-L2223】【F:test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs†L625-L679】
-   2. ✅ Updated `BindLambdaExpression` so lambdas capture every candidate
+      full delegate set.
+   2. 🛠️ Update `BindLambdaExpression` so lambdas capture every candidate
       delegate, stash suppressed `RAV2200` diagnostics, and surface a
       `BoundUnboundLambda` payload that overload resolution can replay in the
-      next step.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L1082-L1265】【F:src/Raven.CodeAnalysis/BoundTree/BoundUnboundLambda.cs†L1-L43】
-   3. ✅ Replay lambda binding across overload candidates.
-      1. ✅ Adjusted overload resolution and delegate conversions to rebind
+      next step.
+   3. 🛠️ Replay lambda binding across overload candidates.
+      1. 🛠️ Adjust overload resolution and delegate conversions to rebind
          lambdas under each candidate delegate, mirroring Roslyn's
          `UnboundLambda` pipeline while preserving suppression behavior.
-      2. ✅ Captured lambda replay perf counters so we can monitor cache hit
+      2. 🛠️ Capture lambda replay perf counters so we can monitor cache hit
          rates, rebind attempts, and success ratios while iterating on
          multi-pass binding behavior.
-   4. ✅ Captured semantic tests against both `System.Linq.Enumerable.Where` and
+   4. 🛠️ Capture semantic tests against both `System.Linq.Enumerable.Where` and
       the Raven LINQ fixture to prove implicit lambda parameters bind without
-      diagnostics.【F:test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs†L245-L280】【F:test/Raven.CodeAnalysis.Tests/Semantics/MetadataExtensionMethodSemanticTests.cs†L354-L398】
+      diagnostics.
    5. 📐 Add a binder integration test that covers nested lambdas (e.g. `Select`
       with a trailing `Where`) to ensure delegate replay composes.
 5. Validate end-to-end lowering/execution by compiling a LINQ-heavy sample with

--- a/docs/lang/spec/dotnet-implementation.md
+++ b/docs/lang/spec/dotnet-implementation.md
@@ -17,6 +17,12 @@ first argument. For example, `items.Where(predicate)` lowers to
 `Enumerable.Where(items, predicate)` in IL. Accessibility is enforced prior to
 rewriting, so the emitted call is always valid for the imported method.
 
+> **Implementation status:** The current CLI cannot yet recognize metadata
+> extensions when the invocation supplies a lambda argument. Compiling
+> `samples/linq.rav` still reports `RAV1501` (“No overload for method 'Where'
+> takes 1 arguments”) followed by `RAV2200` for the lambda parameter, so the
+> lowering described above is not exercised end-to-end.【395e77†L1-L7】
+
 ## Union types
 When emitted to .NET metadata, a union is projected as the narrowest common denominator of its members. If every member shares a base class, that base type becomes the metadata type; otherwise, `object` is used. Including `null` in the union marks the emitted type as nullable.
 


### PR DESCRIPTION
## Summary
- Document the current CLI diagnostics raised by `samples/linq.rav` when invoking `Enumerable.Where` with a lambda and note that explicit annotations still fail.
- Update the extension-methods plan to reopen the lambda replay work and record the failing sample output.
- Add an implementation-status caveat to the language spec so readers know extension method lowering does not yet work with lambda arguments.

## Testing
- Not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8fa562958832faf25814d6643e2e2