### PR TITLE
Add try block expression support

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -88,6 +88,7 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundTypeOfExpression typeOfExpression => (BoundExpression)VisitTypeOfExpression(typeOfExpression)!,
             BoundTypeExpression typeExpression => (BoundExpression)VisitTypeExpression(typeExpression)!,
             BoundMatchExpression matchExpression => (BoundExpression)VisitMatchExpression(matchExpression)!,
+            BoundTryBlockExpression tryBlockExpression => (BoundExpression)VisitTryBlockExpression(tryBlockExpression)!,
             _ => node,
         };
     }

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -53,6 +53,9 @@ internal class BoundTreeWalker : BoundTreeVisitor
             case BoundBlockExpression block:
                 VisitBlockExpression(block);
                 break;
+            case BoundTryBlockExpression tryBlock:
+                VisitTryBlockExpression(tryBlock);
+                break;
             case BoundParenthesizedExpression paren:
                 VisitParenthesizedExpression(paren);
                 break;
@@ -206,6 +209,11 @@ internal class BoundTreeWalker : BoundTreeVisitor
         {
             VisitStatement(s);
         }
+    }
+
+    public virtual void VisitTryBlockExpression(BoundTryBlockExpression node)
+    {
+        VisitBlockExpression(node.Block);
     }
 
     public override void VisitParenthesizedExpression(BoundParenthesizedExpression node)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTryBlockExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTryBlockExpression.cs
@@ -1,0 +1,16 @@
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class BoundTryBlockExpression : BoundExpression
+{
+    public BoundTryBlockExpression(BoundBlockExpression block, ITypeSymbol exceptionType, ITypeSymbol type)
+        : base(type, null, BoundExpressionReason.None)
+    {
+        Block = block;
+        ExceptionType = exceptionType;
+    }
+
+    public BoundBlockExpression Block { get; }
+    public ITypeSymbol ExceptionType { get; }
+}

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -340,6 +340,10 @@ internal class ExpressionSyntaxParser : SyntaxParser
                 expr = ParseIfExpressionSyntax();
                 break;
 
+            case SyntaxKind.TryKeyword:
+                expr = ParseTryBlockExpression();
+                break;
+
             case SyntaxKind.OpenBraceToken:
                 expr = ParseBlockSyntax();
                 break;
@@ -354,6 +358,13 @@ internal class ExpressionSyntaxParser : SyntaxParser
         }
 
         return ParseMatchExpressionSuffixes(expr);
+    }
+
+    private TryBlockExpressionSyntax ParseTryBlockExpression()
+    {
+        var tryKeyword = ReadToken();
+        var block = ParseBlockSyntax();
+        return TryBlockExpression(tryKeyword, block);
     }
 
     private LambdaExpressionSyntax ParseLambdaExpression()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -384,6 +384,10 @@
     <Slot Name="Statements" Type="List" ElementType="Statement" />
     <Slot Name="CloseBraceToken" Type="Token" DefaultToken="CloseBraceToken"/>
   </Node>
+  <Node Name="TryBlockExpression" Inherits="Expression">
+    <Slot Name="TryKeyword" Type="Token" DefaultToken="TryKeyword"/>
+    <Slot Name="Block" Type="Block" />
+  </Node>
   <Node Name="BlockStatement" Inherits="Statement">
     <Slot Name="OpenBraceToken" Type="Token" DefaultToken="OpenBraceToken"/>
     <Slot Name="Statements" Type="List" ElementType="Statement" />

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExceptionHandlingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExceptionHandlingTests.cs
@@ -1,4 +1,10 @@
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
+
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
@@ -32,6 +38,33 @@ catch (int ex) {
             expectedDiagnostics: [
                 new DiagnosticResult("RAV1016").WithSpan(3, 8, 3, 11).WithArguments("int")
             ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void TryBlockExpression_InferredTypeIncludesException()
+    {
+        var code = """
+let value = try {
+    int.Parse("foo")
+}
+""";
+
+        var verifier = CreateVerifier(code);
+        var result = verifier.GetResult();
+
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+        var variable = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(v => v.Identifier.Text == "value");
+        var local = (ILocalSymbol)model.GetDeclaredSymbol(variable)!;
+        var union = Assert.IsAssignableFrom<IUnionTypeSymbol>(local.Type);
+
+        Assert.Contains(union.Types, t => t.SpecialType == SpecialType.System_Int32);
+
+        var exceptionType = result.Compilation.GetTypeByMetadataName("System.Exception");
+        Assert.NotNull(exceptionType);
+        Assert.Contains(union.Types, t => SymbolEqualityComparer.Default.Equals(TypeSymbolNormalization.NormalizeForInference(t), exceptionType));
 
         verifier.Verify();
     }


### PR DESCRIPTION
## Summary
- add a TryBlockExpression syntax node and parse `try { ... }` in expression contexts
- bind try block expressions to a new bound node that unions the block type with `System.Exception`
- lower and emit try block expressions and cover the new behavior with a semantic test

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: known pre-existing LambdaInferenceTests failure)*

------
https://chatgpt.com/codex/tasks/task_e_68da38eef8f4832fb720e0982a05c521