### PR TITLE
Document extension method fixture status

### DIFF
--- a/docs/compiler/design/extension-methods-metadata-pipeline.md
+++ b/docs/compiler/design/extension-methods-metadata-pipeline.md
@@ -52,3 +52,12 @@ shapes through overload resolution. We'll return to lowering coverage once the
 new binder plumbing lands so we can record a successful trace for `Where` as
 well.【F:docs/compiler/design/extension-methods-baseline.md†L52-L104】【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L1056-L1109】
 
+## Regression status
+
+* 2025-09-28 — Running `dotnet test test/Raven.CodeAnalysis.Tests` keeps the
+  metadata-backed `ExtensionMethodsFixture` green, confirming the semantic trace
+  above still reflects the current implementation. The broader suite currently
+  fails earlier in `GlobalForEach_AnalyzesAsImperativeLoop`, so the extension
+  method plan remains blocked on the lambda inference work captured in Stage 2
+  even though the dedicated fixture continues to pass.【a0a663†L1-L2】【acbd56†L13-L33】
+


### PR DESCRIPTION
## Summary
- record the current regression status of the metadata extension method pipeline
- note that the extension method fixture still passes while the suite fails earlier in global statement data flow

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: GlobalForEach_AnalyzesAsImperativeLoop Shouldly assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68d9029ab8a8832fa7da6865a24e1c70