### PR TITLE
Document LINQ extension metadata limitations

### DIFF
--- a/docs/compiler/design/extension-methods-consumption-status.md
+++ b/docs/compiler/design/extension-methods-consumption-status.md
@@ -26,13 +26,15 @@
 * **Real-world metadata gaps.** The infrastructure that recognises extension
   methods inside the metadata fixture still fails against the reference
   assemblies that ship with .NET. Running the CLI against
-  `src/Raven.Compiler/samples/linq.rav` produces overload-resolution failures and
-  misses `System.Linq.Enumerable` entirely, even though `Program.cs` adds
+  `src/Raven.Compiler/samples/linq.rav` produces overload-resolution failures
+  (`RAV1501: No overload for method 'Where' takes 1 arguments`) and misses
+  `System.Linq.Enumerable` entirely, even though `Program.cs` adds
   `System.Linq.dll` by default.【F:src/Raven.Compiler/samples/linq.rav†L1-L18】【F:src/Raven.Compiler/Program.cs†L172-L188】 This
   suggests the metadata walker is either skipping the reference-assembly types
   or rejecting the generic receiver conversion when the declaring type comes
   from the BCL. Until the binder can surface those real assemblies, extension
-  consumption only succeeds when callers reference the bespoke test fixture.
+  consumption only succeeds when callers reference the bespoke test fixture or
+  Raven-authored extensions compiled into the same project.
 
 ## Follow-up investigations
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -73,3 +73,11 @@ matches the receiver's type. The compiler then rewrites the invocation so the
 receiver becomes the leading argument to the static method, which means the
 emitted IL and runtime behavior match what C# would produce.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.cs†L1946-L2001】【F:src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Invocation.cs†L8-L29】
 
+> **Note:** Raven's metadata loader is still gaining parity with the .NET
+> reference assemblies. Invocations like `numbers.Where(...)` succeed when the
+> extension comes from Raven-authored code or the test fixtures bundled with the
+> compiler, but calls into `System.Linq.Enumerable` currently fail with
+> overload-resolution errors such as `RAV1501`. The
+> [extension-method consumption status](compiler/design/extension-methods-consumption-status.md)
+> tracker captures the open work needed to unblock real-world assemblies.
+


### PR DESCRIPTION
## Summary
- note the current LINQ extension method failure in the introduction guide and point readers to the status tracker
- capture the RAV1501 overload-resolution error in the extension-consumption status document

## Testing
- not run (docs only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da79421620832fa40260cc19eda02c