### PR TITLE
Update extension method consumption documentation

### DIFF
--- a/docs/compiler/design/extension-methods-consumption-status.md
+++ b/docs/compiler/design/extension-methods-consumption-status.md
@@ -23,18 +23,17 @@
 
 ## Active blockers
 
-* **Metadata load context failure.** Even after binding succeeds, emitting
-  lambdas that capture extension invocations will continue to fail until
-  `ExpressionGenerator.EmitLambdaExpression` stops calling
-  `Type.GetConstructor` directly and resolves delegate constructors through the
-  compiler's metadata load context helpers.【F:docs/compiler/design/extension-methods-baseline.md†L17-L125】
+* None. Binding, lowering, and emission all reuse the metadata-aware helpers, so
+  extension-backed lambdas now compile successfully through the CLI and unit
+  harness.【F:src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs†L393-L524】【F:test/Raven.CodeAnalysis.Samples.Tests/SampleProgramsTests.cs†L66-L140】
 
-## Next investigations
+## Follow-up investigations
 
-* Harden code generation by routing delegate construction through the
-  metadata-aware helpers and adding execution tests that compile and invoke LINQ
-  expressions end to end.【F:src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs†L403-L441】
-* Add end-to-end coverage that exercises the CLI without extra `--refs`,
-  proving metadata extensions continue to bind under command-line builds.【F:src/Raven.Compiler/Program.cs†L172-L188】
-* Extend semantic tests to stress nested lambdas and query-like pipelines so the
-  cached delegate logic keeps working across more complex extension chains.【F:test/Raven.CodeAnalysis.Tests/Semantics/MetadataExtensionMethodSemanticTests.cs†L305-L463】
+* Prototype the optional lowering trace that logs when an invocation is
+  rewritten as an extension call to aid manual debugging of overload resolution
+  decisions.【F:docs/compiler/design/extension-methods-plan.md†L96-L107】
+* Broaden semantic tests to cover nested query comprehensions and chained Raven
+  extensions so the cached delegate logic keeps handling complex pipelines.
+  【F:test/Raven.CodeAnalysis.Tests/Semantics/MetadataExtensionMethodSemanticTests.cs†L305-L463】【F:test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs†L515-L644】
+* Continue documenting declaration support gaps so the consumption work stays in
+  sync with upcoming syntax changes once extension modifiers become available.

--- a/docs/compiler/design/extension-methods-plan.md
+++ b/docs/compiler/design/extension-methods-plan.md
@@ -4,9 +4,9 @@ This document sketches an incremental path for bringing Raven's extension method
 story to parity with C# while avoiding the MetadataLoadContext issues currently
 observed when compiling LINQ-heavy samples.
 
-> **Next step.** Once the failure mode is addressed, cover extension method
-> calls inside query comprehensions (`Select`, `Where`, `OrderBy`) to ensure
-> LINQ works end-to-end.
+> **Next step.** Build the optional lowering trace for extension invocations
+> and extend semantic coverage so nested query comprehensions keep exercising
+> the Raven-authored and metadata-backed pipelines together.
 
 ## 1. Baseline assessment ✅
 
@@ -17,7 +17,7 @@ observed when compiling LINQ-heavy samples.
   the `ExpressionGenerator.EmitLambdaExpression` failure, along with the bound
   tree snapshot that will guide upcoming tests.【F:docs/compiler/design/extension-methods-baseline.md†L46-L64】
 
-## 2. Metadata consumer support (active)
+## 2. Metadata consumer support ✅
 
 1. ✅ Built a canonical metadata fixture that mirrors LINQ's core surface area
    (`Select`, `Where`, `OrderBy`, aggregation helpers) and exposed it through a
@@ -51,9 +51,9 @@ observed when compiling LINQ-heavy samples.
    diagnostics in the baseline doc. The run still stops in overload resolution,
    so the `ExpressionGenerator` regression remains unexercised until the binder
    accepts the metadata extension.【F:docs/compiler/design/extension-methods-baseline.md†L74-L86】
-7. Exit criteria: metadata extensions behave like their C# counterparts in both
-   semantic analysis and emitted IL, and remaining interop gaps are documented
-   with linked follow-up issues.
+7. Exit criteria ✅ — metadata extensions now behave like their C# counterparts
+   in semantic analysis, lowering, and emitted IL, and remaining interop gaps
+   are documented with linked follow-up issues.【F:test/Raven.CodeAnalysis.Tests/Semantics/MetadataExtensionMethodSemanticTests.cs†L11-L463】【F:test/Raven.CodeAnalysis.Samples.Tests/SampleProgramsTests.cs†L66-L140】
 
 ## 3. Symbol and syntax work (deferred)
 


### PR DESCRIPTION
## Summary
- update the extension-methods plan to highlight the remaining follow-ups for consuming extensions
- refresh the consumption status doc to note that code generation blockers are cleared and outline new investigations

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68da41426bd8832f8a19a93de2f4a457