### PR TITLE
Add optional lowering trace for extension invocations

### DIFF
--- a/docs/compiler/design/extension-methods-plan.md
+++ b/docs/compiler/design/extension-methods-plan.md
@@ -120,9 +120,12 @@ observed when compiling LINQ-heavy samples.
    reject nullable receivers where C# would. New lowering coverage exercises the
    boxed first argument and verifies we emit the diagnostic for `int?` receivers
    targeting non-nullable parameters.【F:test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs†L585-L644】
-3. Prototype a lowering pass trace (behind a compiler flag) that logs when a
-   call is rewritten as an extension dispatch. This will aid in validating that
-   overload resolution selected the expected candidate during manual review.
+3. ✅ Prototyped a lowering pass trace (toggled via compilation options) that
+   records each extension invocation rewritten during lowering. The optional
+   `LoweringTraceLog` sink captures the containing symbol, method, receiver, and
+   argument types so nested pipelines can be inspected in tests. New lowering
+   coverage asserts that mixed Raven and metadata LINQ pipelines emit the trace
+   entries expected for nested comprehensions.【F:src/Raven.CodeAnalysis/BoundTree/Lowering/LoweringTrace.cs†L1-L58】【F:src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Invocation.cs†L1-L47】【F:test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs†L609-L699】
 
 ## 6. Code generation fixes
 

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/LoweringTrace.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/LoweringTrace.cs
@@ -1,0 +1,65 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+public interface ILoweringTraceSink
+{
+    void RecordExtensionInvocation(ExtensionInvocationLoweringTrace entry);
+}
+
+public sealed class LoweringTraceLog : ILoweringTraceSink
+{
+    private readonly bool _isEnabled;
+    private readonly ConcurrentQueue<ExtensionInvocationLoweringTrace> _extensionInvocations = new();
+
+    public LoweringTraceLog()
+        : this(isEnabled: true)
+    {
+    }
+
+    public LoweringTraceLog(bool isEnabled)
+    {
+        _isEnabled = isEnabled;
+    }
+
+    public ImmutableArray<ExtensionInvocationLoweringTrace> ExtensionInvocations
+        => _extensionInvocations.ToImmutableArray();
+
+    void ILoweringTraceSink.RecordExtensionInvocation(ExtensionInvocationLoweringTrace entry)
+    {
+        if (!_isEnabled)
+            return;
+
+        _extensionInvocations.Enqueue(entry);
+    }
+}
+
+public sealed class ExtensionInvocationLoweringTrace
+{
+    public ExtensionInvocationLoweringTrace(
+        ISymbol containingSymbol,
+        IMethodSymbol method,
+        ITypeSymbol receiverType,
+        bool receiverCameFromInvocation,
+        ImmutableArray<ITypeSymbol> argumentTypes)
+    {
+        ContainingSymbol = containingSymbol;
+        Method = method;
+        ReceiverType = receiverType;
+        ReceiverCameFromInvocation = receiverCameFromInvocation;
+        ArgumentTypes = argumentTypes;
+    }
+
+    public ISymbol ContainingSymbol { get; }
+
+    public IMethodSymbol Method { get; }
+
+    public ITypeSymbol ReceiverType { get; }
+
+    public bool ReceiverCameFromInvocation { get; }
+
+    public ImmutableArray<ITypeSymbol> ArgumentTypes { get; }
+}

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -44,6 +44,8 @@ public class Compilation
 
     public PerformanceInstrumentation PerformanceInstrumentation => Options.PerformanceInstrumentation;
 
+    public ILoweringTraceSink? LoweringTrace => Options.LoweringTrace;
+
     public IAssemblySymbol Assembly { get; private set; }
 
     public IModuleSymbol Module { get; private set; }

--- a/src/Raven.CodeAnalysis/CompilationOptions.cs
+++ b/src/Raven.CodeAnalysis/CompilationOptions.cs
@@ -14,12 +14,14 @@ public class CompilationOptions
         OutputKind outputKind,
         ImmutableDictionary<string, ReportDiagnostic>? specificDiagnosticOptions = null,
         bool runAnalyzers = true,
-        PerformanceInstrumentation? performanceInstrumentation = null)
+        PerformanceInstrumentation? performanceInstrumentation = null,
+        ILoweringTraceSink? loweringTrace = null)
     {
         OutputKind = outputKind;
         SpecificDiagnosticOptions = specificDiagnosticOptions ?? ImmutableDictionary<string, ReportDiagnostic>.Empty;
         RunAnalyzers = runAnalyzers;
         PerformanceInstrumentation = performanceInstrumentation ?? PerformanceInstrumentation.Disabled;
+        LoweringTrace = loweringTrace;
     }
 
     public OutputKind OutputKind { get; }
@@ -29,16 +31,21 @@ public class CompilationOptions
     public bool RunAnalyzers { get; }
 
     public CompilationOptions WithSpecificDiagnosticOptions(IDictionary<string, ReportDiagnostic> options)
-        => new(OutputKind, SpecificDiagnosticOptions.SetItems(options), RunAnalyzers, PerformanceInstrumentation);
+        => new(OutputKind, SpecificDiagnosticOptions.SetItems(options), RunAnalyzers, PerformanceInstrumentation, LoweringTrace);
 
     public CompilationOptions WithSpecificDiagnosticOption(string diagnosticId, ReportDiagnostic option)
-        => new(OutputKind, SpecificDiagnosticOptions.SetItem(diagnosticId, option), RunAnalyzers, PerformanceInstrumentation);
+        => new(OutputKind, SpecificDiagnosticOptions.SetItem(diagnosticId, option), RunAnalyzers, PerformanceInstrumentation, LoweringTrace);
 
     public CompilationOptions WithRunAnalyzers(bool runAnalyzers)
-        => new(OutputKind, SpecificDiagnosticOptions, runAnalyzers, PerformanceInstrumentation);
+        => new(OutputKind, SpecificDiagnosticOptions, runAnalyzers, PerformanceInstrumentation, LoweringTrace);
 
     public PerformanceInstrumentation PerformanceInstrumentation { get; }
 
     public CompilationOptions WithPerformanceInstrumentation(PerformanceInstrumentation? instrumentation)
-        => new(OutputKind, SpecificDiagnosticOptions, RunAnalyzers, instrumentation ?? PerformanceInstrumentation.Disabled);
+        => new(OutputKind, SpecificDiagnosticOptions, RunAnalyzers, instrumentation ?? PerformanceInstrumentation.Disabled, LoweringTrace);
+
+    public ILoweringTraceSink? LoweringTrace { get; }
+
+    public CompilationOptions WithLoweringTrace(ILoweringTraceSink? loweringTrace)
+        => new(OutputKind, SpecificDiagnosticOptions, RunAnalyzers, PerformanceInstrumentation, loweringTrace);
 }


### PR DESCRIPTION
## Summary
- add a lowering trace sink and log to capture rewritten extension invocations
- flow the optional trace through lowering via compilation options and hook the instrumentation
- extend extension method tests to assert nested Raven/metadata pipelines and mark the plan item complete

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter Lowerer_WithLoweringTrace_RecordsNestedExtensionInvocations

------
https://chatgpt.com/codex/tasks/task_e_68da472abe70832fa84a8b3b60266c71