### PR TITLE
Handle boolean match exhaustiveness

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -47,6 +47,41 @@ let result = value match {
     }
 
     [Fact]
+    public void MatchExpression_WithBooleanLiteralArms_IsExhaustive()
+    {
+        const string code = """
+let value: bool = true
+
+let result = value match {
+    true => "true"
+    false => "false"
+}
+""";
+
+        var verifier = CreateVerifier(code);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void MatchExpression_WithBooleanLiteralArmsOnUnion_IsExhaustive()
+    {
+        const string code = """
+let value: bool | (flag: bool, text: string) = false
+
+let result = value match {
+    true => "true"
+    false => "false"
+    (flag: bool, text: string) => "tuple ${text}"
+}
+""";
+
+        var verifier = CreateVerifier(code);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void MatchExpression_WithDiscardArm_BindsDesignation()
     {
         const string code = """


### PR DESCRIPTION
## Summary
- ensure match exhaustiveness recognises boolean patterns by tracking literal coverage for both standalone booleans and booleans within unions
- update union member handling to propagate literal coverage removal and add helper utilities for boolean-aware analysis
- add semantic tests demonstrating that `true`/`false` arms satisfy exhaustiveness for boolean and boolean-union scrutinees

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing GlobalForEach_AnalyzesAsImperativeLoop assertion and msbuild logger error)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdbc1fb74832fbf665299bed8d973