### PR TITLE
Fix null literal coverage for match exhaustiveness

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1854,6 +1854,19 @@ partial class BlockBinder : Binder
                 {
                     var literalType = UnwrapAlias(constant.LiteralType);
 
+                    if (constant.ConstantValue is null)
+                    {
+                        foreach (var candidate in remaining.ToArray())
+                        {
+                            var candidateType = UnwrapAlias(candidate);
+
+                            if (candidateType.TypeKind == TypeKind.Null)
+                                remaining.Remove(candidate);
+                        }
+
+                        break;
+                    }
+
                     foreach (var candidate in remaining.ToArray())
                     {
                         var candidateType = UnwrapAlias(candidate);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -306,6 +306,23 @@ let result = match input {
     }
 
     [Fact]
+    public void MatchExpression_WithUnionScrutineeIncludingNull_DoesNotReportMissingNull()
+    {
+        const string code = """
+let input: string | null = null
+
+let result = match input {
+    null => "Nothing to report."
+    string text => text
+}
+""";
+
+        var verifier = CreateVerifier(code);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void MatchExpression_WithIncompatiblePattern_ReportsDiagnostic()
     {
         const string code = """


### PR DESCRIPTION
## Summary
- ensure exhaustiveness analysis removes union null members when covered by a constant null pattern
- add a regression test confirming match expressions with explicit null arms compile without missing-null diagnostics

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Special type is not supported in existing test fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68d95fee3f64832f98f6176ba0c5f023