### PR TITLE
Fix tuple match emission and add regression test

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1106,9 +1106,9 @@ internal class ExpressionGenerator : Generator
             var labelDone = ILGenerator.DefineLabel();
 
             ILGenerator.Emit(OpCodes.Isinst, tupleInterfaceType);
-            ILGenerator.Emit(OpCodes.Dup);
-            ILGenerator.Emit(OpCodes.Brfalse_S, labelFail);
             ILGenerator.Emit(OpCodes.Stloc, tupleLocal);
+            ILGenerator.Emit(OpCodes.Ldloc, tupleLocal);
+            ILGenerator.Emit(OpCodes.Brfalse_S, labelFail);
 
             ILGenerator.Emit(OpCodes.Ldloc, tupleLocal);
             ILGenerator.Emit(OpCodes.Callvirt, lengthGetter);


### PR DESCRIPTION
## Summary
- store the tuple pattern `isinst` result before the null check so the evaluation stack stays balanced when the cast fails
- add a codegen regression test for matching a union scrutinee with a tuple arm

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter FullyQualifiedName=Raven.CodeAnalysis.Tests.MatchExpressionCodeGenTests.MatchExpression_WithUnionTupleArm_EmitsAndRuns` *(fails: existing entry point detection issue during emit)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf82bb400832fa382f311717931e2