### PR TITLE
Document extension method pipeline details

### DIFF
--- a/docs/compiler/design/extension-methods-plan.md
+++ b/docs/compiler/design/extension-methods-plan.md
@@ -4,8 +4,9 @@ This document sketches an incremental path for bringing Raven's extension method
 story to parity with C# while avoiding the MetadataLoadContext issues currently
 observed when compiling LINQ-heavy samples.
 
-> **Next step.** Document the end-to-end feature in the language
-> specification and user manuals before updating the roadmap and TODO list.
+> **Next step.** With the language specification and user manual updated,
+> sync the roadmap and TODO list so they point at the remaining metadata
+> polish work and declaration syntax milestones.
 
 ## 1. Baseline assessment ✅
 


### PR DESCRIPTION
## Summary
- expand the language specification’s extension method section with declaration, lookup, and invocation details that cover both source and metadata helpers
- refresh the introduction manual to walk through declaring and calling extensions, note the bundled LINQ fixture, and describe the current metadata limitations
- advance the extension-methods implementation plan to point at roadmap/TODO sync work now that the docs are updated

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68da7f01b1c0832fbe90898719286543