### PR TITLE
Add tuple pattern support

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -802,6 +802,10 @@ Patterns compose from the following primitives:
 - `literal` — literal pattern; matches when the scrutinee equals the literal.
   Literal patterns piggyback on Raven's literal types, so `"on"` or `42`
   narrow unions precisely.
+- `(pattern1, pattern2, …)` — tuple pattern; matches when the scrutinee is a
+  tuple with the same arity and each element matches the corresponding
+  subpattern. Tuple patterns destructure positionally, so nested patterns may
+  test or bind each element independently.
 - `pattern1 or pattern2` — alternative; matches when either operand matches.
   Parentheses may be used to group alternatives.
 - `not pattern` — complement; succeeds when the operand fails. `not` does not

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1626,6 +1626,45 @@ partial class BlockBinder : Binder
 
                     return;
                 }
+            case BoundTuplePattern tuplePattern:
+                {
+                    var tuplePatternType = UnwrapAlias(tuplePattern.Type);
+
+                    if (tuplePatternType.TypeKind == TypeKind.Error)
+                        return;
+
+                    if (!PatternCanMatch(scrutineeType, tuplePatternType))
+                    {
+                        var patternDisplay = GetMatchPatternDisplay(tuplePatternType);
+                        _diagnostics.ReportMatchExpressionArmPatternInvalid(
+                            patternDisplay,
+                            scrutineeType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                            patternSyntax.GetLocation());
+                        return;
+                    }
+
+                    if (patternSyntax is TuplePatternSyntax tupleSyntax)
+                    {
+                        var elementTypes = GetTupleElementTypes(scrutineeType);
+
+                        if (elementTypes.Length == 0)
+                            elementTypes = GetTupleElementTypes(tuplePatternType);
+
+                        var patternElements = tuplePattern.Elements;
+                        var elementCount = Math.Min(patternElements.Length, tupleSyntax.Patterns.Count);
+
+                        for (var i = 0; i < elementCount; i++)
+                        {
+                            var elementType = elementTypes.Length > i
+                                ? elementTypes[i]
+                                : patternElements[i].Type ?? Compilation.ErrorTypeSymbol;
+
+                            EnsureMatchArmPatternValid(elementType, tupleSyntax.Patterns[i], patternElements[i]);
+                        }
+                    }
+
+                    return;
+                }
         }
     }
 
@@ -1668,6 +1707,25 @@ partial class BlockBinder : Binder
 
         return IsAssignable(patternType, scrutineeType, out _) ||
                IsAssignable(scrutineeType, patternType, out _);
+    }
+
+    private ImmutableArray<ITypeSymbol> GetTupleElementTypes(ITypeSymbol type)
+    {
+        type = UnwrapAlias(type);
+
+        if (type is INamedTypeSymbol named)
+        {
+            var elements = named.TupleElements;
+            if (!elements.IsDefaultOrEmpty)
+                return elements.Select(e => e.Type).ToImmutableArray();
+        }
+
+        if (type is ITupleTypeSymbol tuple)
+        {
+            return tuple.TupleElements.Select(e => e.Type).ToImmutableArray();
+        }
+
+        return ImmutableArray<ITypeSymbol>.Empty;
     }
 
     private void EnsureMatchArmOrder(
@@ -1835,6 +1893,24 @@ partial class BlockBinder : Binder
             case BoundOrPattern orPattern:
                 return IsCatchAllPattern(scrutineeType, orPattern.Left) ||
                        IsCatchAllPattern(scrutineeType, orPattern.Right);
+            case BoundTuplePattern tuplePattern:
+                {
+                    var elementTypes = GetTupleElementTypes(scrutineeType);
+
+                    if (elementTypes.Length == 0 && tuplePattern.Elements.Length == 0)
+                        return true;
+
+                    if (elementTypes.Length != tuplePattern.Elements.Length)
+                        return false;
+
+                    for (var i = 0; i < tuplePattern.Elements.Length; i++)
+                    {
+                        if (!IsCatchAllPattern(elementTypes[i], tuplePattern.Elements[i]))
+                            return false;
+                    }
+
+                    return true;
+                }
         }
 
         return false;
@@ -1880,6 +1956,9 @@ partial class BlockBinder : Binder
             case BoundOrPattern orPattern:
                 RemoveCoveredUnionMembers(remaining, orPattern.Left);
                 RemoveCoveredUnionMembers(remaining, orPattern.Right);
+                break;
+            case BoundTuplePattern tuplePattern:
+                RemoveMembersAssignableToPattern(remaining, tuplePattern.Type);
                 break;
         }
     }

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -536,6 +536,11 @@
     <Slot Name="Type" Type="Type" />
     <Slot Name="Designation" Type="VariableDesignation" />
   </Node>
+  <Node Name="TuplePattern" Inherits="Pattern">
+    <Slot Name="OpenParenToken" Type="Token" DefaultToken="OpenParenToken"/>
+    <Slot Name="Patterns" Type="SeparatedList" ElementType="Pattern" />
+    <Slot Name="CloseParenToken" Type="Token" DefaultToken="CloseParenToken"/>
+  </Node>
   <Node Name="EnumDeclaration" Inherits="BaseTypeDeclaration">
     <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />


### PR DESCRIPTION
## Summary
- add a `TuplePattern` node and parser support for `(pattern, …)` destructuring
- bind tuple patterns, participate in match validation, and emit runtime evaluation
- document tuple patterns in the language specification

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: RAV2200 lambda inference pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68d97647c034832f9e627d1ea0ad4a82