### PR TITLE
Refactor lowerer feature overrides into partials

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Blocks.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Blocks.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class Lowerer
+{
+    public override BoundNode? VisitBlockStatement(BoundBlockStatement node)
+    {
+        var statements = new List<BoundStatement>();
+
+        foreach (var statement in node.Statements)
+        {
+            statements.Add((BoundStatement)VisitStatement(statement));
+        }
+
+        return new BoundBlockStatement(statements, node.LocalsToDispose);
+    }
+
+    public override BoundNode? VisitIfStatement(BoundIfStatement node)
+    {
+        var condition = (BoundExpression)VisitExpression(node.Condition)!;
+        var thenStatement = (BoundStatement)VisitStatement(node.ThenNode);
+        var elseStatement = node.ElseNode is null ? null : (BoundStatement)VisitStatement(node.ElseNode);
+
+        if (elseStatement is null)
+        {
+            var endLabel = CreateLabel("if_end");
+            return new BoundBlockStatement([
+                new BoundConditionalGotoStatement(endLabel, condition, jumpIfTrue: false),
+                thenStatement,
+                CreateLabelStatement(endLabel),
+            ]);
+        }
+        else
+        {
+            var elseLabel = CreateLabel("if_else");
+            var endLabel = CreateLabel("if_end");
+            return new BoundBlockStatement([
+                new BoundConditionalGotoStatement(elseLabel, condition, jumpIfTrue: false),
+                thenStatement,
+                new BoundGotoStatement(endLabel),
+                new BoundLabeledStatement(elseLabel, elseStatement),
+                CreateLabelStatement(endLabel),
+            ]);
+        }
+    }
+}
+

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Invocation.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Invocation.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class Lowerer
+{
+    public override BoundNode? VisitInvocationExpression(BoundInvocationExpression node)
+    {
+        var receiver = (BoundExpression?)VisitExpression(node.Receiver);
+        var arguments = node.Arguments.Select(a => (BoundExpression)VisitExpression(a)!).ToArray();
+
+        BoundExpression? extensionReceiver = null;
+        if (node.ExtensionReceiver is not null)
+        {
+            extensionReceiver = ReferenceEquals(node.ExtensionReceiver, node.Receiver)
+                ? receiver
+                : (BoundExpression?)VisitExpression(node.ExtensionReceiver);
+        }
+
+        if (node.Method.IsExtensionMethod && extensionReceiver is not null)
+        {
+            var loweredArguments = new BoundExpression[arguments.Length + 1];
+            loweredArguments[0] = extensionReceiver;
+            Array.Copy(arguments, 0, loweredArguments, 1, arguments.Length);
+            return new BoundInvocationExpression(node.Method, loweredArguments, receiver: null);
+        }
+
+        return new BoundInvocationExpression(node.Method, arguments, receiver, extensionReceiver);
+    }
+}
+

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Loops.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Loops.cs
@@ -1,0 +1,44 @@
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class Lowerer
+{
+    public override BoundNode? VisitWhileStatement(BoundWhileStatement node)
+    {
+        var breakLabel = CreateLabel("while_break");
+        var continueLabel = CreateLabel("while_continue");
+
+        var condition = (BoundExpression)VisitExpression(node.Condition)!;
+
+        _loopStack.Push((breakLabel, continueLabel));
+        var body = (BoundStatement)VisitStatement(node.Body);
+        _loopStack.Pop();
+
+        return new BoundBlockStatement([
+            new BoundLabeledStatement(continueLabel, new BoundBlockStatement([
+                new BoundConditionalGotoStatement(breakLabel, condition, jumpIfTrue: false),
+            ])),
+            body,
+            new BoundGotoStatement(continueLabel, isBackward: true),
+            CreateLabelStatement(breakLabel),
+        ]);
+    }
+
+    public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
+    {
+        if (_loopStack.Count == 0)
+            return base.VisitBreakStatement(node);
+
+        var (breakLabel, _) = _loopStack.Peek();
+        return new BoundGotoStatement(breakLabel);
+    }
+
+    public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
+    {
+        if (_loopStack.Count == 0)
+            return base.VisitContinueStatement(node);
+
+        var (_, continueLabel) = _loopStack.Peek();
+        return new BoundGotoStatement(continueLabel, isBackward: true);
+    }
+}
+


### PR DESCRIPTION
## Summary
- move block and conditional lowering into a dedicated `Lowerer.Blocks` partial class
- move invocation lowering into a dedicated `Lowerer.Invocation` partial class
- move loop-related lowering into a dedicated `Lowerer.Loops` partial class
- keep shared helpers and entry points in the primary `Lowerer` definition

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d916823d18832fbb4124a98ee4fbe0