### PR TITLE
Handle extension attributes on containing type

### DIFF
--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -132,6 +132,9 @@ internal sealed class OverloadResolver
             if (argumentType.TypeKind == TypeKind.Error)
                 continue;
 
+            if (arguments[i] is BoundLambdaExpression)
+                continue;
+
             if (!TryInferFromTypes(compilation, parameters[parameterIndex].Type, argumentType, substitutions))
                 return null;
         }

--- a/test/Raven.CodeAnalysis.Tests/TestMetadataReferences.cs
+++ b/test/Raven.CodeAnalysis.Tests/TestMetadataReferences.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Linq;
 
+using Microsoft.CodeAnalysis;
+
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Testing;
 
@@ -19,12 +21,33 @@ internal static class TestMetadataReferences
         return (TestTargetFramework.Default, refs);
     });
 
+    private static readonly Lazy<MetadataReference[]> s_defaultWithoutSystemLinq = new(() =>
+        Default.Where(reference => !IsSystemLinq(reference)).ToArray());
+
+    private static readonly Lazy<MetadataReference[]> s_defaultWithoutSystemLinqWithExtensionMethods = new(() =>
+        [.. DefaultWithoutSystemLinq, ExtensionMethodsFixture]);
+
     private static readonly Lazy<MetadataReference> s_extensionMethodsFixture = new(() =>
         MetadataReference.CreateFromFile(typeof(Raven.MetadataFixtures.Linq.RavenEnumerableExtensions).Assembly.Location));
 
     public static string TargetFramework => s_default.Value.tfm;
     public static MetadataReference[] Default => s_default.Value.refs;
     public static MetadataReference ExtensionMethodsFixture => s_extensionMethodsFixture.Value;
+    public static MetadataReference[] DefaultWithoutSystemLinq => s_defaultWithoutSystemLinq.Value;
+    public static MetadataReference[] DefaultWithoutSystemLinqWithExtensionMethods => s_defaultWithoutSystemLinqWithExtensionMethods.Value;
     public static MetadataReference[] DefaultWithExtensionMethods
         => [.. Default, ExtensionMethodsFixture];
+
+    private static bool IsSystemLinq(MetadataReference reference)
+    {
+        if (reference is not PortableExecutableReference portable)
+            return false;
+
+        var path = portable.FilePath;
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var fileName = Path.GetFileName(path);
+        return string.Equals(fileName, "System.Linq.dll", StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary
- recognize metadata extension methods when ExtensionAttribute is declared on the containing type and cache the detection
- avoid type inference failures for extension overloads with lambdas and keep fixture tests isolated from System.Linq by filtering reference assemblies
- add coverage that verifies System.Linq.Enumerable extensions bind correctly and adjust existing metadata fixture tests for explicit lambda parameter types

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter MetadataExtensionMethodSemanticTests`


------
https://chatgpt.com/codex/tasks/task_e_68da63f73e9c832f86abb03f7aeca112