### PR TITLE
Route delegate constructors through metadata helpers

### DIFF
--- a/docs/compiler/design/extension-methods-plan.md
+++ b/docs/compiler/design/extension-methods-plan.md
@@ -4,11 +4,10 @@ This document sketches an incremental path for bringing Raven's extension method
 story to parity with C# while avoiding the MetadataLoadContext issues currently
 observed when compiling LINQ-heavy samples.
 
-> **Next step.** Route delegate construction through the metadata-aware helpers
-> so command-line builds that call metadata extensions can emit successfully.
-> With lambda binding now replaying every candidate delegate, the remaining
-> blocker for Stage&nbsp;2 is the `ExpressionGenerator` path that still uses raw
-> reflection and fails under `MetadataLoadContext`.
+> **Next step.** Add execution coverage for lambdas that invoke metadata
+> extensions so the CLI path exercises the fixed delegate construction logic.
+> Capturing `Where`/`Select` calls will prove the emitter survives extension
+> lambdas end to end before we expand into query comprehension scenarios.
 
 ## 1. Baseline assessment ✅
 
@@ -128,9 +127,10 @@ observed when compiling LINQ-heavy samples.
 
 ## 6. Code generation fixes
 
-1. Fix `ExpressionGenerator.EmitLambdaExpression` so that it resolves delegate
-   constructors using `Compilation`'s `MetadataLoadContext`-aware APIs. Avoid
-   `Type.GetConstructor` calls that introduce foreign `Type` instances.
+1. ✅ Fix `ExpressionGenerator.EmitLambdaExpression` so that it resolves
+   delegate constructors using `Compilation`'s `MetadataLoadContext`-aware
+   APIs. Avoid `Type.GetConstructor` calls that introduce foreign `Type`
+   instances.【F:src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs†L409-L482】
 2. Harden the delegate construction path by caching resolved constructors per
    `DelegateTypeSymbol` so repeated lambda emission does not incur redundant
    reflection or leak metadata handles.


### PR DESCRIPTION
## Summary
- resolve delegate constructors for lambda emission via metadata-aware symbol helpers before falling back to raw reflection, keeping constructor discovery within the compilation's metadata load context
- update the extension-methods plan to mark the constructor routing milestone complete and call out execution coverage for the next step

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: repository requires regenerated syntax bindings that are not present in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da2ce794bc832f89dd7e9e1661056b