### PR TITLE
Clarify try forms in spec and grammar

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -118,6 +118,7 @@ Statement                ::= LocalDeclaration
                            | IfStatement
                            | WhileStatement
                            | ForStatement
+                           | TryStatement
                            | ExpressionStatement ;
 
 LocalDeclaration         ::= ('let' | 'var') LocalVariableDeclarators ;
@@ -137,6 +138,12 @@ ExpressionStatement      ::= Expression ;
 IfStatement              ::= 'if' Expression Statement ['else' Statement] ;
 WhileStatement           ::= 'while' Expression Statement ;
 ForStatement             ::= 'for' 'each'? Identifier 'in' Expression Statement ;
+
+TryStatement             ::= 'try' Block (CatchClauseList [FinallyClause] | FinallyClause) ;
+CatchClauseList          ::= CatchClause {CatchClause} ;
+CatchClause              ::= 'catch' CatchDeclaration? Block ;
+CatchDeclaration         ::= '(' Type [Identifier] ')' ;
+FinallyClause            ::= 'finally' Block ;
 
 (* ---------- Expressions & precedence (lowest → highest) ---------- *)
 
@@ -210,9 +217,12 @@ PrimaryExpression        ::= Literal
                            | ObjectCreationExpression
                            | TupleExpression
                            | ParenthesizedExpression
+                           | TryBlockExpression
                            | Block
                            | IfExpression
                            | InterpolatedStringExpression ;
+
+TryBlockExpression       ::= 'try' Block ;
 
 Block                    ::= '{' {Statement} '}' ;
 


### PR DESCRIPTION
## Summary
- clarify try-statement behaviour, including catch ordering, finally execution, and expression availability
- document that try block expressions are usable in any expression position and cannot include catch/finally clauses
- update the EBNF grammar to cover try statements and try block expressions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68da3d1bd3e4832f972f33296011d205