### PR TITLE
Refactor lambda lowering into dedicated helper

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/LambdaLowerer.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/LambdaLowerer.cs
@@ -1,0 +1,40 @@
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal static class LambdaLowerer
+{
+    public static BoundLambdaExpression Rewrite(BoundLambdaExpression lambda, ISymbol containingSymbol)
+    {
+        var owner = lambda.Symbol ?? containingSymbol;
+
+        var loweredBody = LowerBody(lambda.Body, owner);
+        if (ReferenceEquals(loweredBody, lambda.Body))
+            return lambda;
+
+        var lowered = new BoundLambdaExpression(
+            lambda.Parameters,
+            lambda.ReturnType,
+            loweredBody,
+            owner,
+            lambda.DelegateType,
+            lambda.CapturedVariables,
+            lambda.CandidateDelegates);
+
+        if (lambda.Unbound is { } unbound)
+            lowered.AttachUnbound(unbound);
+
+        return lowered;
+    }
+
+    private static BoundExpression LowerBody(BoundExpression body, ISymbol owner)
+    {
+        if (body is BoundBlockExpression block)
+        {
+            var loweredBlock = Lowerer.LowerBlock(owner, new BoundBlockStatement(block.Statements, block.LocalsToDispose));
+            return new BoundBlockExpression(loweredBlock.Statements, block.UnitType, loweredBlock.LocalsToDispose);
+        }
+
+        return Lowerer.LowerExpression(owner, body);
+    }
+}

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Lambdas.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Lambdas.cs
@@ -1,0 +1,11 @@
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class Lowerer
+{
+    public override BoundNode? VisitLambdaExpression(BoundLambdaExpression node)
+    {
+        return LambdaLowerer.Rewrite(node, _containingSymbol);
+    }
+}

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.cs
@@ -29,6 +29,12 @@ internal sealed partial class Lowerer : BoundTreeRewriter
         return (BoundStatement)lowerer.VisitStatement(statement);
     }
 
+    public static BoundExpression LowerExpression(ISymbol containingSymbol, BoundExpression expression)
+    {
+        var lowerer = new Lowerer(containingSymbol);
+        return (BoundExpression)lowerer.VisitExpression(expression)!;
+    }
+
     private ILabelSymbol CreateLabel(string prefix)
     {
         var name = $"{prefix}_{_labelCounter++}";


### PR DESCRIPTION
## Summary
- extract lambda lowering into a dedicated `LambdaLowerer` helper so the main lowerer delegates to localized logic
- add a reusable `LowerExpression` entry point for nested lambda bodies to reuse lowering passes
- extend the binder/lowerer tests to ensure local function statements are preserved alongside lambda lowering

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "Lowerer_LambdaBody_RewritesNestedLoop"
- dotnet test test/Raven.CodeAnalysis.Tests --filter "Lowerer_FunctionStatement_RemainsFunctionStatement"

------
https://chatgpt.com/codex/tasks/task_e_68d96161b790832f83016df060c9d91a