### PR TITLE
Lower lambda expressions during lowering pass

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Lambdas.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Lambdas.cs
@@ -1,0 +1,48 @@
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class Lowerer
+{
+    public override BoundNode? VisitLambdaExpression(BoundLambdaExpression node)
+    {
+        var lowered = LowerLambda(node);
+        return lowered;
+    }
+
+    private BoundLambdaExpression LowerLambda(BoundLambdaExpression lambda)
+    {
+        var containingSymbol = lambda.Symbol ?? _containingSymbol;
+
+        var loweredBody = LowerLambdaBody(lambda.Body, containingSymbol);
+
+        if (ReferenceEquals(loweredBody, lambda.Body))
+            return lambda;
+
+        var lowered = new BoundLambdaExpression(
+            lambda.Parameters,
+            lambda.ReturnType,
+            loweredBody,
+            lambda.Symbol ?? containingSymbol,
+            lambda.DelegateType,
+            lambda.CapturedVariables,
+            lambda.CandidateDelegates);
+
+        if (lambda.Unbound is { } unbound)
+            lowered.AttachUnbound(unbound);
+
+        return lowered;
+    }
+
+    private BoundExpression LowerLambdaBody(BoundExpression body, ISymbol containingSymbol)
+    {
+        if (body is BoundBlockExpression block)
+        {
+            var loweredBlock = LowerBlock(containingSymbol, new BoundBlockStatement(block.Statements, block.LocalsToDispose));
+            return new BoundBlockExpression(loweredBlock.Statements, block.UnitType, loweredBlock.LocalsToDispose);
+        }
+
+        var lambdaLowerer = new Lowerer(containingSymbol);
+        return (BoundExpression)lambdaLowerer.VisitExpression(body)!;
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/BinderAndLowererTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/BinderAndLowererTests.cs
@@ -156,4 +156,69 @@ class C {
         var breakLabel = Assert.IsType<BoundLabeledStatement>(statements[3]);
         Assert.Same(breakLabel.Label, bodyGoto.Target);
     }
+
+    [Fact]
+    public void Lowerer_LambdaBody_RewritesNestedLoop()
+    {
+        const string source = """
+class C {
+    Test(flag: bool) {
+        let lambda = func () => {
+            while flag {
+                ()
+            }
+        }
+
+        lambda()
+    }
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var methodSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.Text == "Test");
+
+        var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(methodSyntax)!;
+        var boundBody = (BoundBlockStatement)model.GetBoundNode(methodSyntax.Body!)!;
+        var loweredBody = Lowerer.LowerBlock(methodSymbol, boundBody);
+
+        var lambda = loweredBody.Statements
+            .OfType<BoundLocalDeclarationStatement>()
+            .SelectMany(s => s.Declarators)
+            .Select(d => d.Initializer)
+            .OfType<BoundLambdaExpression>()
+            .Single();
+
+        var lambdaBlock = Assert.IsType<BoundBlockExpression>(lambda.Body);
+        var inspector = new LambdaLoweringInspector();
+        inspector.VisitBlockExpression(lambdaBlock);
+
+        Assert.False(inspector.SeenWhile);
+        Assert.True(inspector.GotoCount > 0);
+    }
+
+    private sealed class LambdaLoweringInspector : BoundTreeWalker
+    {
+        public bool SeenWhile { get; private set; }
+        public int GotoCount { get; private set; }
+
+        public override void VisitWhileStatement(BoundWhileStatement node)
+        {
+            SeenWhile = true;
+        }
+
+        public override void VisitGotoStatement(BoundGotoStatement node)
+        {
+            GotoCount++;
+            base.VisitGotoStatement(node);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a lambda-specific lowering hook so nested bodies are rewritten with their own Lowerer instance
- add a regression test that exercises a loop inside a lambda and inspects the lowered tree with a custom walker

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "Lowerer_LambdaBody_RewritesNestedLoop"

------
https://chatgpt.com/codex/tasks/task_e_68d96161b790832f83016df060c9d91a