### PR TITLE
Add syntax and binding support for array types

### DIFF
--- a/docs/lang/proposals/array-type.md
+++ b/docs/lang/proposals/array-type.md
@@ -1,7 +1,5 @@
 # Proposal: Array type syntax
 
-> ⚠️ This proposal has **NOT** been implemented
-
 ## Summary
 
 Introduce `ArrayTypeSyntax` to express array types using brackets after a type name.
@@ -19,10 +17,13 @@ The element type may be a simple or fully qualified name.
 ```raven
 let numbers: Int[] = [1, 2, 3]
 let names: System.String[] = ["Tony", "Steve"]
+let matrix: Int[,] = [[1, 2], [3, 4]]
 
 fun head(values: Int[]): Int {
     return values[0]
 }
 ```
 
-Array types can be used anywhere a type is expected, including variable declarations, parameters, and return types.
+Array types can be used anywhere a type is expected, including variable declarations, parameters, and return types. Multidimensional
+arrays use commas inside the brackets (for example, `Int[,]` for a two-dimensional array), and jagged arrays repeat the bracketed
+rank specifier (for example, `Int[][,,]`).

--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -369,6 +369,19 @@ internal abstract class Binder
             return new UnionTypeSymbol(types, null, null, null, []);
         }
 
+        if (typeSyntax is ArrayTypeSyntax arrayTypeSyntax)
+        {
+            var currentElementType = ResolveType(arrayTypeSyntax.ElementType);
+
+            foreach (var rankSpecifier in arrayTypeSyntax.RankSpecifiers)
+            {
+                var rank = rankSpecifier.CommaTokens.Count + 1;
+                currentElementType = Compilation.CreateArrayTypeSymbol(currentElementType, rank);
+            }
+
+            return currentElementType;
+        }
+
         if (typeSyntax is TupleTypeSyntax tupleTypeSyntax)
         {
             var elements = tupleTypeSyntax.Elements

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -1209,10 +1209,10 @@ public class Compilation
         return assemblySymbol;
     }
 
