### PR TITLE
Ensure match arms parse patterns correctly

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -933,6 +933,10 @@ internal class ExpressionSyntaxParser : SyntaxParser
         {
             while (true)
             {
+                SetTreatNewlinesAsTokens(true);
+
+                SkipMatchArmSeparators();
+
                 if (IsNextToken(SyntaxKind.CloseBraceToken, out _))
                     break;
 
@@ -967,6 +971,22 @@ internal class ExpressionSyntaxParser : SyntaxParser
         SetTreatNewlinesAsTokens(false);
 
         return MatchExpression(scrutinee, matchKeyword, openBraceToken, List(arms.ToArray()), closeBraceToken);
+    }
+
+    private void SkipMatchArmSeparators()
+    {
+        while (true)
+        {
+            var kind = PeekToken().Kind;
+
+            if (kind is SyntaxKind.NewLineToken or SyntaxKind.LineFeedToken or SyntaxKind.CarriageReturnToken or SyntaxKind.CarriageReturnLineFeedToken)
+            {
+                ReadToken();
+                continue;
+            }
+
+            break;
+        }
     }
 
     private IfExpressionSyntax ParseIfExpressionSyntax()


### PR DESCRIPTION
## Summary
- skip newline tokens before parsing match arms so real patterns are consumed
- expand match expression syntax tests to cover declaration, variable, binary, and unary patterns
- update the match arm newline test to assert tokens without relying on string rendering

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter MatchExpressionSyntaxTests

------
https://chatgpt.com/codex/tasks/task_e_68db98f1c1c4832f9e20db7e7a55d279