### PR TITLE
Add tests ensuring lexer comment trivia handles quoted text

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/MultiLineCommentTriviaTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/MultiLineCommentTriviaTest.cs
@@ -46,6 +46,8 @@ public class MultiLineCommentTriviaTest
     [InlineData("/* Привет мир */", "/* Привет мир */")]
     [InlineData("/* 😀 emoji */", "/* 😀 emoji */")]
     [InlineData("/* Café au lait */", "/* Café au lait */")]
+    [InlineData("/* let x = \"hej\" */", "/* let x = \"hej\" */")]
+    [InlineData("/* let x = “hej” */", "/* let x = “hej” */")]
     public void MultiLineCommentTrivia_PreservesUnicodeContent(string code, string expectedComment)
     {
         var syntaxTree = SyntaxTree.ParseText(code);

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/SingleLineCommentTriviaTest.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/SingleLineCommentTriviaTest.cs
@@ -60,6 +60,8 @@ public class SingleLineCommentTriviaTest
     [InlineData("let x = 1; // Привет мир", "// Привет мир")]
     [InlineData("let x = 1; // Café au lait", "// Café au lait")]
     [InlineData("let x = 1; // 😀 emoji", "// 😀 emoji")]
+    [InlineData("let x = 1; // let x = \"hej\"", "// let x = \"hej\"")]
+    [InlineData("let x = 1; // let x = “hej”", "// let x = “hej”")]
     public void SingleLineCommentTrivia_PreservesUnicodeContent(string code, string expectedComment)
     {
         var syntaxTree = SyntaxTree.ParseText(code);


### PR DESCRIPTION
## Summary
- extend the single-line comment trivia preservation test data with double-quoted and smart-quoted scenarios
- extend the multi-line comment trivia preservation test data with equivalent quoted comment examples to cover the lexer path

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~SingleLineCommentTriviaTest
- dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName~MultiLineCommentTriviaTest

------
https://chatgpt.com/codex/tasks/task_e_68db9ff51d80832fb38bdff1cd8dae12