### PR TITLE
Handle unrecognized bound expressions in BoundTreeRewriter

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -88,7 +88,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundTypeOfExpression typeOfExpression => (BoundExpression)VisitTypeOfExpression(typeOfExpression)!,
             BoundTypeExpression typeExpression => (BoundExpression)VisitTypeExpression(typeExpression)!,
             BoundMatchExpression matchExpression => (BoundExpression)VisitMatchExpression(matchExpression)!,
-            _ => throw new NotImplementedException($"Unhandled expression: {node.GetType().Name}"),
+            _ => node,
         };
     }
     public virtual BoundNode? VisitAssignmentExpression(BoundAssignmentExpression node) => node;


### PR DESCRIPTION
## Summary
- return unhandled bound expressions from the generic rewriter unchanged to avoid unnecessary exceptions

## Testing
- dotnet build *(fails: requires regenerated syntax/bound node sources in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d92b22630c832fa853792f775615a6