### PR TITLE
Document extension method consumption progress

### DIFF
--- a/docs/compiler/design/extension-methods-baseline.md
+++ b/docs/compiler/design/extension-methods-baseline.md
@@ -71,6 +71,11 @@ error RAV2200: Cannot infer the type of parameter 'value'. Specify an explicit
 type or use the lambda in a delegate-typed context
 ```
 
+> **Update (2025-05-XX).** After the delegate replay work landed, both metadata
+> and fixture-backed `Where` calls now bind without diagnostics; the CLI still
+> fails later in emission because `ExpressionGenerator` looks up delegate
+> constructors via raw reflection.【F:test/Raven.CodeAnalysis.Tests/Semantics/MetadataExtensionMethodSemanticTests.cs†L305-L399】【F:src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs†L403-L441】
+
 The first error shows that we still do not recognize metadata `Where`
 definitions as extension methods when a lambda argument is present, so overload
 resolution thinks the call is missing the `source` argument altogether. The


### PR DESCRIPTION
## Summary
- refresh the extension method consumption status to highlight the new lambda delegate replay support and built-in CLI LINQ reference
- update the support plan so Stage 2 now focuses on fixing emission under MetadataLoadContext instead of lambda binding
- annotate the baseline audit with the latest binding results and remaining emission failure

## Testing
- `dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/linq.rav --no-emit` *(fails: generator outputs not regenerated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9725cccfc832f866b0bd90a0cc429