### PR TITLE
Fix file-scoped namespace binding regression

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
+++ b/src/Raven.CodeAnalysis/Binder/BinderFactory.cs
@@ -89,7 +89,10 @@ class BinderFactory
     private Binder CreateNamespaceBinder(BaseNamespaceDeclarationSyntax nsSyntax, Binder parentBinder)
     {
         var parentNamespace = parentBinder.CurrentNamespace;
-        var namespaceName = parentNamespace.QualifyName(nsSyntax.Name.ToString());
+        var namespaceName = nsSyntax is FileScopedNamespaceDeclarationSyntax
+            ? nsSyntax.Name.ToString()
+            : parentNamespace.QualifyName(nsSyntax.Name.ToString());
+
         var nsSymbol = _compilation.GetOrCreateNamespaceSymbol(namespaceName)
             ?? throw new InvalidOperationException($"Unable to resolve namespace '{namespaceName}'.");
 

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -648,7 +648,10 @@ public partial class SemanticModel
             {
                 case BaseNamespaceDeclarationSyntax nsDecl:
                     {
-                        var namespaceName = parentNamespace.QualifyName(nsDecl.Name.ToString());
+                        var namespaceName = nsDecl is FileScopedNamespaceDeclarationSyntax
+                            ? nsDecl.Name.ToString()
+                            : parentNamespace.QualifyName(nsDecl.Name.ToString());
+
                         var nsSymbol = Compilation.GetOrCreateNamespaceSymbol(namespaceName);
 
                         var nsBinder = Compilation.BinderFactory.GetBinder(nsDecl, parentBinder)!;


### PR DESCRIPTION
## Summary
- avoid qualifying file-scoped namespace names when resolving binders
- ensure semantic model registers file-scoped namespaces without duplicating the name

## Testing
- dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/classes.rav -o test.dll -d pretty

------
https://chatgpt.com/codex/tasks/task_e_68dad2b3918c832facf24bfc122b94f0