### PR TITLE
Fix nested namespace binding and display

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -88,8 +88,12 @@ class BinderFactory
 
     private Binder CreateNamespaceBinder(BaseNamespaceDeclarationSyntax nsSyntax, Binder parentBinder)
     {
-        var nsSymbol = _compilation.GetNamespaceSymbol(nsSyntax.Name.ToString());
-        var nsBinder = new NamespaceBinder(parentBinder, nsSymbol!);
+        var parentNamespace = parentBinder.CurrentNamespace;
+        var namespaceName = parentNamespace.QualifyName(nsSyntax.Name.ToString());
+        var nsSymbol = _compilation.GetOrCreateNamespaceSymbol(namespaceName)
+            ?? throw new InvalidOperationException($"Unable to resolve namespace '{namespaceName}'.");
+
+        var nsBinder = new NamespaceBinder(parentBinder, nsSymbol);
 
         var namespaceImports = new List<INamespaceOrTypeSymbol>();
         var typeImports = new List<ITypeSymbol>();

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -648,7 +648,8 @@ public partial class SemanticModel
             {
                 case BaseNamespaceDeclarationSyntax nsDecl:
                     {
-                        var nsSymbol = Compilation.GetOrCreateNamespaceSymbol(nsDecl.Name.ToString());
+                        var namespaceName = parentNamespace.QualifyName(nsDecl.Name.ToString());
+                        var nsSymbol = Compilation.GetOrCreateNamespaceSymbol(namespaceName);
 
                         var nsBinder = Compilation.BinderFactory.GetBinder(nsDecl, parentBinder)!;
                         _binderCache[nsDecl] = nsBinder;

--- a/src/Raven.CodeAnalysis/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/MergedNamespaceSymbol.cs
@@ -163,7 +163,7 @@ internal sealed partial class MergedNamespaceSymbol : Symbol, INamespaceSymbol
         return string.Join(".", parts);
     }
 
-    public override string ToString() => IsGlobalNamespace ? "<global>" : this.ToDisplayString();
+    public override string ToString() => IsGlobalNamespace ? "<global>" : ToMetadataName();
 
     private static IEnumerable<INamespaceSymbol> Flatten(IEnumerable<INamespaceSymbol> namespaces)
     {

--- a/src/Raven.CodeAnalysis/Symbols/PE/PENamespaceSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PENamespaceSymbol.cs
@@ -75,7 +75,7 @@ internal sealed partial class PENamespaceSymbol : PESymbol, INamespaceSymbol
         return symbol is not null;
     }
 
-    public override string ToString() => IsGlobalNamespace ? "<global>" : this.ToDisplayString();
+    public override string ToString() => IsGlobalNamespace ? "<global>" : ToMetadataName();
 
     public string ToMetadataName()
     {

--- a/src/Raven.CodeAnalysis/Symbols/Source/NamespaceSymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/NamespaceSymbolExtensions.cs
@@ -52,4 +52,19 @@ internal static class NamespaceSymbolExtensions
 
         return null;
     }
+
+    public static string QualifyName(this INamespaceSymbol? parentNamespace, string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return parentNamespace?.ToMetadataName() ?? string.Empty;
+
+        if (parentNamespace is null || parentNamespace.IsGlobalNamespace)
+            return name;
+
+        var parentMetadataName = parentNamespace.ToMetadataName();
+        if (string.IsNullOrEmpty(parentMetadataName))
+            return name;
+
+        return string.Concat(parentMetadataName, ".", name);
+    }
 }

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceNamespaceSymbol.cs
@@ -48,7 +48,7 @@ internal sealed partial class SourceNamespaceSymbol : SourceSymbol, INamespaceSy
     public ITypeSymbol? LookupType(string name) =>
         _members.OfType<ITypeSymbol>().FirstOrDefault(t => t.Name == name);
 
-    public override string ToString() => IsGlobalNamespace ? "<global>" : this.ToDisplayString();
+    public override string ToString() => IsGlobalNamespace ? "<global>" : ToMetadataName();
 
     public string ToMetadataName()
     {

--- a/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
@@ -121,8 +121,8 @@ public static partial class SymbolExtensions
         // Example: Include namespace and type qualification
         if (format.TypeQualificationStyle == SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces)
         {
-            // Assume `Namespace` and `ContainingType` are properties of the symbol
-            if (symbol.ContainingNamespace?.ContainingNamespace is not null)
+            // Append containing namespaces when present (excluding the global namespace)
+            if (symbol.ContainingNamespace is { } containingNamespace && !containingNamespace.IsGlobalNamespace)
             {
                 var ns = GetFullNamespace(symbol, format);
                 if (!string.IsNullOrEmpty(ns))


### PR DESCRIPTION
## Summary
- ensure namespace binders qualify nested declarations with their parent namespace
- update namespace symbol display helpers to return fully-qualified metadata names

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.NamespaceDirectiveTests.NamespaceDeclaration_BindsMembersInDeclaredNamespace"

------
https://chatgpt.com/codex/tasks/task_e_68da26aa2bb0832fbad77cb4e90af4e5