### PR TITLE
Fix spans for interpolated strings with escapes

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -1016,7 +1016,11 @@ internal class ExpressionSyntaxParser : SyntaxParser
 
             var decoded = SyntaxFacts.DecodeStringLiteralContent(segmentRaw.AsSpan(), out _);
             var interned = string.Intern(decoded);
-            contents.Add(InterpolatedStringText(new SyntaxToken(SyntaxKind.StringLiteralToken, interned, interned, interned.Length)));
+            contents.Add(InterpolatedStringText(new SyntaxToken(
+                SyntaxKind.StringLiteralToken,
+                interned,
+                interned,
+                segmentRaw.Length)));
         }
     }
 

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/InterpolatedStringTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Raven.CodeAnalysis.Syntax;
 using Xunit;
@@ -104,5 +105,22 @@ public class InterpolatedStringTests
                 var trailing = Assert.IsType<InterpolatedStringTextSyntax>(third);
                 Assert.Equal("'" + "\t", trailing.Token.ValueText);
             });
+    }
+
+    [Fact]
+    public void InterpolatedStringText_SpansAccountForEscapes()
+    {
+        var source = """
+let text = "value"
+let message = "Saw \"${text}\""
+let result = describe(null)
+""";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var invocation = root.DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+
+        var expectedStart = source.IndexOf("describe(null)", StringComparison.Ordinal);
+        Assert.Equal(expectedStart, invocation.Span.Start);
+        Assert.Equal("describe(null)".Length, invocation.Span.Length);
     }
 }


### PR DESCRIPTION
## Summary
- adjust interpolated string text tokens to use the raw segment length when building syntax
- add a regression test ensuring spans after escaped content remain aligned

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter InterpolatedStringTests

------
https://chatgpt.com/codex/tasks/task_e_68d909dbd6a0832fa854930dd13f1d8c