### PR TITLE
Add discard pattern syntax handling

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -3069,7 +3069,7 @@ partial class BlockBinder : Binder
                 return BindVariablePatternForAssignment(variablePattern, valueType);
             case TuplePatternSyntax tuplePattern:
                 return BindTuplePatternForAssignment(tuplePattern, valueType);
-            case DeclarationPatternSyntax declaration when IsDiscardPatternSyntax(declaration):
+            case DiscardPatternSyntax:
                 return new BoundDiscardPattern(valueType.TypeKind == TypeKind.Error ? Compilation.ErrorTypeSymbol : valueType);
             case DeclarationPatternSyntax declaration:
                 return BindDeclarationPatternForAssignment(declaration, valueType, node);

--- a/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
@@ -242,6 +242,7 @@ internal partial class BlockBinder
     {
         return syntax switch
         {
+            DiscardPatternSyntax discard => BindDiscardPattern(discard),
             DeclarationPatternSyntax d => BindDeclarationPattern(d),
             TuplePatternSyntax t => BindTuplePattern(t),
             UnaryPatternSyntax u => BindUnaryPattern(u),
@@ -252,12 +253,6 @@ internal partial class BlockBinder
 
     private BoundPattern BindDeclarationPattern(DeclarationPatternSyntax syntax)
     {
-        if (IsDiscardPatternSyntax(syntax))
-        {
-            var objectType = Compilation.GetSpecialType(SpecialType.System_Object);
-            return new BoundDiscardPattern(objectType);
-        }
-
         var type = BindTypeSyntax(syntax.Type);
 
         BoundDesignator designator = syntax.Designation switch
@@ -336,21 +331,10 @@ internal partial class BlockBinder
         return new BoundDeclarationPattern(declaration.DeclaredType, designator, declaration.Reason);
     }
 
-    private static bool IsDiscardPatternSyntax(DeclarationPatternSyntax syntax)
+    private BoundPattern BindDiscardPattern(DiscardPatternSyntax syntax)
     {
-        if (syntax.Type is not IdentifierNameSyntax identifier)
-            return false;
-
-        if (identifier.Identifier.ValueText != "_")
-            return false;
-
-        if (syntax.Designation is not SingleVariableDesignationSyntax designation)
-            return false;
-
-        if (designation.Identifier.IsMissing)
-            return true;
-
-        return designation.Identifier.ValueText == "_";
+        var objectType = Compilation.GetSpecialType(SpecialType.System_Object);
+        return new BoundDiscardPattern(objectType);
     }
 
     private BoundPattern BindUnaryPattern(UnaryPatternSyntax syntax)

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
@@ -72,7 +72,7 @@ internal class PatternSyntaxParser : SyntaxParser
         if (PeekToken().Kind is SyntaxKind.UnderscoreToken)
         {
             var underscoreToken = ReadToken();
-            //return new DiscardPattern(underscoreToken);
+            return DiscardPattern(underscoreToken);
         }
 
         var type = new NameSyntaxParser(this).ParseTypeName();

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -554,6 +554,9 @@
     <Slot Name="LetOrVarKeyword" Type="Token" />
     <Slot Name="Designation" Type="VariableDesignation" />
   </Node>
+  <Node Name="DiscardPattern" Inherits="Pattern">
+    <Slot Name="UnderscoreToken" Type="Token" DefaultToken="UnderscoreToken"/>
+  </Node>
   <Node Name="DeclarationPattern" Inherits="Pattern">
     <Slot Name="Type" Type="Type" />
     <Slot Name="Designation" Type="VariableDesignation" />

--- a/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
+++ b/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
@@ -54,6 +54,7 @@
   <NodeKind Name="RightShiftAssignmentStatement" Type="AssignmentStatement" />
   <NodeKind Name="ConcatenateAssignmentStatement" Type="AssignmentStatement" />
   <NodeKind Name="SimpleMemberAccessExpression" Type="MemberAccessExpression" />
+  <NodeKind Name="DiscardPattern" Type="DiscardPattern" />
   <NodeKind Name="NotPattern" Type="UnaryPattern" />
   <NodeKind Name="AndPattern" Type="BinaryPattern" />
   <NodeKind Name="OrPattern" Type="BinaryPattern" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/PatternSyntaxParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/PatternSyntaxParserTests.cs
@@ -25,6 +25,18 @@ public class PatternSyntaxParserTests
     }
 
     [Fact]
+    public void DiscardPattern_Parses()
+    {
+        var (pattern, tree) = ParsePattern("_");
+        var sourceText = tree.GetText() ?? throw new InvalidOperationException("Missing source text.");
+
+        var discard = Assert.IsType<DiscardPatternSyntax>(pattern);
+        Assert.Equal("_", sourceText.ToString(discard.Span));
+
+        AssertNoErrors(tree);
+    }
+
+    [Fact]
     public void VariablePattern_WithTypedParenthesizedDesignation_Parses()
     {
         var (pattern, tree) = ParsePattern("let (first, second): (int, string)");


### PR DESCRIPTION
## Summary
- add a generated DiscardPattern syntax node and map `_` patterns to it in the parser
- update binding logic to produce bound discard patterns from the new syntax, including assignment scenarios
- cover discard parsing with a dedicated syntax test

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing diagnostics and codegen tests unrelated to discard patterns)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc67cb1f0832fab43633df6dbda56