### PR TITLE
Add lowering coverage for extension boxing and nullability

### DIFF
--- a/docs/compiler/design/extension-methods-plan.md
+++ b/docs/compiler/design/extension-methods-plan.md
@@ -118,8 +118,10 @@ observed when compiling LINQ-heavy samples.
    the first argument to the lowered static call. Coverage now confirms lowering
    rewrites source-defined extensions into static calls with the receiver as the
    leading argument.【F:src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Invocation.cs†L8-L29】【F:test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs†L540-L609】
-2. Confirm that the lowered invocation obeys value-type boxing semantics and
-   nullability checks that C# enforces.
+2. ✅ Confirmed that lowered extension invocations preserve value-type boxing and
+   reject nullable receivers where C# would. New lowering coverage exercises the
+   boxed first argument and verifies we emit the diagnostic for `int?` receivers
+   targeting non-nullable parameters.【F:test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs†L585-L644】
 3. Prototype a lowering pass trace (behind a compiler flag) that logs when a
    call is rewritten as an extension dispatch. This will aid in validating that
    overload resolution selected the expected candidate during manual review.

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
@@ -610,6 +610,91 @@ public static class NumberExtensions {
     }
 
     [Fact]
+    public void Lowerer_ExtensionInvocation_BoxesValueTypeReceiverWhenRequired()
+    {
+        const string source = """
+import System.Runtime.CompilerServices.*
+
+class Query {
+    Run() -> object {
+        let value = 3
+        return value.ToObject()
+    }
+}
+
+public static class BoxingExtensions {
+    [ExtensionAttribute]
+    public static ToObject(x: object) -> object {
+        return x
+    }
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var methodSyntax = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.Text == "Run");
+
+        var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(methodSyntax)!;
+        var boundBody = (BoundBlockStatement)model.GetBoundNode(methodSyntax.Body!)!;
+
+        var lowered = Lowerer.LowerBlock(methodSymbol, boundBody);
+
+        var returnStatement = Assert.IsType<BoundReturnStatement>(lowered.Statements.Last());
+        var invocation = Assert.IsType<BoundInvocationExpression>(returnStatement.Expression);
+
+        Assert.True(invocation.Method.IsExtensionMethod);
+        Assert.Null(invocation.Receiver);
+
+        var arguments = invocation.Arguments.ToArray();
+        Assert.Equal(invocation.Method.Parameters.Length, arguments.Length);
+
+        var boxedReceiver = Assert.IsType<BoundCastExpression>(arguments[0]);
+        Assert.Equal(invocation.Method.Parameters[0].Type, boxedReceiver.Type);
+
+        var local = Assert.IsType<BoundLocalAccess>(boxedReceiver.Expression);
+        Assert.Equal("value", local.Local.Name);
+    }
+
+    [Fact]
+    public void ExtensionInvocation_WithNullableValueReceiver_RequiresNonNullableParameter()
+    {
+        const string source = """
+import System.Runtime.CompilerServices.*
+
+class Query {
+    Run() -> int {
+        let value: int? = null
+        return value.Double()
+    }
+}
+
+public static class NumberExtensions {
+    [ExtensionAttribute]
+    public static Double(x: int) -> int {
+        return x + x
+    }
+}
+""";
+
+        var (compilation, _) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(CompilerDiagnostics.TheNameDoesNotExistInTheCurrentContext, diagnostic.Descriptor);
+        Assert.Contains("Double", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExtensionInvocation_WithUnsatisfiedGenericConstraint_ReportsDiagnostic()
     {
         const string source = """


### PR DESCRIPTION
## Summary
- add lowering coverage that ensures extension calls box value-type receivers when required
- verify nullable receivers fail to bind when invoking non-nullable extension methods
- mark the next milestone in the extension-method plan as completed

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.ExtensionMethodSemanticTests.Lowerer_ExtensionInvocation_BoxesValueTypeReceiverWhenRequired"`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.ExtensionMethodSemanticTests.ExtensionInvocation_WithNullableValueReceiver_RequiresNonNullableParameter"`


------
https://chatgpt.com/codex/tasks/task_e_68da29b880f4832fa890f2d072c0845f