-    public ITypeSymbol CreateArrayTypeSymbol(ITypeSymbol elementType)
+    public ITypeSymbol CreateArrayTypeSymbol(ITypeSymbol elementType, int rank = 1)
     {
         var ns = GlobalNamespace.LookupNamespace("System");
-        return new ArrayTypeSymbol(GetSpecialType(SpecialType.System_Array), elementType, ns, null, ns, []);
+        return new ArrayTypeSymbol(GetSpecialType(SpecialType.System_Array), elementType, ns, null, ns, [], rank);
     }
 
     /*

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ArrayTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ArrayTypeSymbol.cs
@@ -25,7 +25,17 @@ internal partial class ArrayTypeSymbol : PESymbol, IArrayTypeSymbol
         TypeKind = TypeKind.Array;
     }
 
-    public override string Name => $"{ElementType}[]";
+    public override string Name
+    {
+        get
+        {
+            var suffix = Rank == 1
+                ? "[]"
+                : "[" + new string(',', Rank - 1) + "]";
+
+            return $"{ElementType}{suffix}";
+        }
+    }
 
     public override SymbolKind Kind => SymbolKind.Type;
 

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -218,6 +218,15 @@
     <Slot Name="Elements" Type="SeparatedList" ElementType="TupleElement" />
     <Slot Name="CloseParenToken" Type="Token" DefaultToken="CloseParenToken"/>
   </Node>
+  <Node Name="ArrayRankSpecifier" Inherits="Node">
+    <Slot Name="OpenBracketToken" Type="Token" DefaultToken="OpenBracketToken"/>
+    <Slot Name="CommaTokens" Type="TokenList" />
+    <Slot Name="CloseBracketToken" Type="Token" DefaultToken="CloseBracketToken"/>
+  </Node>
+  <Node Name="ArrayType" Inherits="Type">
+    <Slot Name="ElementType" Type="Type" />
+    <Slot Name="RankSpecifiers" Type="List" ElementType="ArrayRankSpecifier" />
+  </Node>
   <Node Name="CollectionExpression" Inherits="Expression">
     <Slot Name="OpenBracketToken" Type="Token" DefaultToken="OpenBracketToken"/>
     <Slot Name="Elements" Type="SeparatedList" ElementType="CollectionElement" />

--- a/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
@@ -51,7 +51,9 @@ public static class TypeSymbolExtensionsForCodeGen
         if (typeSymbol is IArrayTypeSymbol arrayType)
         {
             var elementClrType = arrayType.ElementType.GetClrType(codeGen);
-            return elementClrType.MakeArrayType(); // TODO: support Rank > 1
+            return arrayType.Rank == 1
+                ? elementClrType.MakeArrayType()
+                : elementClrType.MakeArrayType(arrayType.Rank);
         }
 
         // Handle arrays

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ArrayTypeSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ArrayTypeSemanticTests.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class ArrayTypeSemanticTests : CompilationTestBase
+{
+    [Fact]
+    public void SingleDimensionalArrayTypeSyntax_BindsToArrayTypeSymbol()
+    {
+        const string source = "let values: System.String[] = []";
+        var (compilation, tree) = CreateCompilation(source);
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+
+        var typeInfo = model.GetTypeInfo(declarator.TypeAnnotation!.Type);
+        var arrayType = Assert.IsAssignableFrom<IArrayTypeSymbol>(typeInfo.Type);
+        Assert.Equal(1, arrayType.Rank);
+        Assert.Equal(SpecialType.System_String, arrayType.ElementType.SpecialType);
+    }
+
+    [Fact]
+    public void MultiDimensionalArrayTypeSyntax_BindsWithRank()
+    {
+        const string source = "let matrix: int[,]";
+        var (compilation, tree) = CreateCompilation(source);
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+
+        var typeInfo = model.GetTypeInfo(declarator.TypeAnnotation!.Type);
+        var arrayType = Assert.IsAssignableFrom<IArrayTypeSymbol>(typeInfo.Type);
+        Assert.Equal(2, arrayType.Rank);
+        Assert.Equal(SpecialType.System_Int32, arrayType.ElementType.SpecialType);
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Syntax/ArrayTypeSyntaxTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/ArrayTypeSyntaxTest.cs
@@ -1,0 +1,52 @@
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+public class ArrayTypeSyntaxTest
+{
+    [Fact]
+    public void ArrayType_WithQualifiedElementType_Parses()
+    {
+        const string code = "let names: System.String[] = []";
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var local = (LocalDeclarationStatementSyntax)((GlobalStatementSyntax)root.Members[0]).Statement!;
+        var typeSyntax = local.Declaration.Declarators[0].TypeAnnotation!.Type;
+
+        var array = Assert.IsType<ArrayTypeSyntax>(typeSyntax);
+        Assert.IsType<QualifiedNameSyntax>(array.ElementType);
+        var rankSpecifier = Assert.Single(array.RankSpecifiers);
+        Assert.Empty(rankSpecifier.CommaTokens);
+    }
+
+    [Fact]
+    public void ArrayType_WithMultiDimensionalRank_Parses()
+    {
+        const string code = "let matrix: int[,]";
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var local = (LocalDeclarationStatementSyntax)((GlobalStatementSyntax)root.Members[0]).Statement!;
+        var typeSyntax = local.Declaration.Declarators[0].TypeAnnotation!.Type;
+
+        var array = Assert.IsType<ArrayTypeSyntax>(typeSyntax);
+        var rankSpecifier = Assert.Single(array.RankSpecifiers);
+        Assert.Single(rankSpecifier.CommaTokens);
+    }
+
+    [Fact]
+    public void ArrayType_WithJaggedAndMultiDimensionalRanks_Parses()
+    {
+        const string code = "let values: int[][,]";
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var local = (LocalDeclarationStatementSyntax)((GlobalStatementSyntax)root.Members[0]).Statement!;
+        var typeSyntax = local.Declaration.Declarators[0].TypeAnnotation!.Type;
+
+        var array = Assert.IsType<ArrayTypeSyntax>(typeSyntax);
+        Assert.Collection(
+            array.RankSpecifiers,
+            first => Assert.Empty(first.CommaTokens),
+            second => Assert.Single(second.CommaTokens));
+    }
+}


### PR DESCRIPTION
## Summary
- add ArrayType syntax nodes and parse array suffixes, including multidimensional rank specifiers
- bind array types with rank-aware symbols and update codegen array type resolution
- document array type usage and add syntax/semantic regression tests

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --filter "ArrayType"


------
https://chatgpt.com/codex/tasks/task_e_68d93fd88100832f8f03b31a7580bba9