### PR TITLE
Lower match expressions during lowering

### DIFF
--- a/docs/compiler/design/lowering.md
+++ b/docs/compiler/design/lowering.md
@@ -60,7 +60,7 @@ Even without an IR in place today, several implemented features assume that a lo
 * Rewriting each arm into cascaded `if`/`else` statements (or a switch) that preserves the source ordering and fall-through semantics.
 * Ensuring that bindings introduced by the pattern remain scoped to the guard and arm expression, matching the specification's flow rules.
 
-This transformation lets the binder and emitter operate on the simpler `if`/`else` and assignment constructs they already understand while keeping exhaustiveness diagnostics intact.
+This transformation lets the binder and emitter operate on the simpler `if`/`else` and assignment constructs they already understand while keeping exhaustiveness diagnostics intact. The concrete shape we emit today is captured in [Lowering strategy for `match` expressions](match-expression-lowering.md).
 
 ### Null-conditional access
 

--- a/docs/compiler/design/match-expression-lowering.md
+++ b/docs/compiler/design/match-expression-lowering.md
@@ -1,0 +1,24 @@
+# Lowering strategy for `match` expressions
+
+Raven lowers a bound `match` expression into an expression-bodied block so that control
+flow and code generation can rely on more primitive constructs. The block performs the
+following steps:
+
+1. **Evaluate the scrutinee once.** The lowerer synthesizes a read-only temporary local
+   (named `match_scrutinee`) that captures the incoming scrutinee expression to prevent
+   duplicated side effects.
+2. **Declare a mutable result slot.** Another synthesized local (`match_result`) stores
+   the chosen arm's value. It is initialized to the default for the target type and
+   updated when an arm is selected.
+3. **Test each arm in order.** For every arm the lowerer rewrites the bound pattern into
+   an `is pattern` test against the scrutinee local. Guards are preserved by wrapping the
+   arm body inside an `if` statement when present.
+4. **Assign the arm value and break.** When an arm matches, its expression is converted to
+   the overall match type if required, stored into the result local, and the block jumps
+   to a synthesized `match_end` label.
+5. **Yield the computed result.** After visiting all arms, the end label is emitted and the
+   result local is the final expression value of the block.
+
+This structure ensures that all existing lowering passes and the statement emitter can
+operate on `match` expressions without special cases while preserving short-circuiting
+semantics and type conversions.

--- a/docs/compiler/toc.yml
+++ b/docs/compiler/toc.yml
@@ -28,6 +28,8 @@
       href: design/semantic-analysis.md
     - name: Lowering
       href: design/lowering.md
+    - name: Match expression lowering
+      href: design/match-expression-lowering.md
     - name: Symbols
       href: design/symbols.md
     - name: Spans

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -87,6 +87,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundMethodGroupExpression methodGroup => (BoundExpression)VisitMethodGroupExpression(methodGroup)!,
             BoundTypeOfExpression typeOfExpression => (BoundExpression)VisitTypeOfExpression(typeOfExpression)!,
             BoundTypeExpression typeExpression => (BoundExpression)VisitTypeExpression(typeExpression)!,
+            BoundMatchExpression matchExpression => (BoundExpression)VisitMatchExpression(matchExpression)!,
             _ => throw new NotImplementedException($"Unhandled expression: {node.GetType().Name}"),
         };
     }

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.MatchExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.MatchExpression.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class Lowerer
+{
+    public override BoundNode? VisitMatchExpression(BoundMatchExpression node)
+    {
+        var compilation = GetCompilation();
+        var booleanType = compilation.GetSpecialType(SpecialType.System_Boolean);
+        var unitType = compilation.GetSpecialType(SpecialType.System_Unit);
+
+        var scrutinee = (BoundExpression)VisitExpression(node.Expression)!;
+        var scrutineeType = scrutinee.Type ?? compilation.ErrorTypeSymbol;
+        var scrutineeLocal = CreateTempLocal("match_scrutinee", scrutineeType, isMutable: false);
+
+        var statements = new List<BoundStatement>
+        {
+            new BoundLocalDeclarationStatement([
+                new BoundVariableDeclarator(scrutineeLocal, scrutinee)
+            ])
+        };
+
+        var resultType = node.Type ?? compilation.ErrorTypeSymbol;
+        var resultLocal = CreateTempLocal("match_result", resultType, isMutable: true);
+        statements.Add(new BoundLocalDeclarationStatement([
+            new BoundVariableDeclarator(resultLocal, initializer: null)
+        ]));
+
+        var endLabel = CreateLabel("match_end");
+
+        foreach (var arm in node.Arms)
+        {
+            var pattern = (BoundPattern)VisitPattern(arm.Pattern);
+            var guard = (BoundExpression?)VisitExpression(arm.Guard);
+            var expression = (BoundExpression)VisitExpression(arm.Expression)!;
+
+            expression = ApplyConversionIfNeeded(expression, resultType, compilation);
+
+            BoundStatement armResult = new BoundBlockStatement([
+                new BoundExpressionStatement(new BoundLocalAssignmentExpression(resultLocal, expression)),
+                new BoundGotoStatement(endLabel)
+            ]);
+
+            if (guard is not null)
+            {
+                armResult = new BoundIfStatement(guard, armResult, null);
+            }
+
+            var condition = new BoundIsPatternExpression(
+                new BoundLocalAccess(scrutineeLocal),
+                pattern,
+                booleanType);
+
+            statements.Add(new BoundIfStatement(condition, armResult, null));
+        }
+
+        statements.Add(CreateLabelStatement(endLabel));
+        statements.Add(new BoundExpressionStatement(new BoundLocalAccess(resultLocal)));
+
+        return new BoundBlockExpression(statements, unitType);
+    }
+}


### PR DESCRIPTION
## Summary
- update the rewriter dispatcher so match expressions flow through the lowering pipeline
- lower match expressions into block expressions that evaluate the scrutinee once, test each arm with guards, and assign the result via temporaries

## Testing
- DOTNET_CLI_USE_TERMINAL_LOGGER=0 dotnet build
- DOTNET_CLI_USE_TERMINAL_LOGGER=0 dotnet test test/Raven.CodeAnalysis.Tests *(fails: NullReferenceException and assertion failures in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d912632d38832f99fd67851b50a4ac