### PR TITLE
Document metadata load context requirements for code generation

### DIFF
--- a/docs/compiler/development/code-generation.md
+++ b/docs/compiler/development/code-generation.md
@@ -1,0 +1,10 @@
+# Code generation notes
+
+When emitting IL we must resolve CLR metadata types through the same `MetadataLoadContext` used by the compiler.
+
+- Always obtain runtime type symbols via the symbols API or the `CoreAssembly` helpers so they originate from the metadata context hosting the reference assemblies.
+- Avoid using `typeof(...)` when you need a `Type` handle in the emitter. `typeof` binds against the compiler host's runtime and the resulting symbol will not match the metadata context.
+- If you start from an `ITypeSymbol`, use `GetClrType()` to map the symbol into the `MetadataLoadContext` before passing it to the IL generator.
+- Every type, method, and field reference emitted into IL must ultimately resolve through the `MetadataLoadContext`; mixing contexts will produce invalid handles or missing members at runtime.
+
+Following these rules keeps the code generator consistent with the metadata snapshot supplied to `MetadataLoadContext` and ensures we emit IL using the correct reference assemblies.

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -52,6 +52,8 @@
       href: development/common-problems.md
     - name: Debugging
       href: development/debugging.md
+    - name: Code generation notes
+      href: development/code-generation.md
     - name: Source generation
       href: development/source-generation.md
     - name: Node generator


### PR DESCRIPTION
## Summary
- add documentation that explains resolving CLR metadata types via MetadataLoadContext when emitting IL
- link the new guidance in the compiler development table of contents

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d8fe245bcc832f9e0f5246e4834676