### PR TITLE
Fix bool literal match exhaustiveness on unions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1909,6 +1909,23 @@ partial class BlockBinder : Binder
         {
             var token = literalType.Token;
             var value = token.Value ?? token.ValueText!;
+
+            if (value is string stringValue)
+            {
+                if (literalType.Kind == SyntaxKind.TrueLiteralType)
+                {
+                    value = true;
+                }
+                else if (literalType.Kind == SyntaxKind.FalseLiteralType)
+                {
+                    value = false;
+                }
+                else
+                {
+                    value = stringValue;
+                }
+            }
+
             ITypeSymbol underlying = value switch
             {
                 int => Compilation.GetSpecialType(SpecialType.System_Int32),

--- a/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
@@ -259,6 +259,8 @@ internal partial class BlockBinder
         BoundDesignator designator = syntax.Designation switch
         {
             SingleVariableDesignationSyntax single when !single.Identifier.IsMissing &&
+                                                      single.Identifier.Kind != SyntaxKind.None &&
+                                                      !string.IsNullOrEmpty(single.Identifier.ValueText) &&
                                                       single.Identifier.ValueText != "_"
                 => BindSingleVariableDesignation(single)!,
             _ => new BoundDiscardDesignator(type.Type)


### PR DESCRIPTION
## Summary
- normalize boolean literal type tokens to actual `bool` values when binding literal types so constant patterns expose the right constant
- treat declaration patterns without an identifier as discards, letting boolean literal arms bind as constant patterns instead of declarations

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "MatchExpression_WithBooleanLiteralArmsOnUnion_IsExhaustive"

------
https://chatgpt.com/codex/tasks/task_e_68dbe80cbd7c832f96a9483a86d6dbf8