### PR TITLE
Add System namespace import to test5 sample

### DIFF
--- a/src/Raven.Compiler/samples/test5.rav
+++ b/src/Raven.Compiler/samples/test5.rav
@@ -1,3 +1,4 @@
+import System.*
 import System.Console.*
 
 let input = "foo"


### PR DESCRIPTION
## Summary
- add the System namespace import to the `test5.rav` sample so that `FormatException` resolves without additional directives

## Testing
- dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/test5.rav -o test.dll -d pretty

------
https://chatgpt.com/codex/tasks/task_e_68da46ed4318832f88099e19676d99b9