### PR TITLE
Fix self member access completions

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
@@ -212,7 +212,8 @@ class Foo : IDisposable {
     public void ReferenceConversion_ArrayToGenericIEnumerable_IsImplicit()
     {
         var compilation = CreateCompilation();
-        var arrayType = compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Int32));
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var arrayType = compilation.CreateArrayTypeSymbol(intType);
         var enumerableDefinition = (INamedTypeSymbol)compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1")!;
         var enumerableOfInt = (INamedTypeSymbol)enumerableDefinition.Construct(intType);
 


### PR DESCRIPTION
## Summary
- ensure member-access completion falls back to the containing instance when accessing `self`
- repair the nullable enumerable conversion test by declaring the missing `intType` local

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --no-restore *(fails: existing issues in SymbolDisplayOptionTests, LambdaInferenceTests, EntryPointDiagnosticsTests; same failures occur on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ff1a919c832f8dd5b14f77e567bc