### PR TITLE
Improve delegate compatibility symbol comparisons

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -724,10 +724,16 @@ partial class BlockBinder : Binder
             if (methodParameter.RefKind != delegateParameter.RefKind)
                 return false;
 
+            if (SymbolEqualityComparer.Default.Equals(delegateParameter.Type, methodParameter.Type))
+                continue;
+
             var conversion = Compilation.ClassifyConversion(delegateParameter.Type, methodParameter.Type);
             if (!conversion.Exists || !conversion.IsImplicit)
                 return false;
         }
+
+        if (SymbolEqualityComparer.Default.Equals(method.ReturnType, invoke.ReturnType))
+            return true;
 
         var returnConversion = Compilation.ClassifyConversion(method.ReturnType, invoke.ReturnType);
         return returnConversion.Exists && returnConversion.IsImplicit;

--- a/src/Raven.CodeAnalysis/BoundTree/BoundLambdaExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundLambdaExpression.cs
@@ -52,6 +52,9 @@ internal partial class BoundLambdaExpression : BoundExpression
             if (candidate.TypeKind != TypeKind.Delegate)
                 continue;
 
+            if (SymbolEqualityComparer.Default.Equals(candidate, delegateType))
+                return true;
+
             var candidateInvoke = candidate.GetDelegateInvokeMethod();
             if (candidateInvoke is null)
                 continue;
@@ -108,7 +111,8 @@ internal partial class BoundLambdaExpression : BoundExpression
                 }
 
                 var substitutedSource = SubstituteType(sourceParameter.Type, substitutions, compilation);
-                var conversion = compilation.ClassifyConversion(substitutedSource, targetParameter.Type);
+                var substitutedTarget = SubstituteType(targetParameter.Type, substitutions, compilation);
+                var conversion = compilation.ClassifyConversion(substitutedSource, substitutedTarget);
                 if (!conversion.Exists || !conversion.IsImplicit)
                     return false;
             }
@@ -126,7 +130,8 @@ internal partial class BoundLambdaExpression : BoundExpression
             }
 
             var substitutedReturn = SubstituteType(source.ReturnType, substitutions, compilation);
-            var returnConversion = compilation.ClassifyConversion(substitutedReturn, target.ReturnType);
+            var substitutedTargetReturn = SubstituteType(target.ReturnType, substitutions, compilation);
+            var returnConversion = compilation.ClassifyConversion(substitutedReturn, substitutedTargetReturn);
             return returnConversion.Exists && returnConversion.IsImplicit;
 
             static bool TryAddTypeMappings(


### PR DESCRIPTION
## Summary
- recognize exact symbol matches when validating method group conversions
- substitute delegate parameter types when comparing lambda delegate candidates to support symbol-based equality checks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daa2a1796c832f8d002802d2956d4b