### PR TITLE
Handle null type syntax in match patterns

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -2490,6 +2490,11 @@ partial class BlockBinder : Binder
 
     protected BoundExpression BindTypeSyntax(TypeSyntax syntax)
     {
+        if (syntax is NullTypeSyntax)
+        {
+            return new BoundTypeExpression(Compilation.NullTypeSymbol);
+        }
+
         if (syntax is LiteralTypeSyntax literalType)
         {
             var token = literalType.Token;


### PR DESCRIPTION
## Summary
- bind `NullTypeSyntax` to the compiler's null type so exhaustiveness analysis recognizes explicit null arms in match expressions

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter MatchExpression_WithUnionScrutineeAndGuard_NotExhaustiveWithoutCatchAll

------
https://chatgpt.com/codex/tasks/task_e_68d94a7a4834832f9c876d1fadcd2daf