### PR TITLE
Fix tuple pattern codegen for union match

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1101,33 +1101,33 @@ internal class ExpressionGenerator : Generator
             if (lengthGetter is null || itemGetter is null)
                 throw new NotSupportedException("System.Runtime.CompilerServices.ITuple is required to match tuple patterns.");
 
-            var tupleLocal = ILGenerator.DeclareLocal(tupleInterfaceType);
             var labelFail = ILGenerator.DefineLabel();
             var labelDone = ILGenerator.DefineLabel();
 
             ILGenerator.Emit(OpCodes.Isinst, tupleInterfaceType);
-            ILGenerator.Emit(OpCodes.Stloc, tupleLocal);
-            ILGenerator.Emit(OpCodes.Ldloc, tupleLocal);
+            ILGenerator.Emit(OpCodes.Dup);
             ILGenerator.Emit(OpCodes.Brfalse_S, labelFail);
 
-            ILGenerator.Emit(OpCodes.Ldloc, tupleLocal);
+            ILGenerator.Emit(OpCodes.Dup);
             ILGenerator.Emit(OpCodes.Callvirt, lengthGetter);
             ILGenerator.Emit(OpCodes.Ldc_I4, tuplePattern.Elements.Length);
             ILGenerator.Emit(OpCodes.Bne_Un_S, labelFail);
 
             for (var i = 0; i < tuplePattern.Elements.Length; i++)
             {
-                ILGenerator.Emit(OpCodes.Ldloc, tupleLocal);
+                ILGenerator.Emit(OpCodes.Dup);
                 ILGenerator.Emit(OpCodes.Ldc_I4, i);
                 ILGenerator.Emit(OpCodes.Callvirt, itemGetter);
                 EmitPattern(tuplePattern.Elements[i], scope);
                 ILGenerator.Emit(OpCodes.Brfalse_S, labelFail);
             }
 
+            ILGenerator.Emit(OpCodes.Pop);
             ILGenerator.Emit(OpCodes.Ldc_I4_1);
             ILGenerator.Emit(OpCodes.Br_S, labelDone);
 
             ILGenerator.MarkLabel(labelFail);
+            ILGenerator.Emit(OpCodes.Pop);
             ILGenerator.Emit(OpCodes.Ldc_I4_0);
 
             ILGenerator.MarkLabel(labelDone);

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
@@ -108,6 +108,31 @@ class Describer {
         Assert.Equal("false,tuple", output);
     }
 
+    [Fact]
+    public void MatchExpression_WithUnionTupleFallback_EmitsAndRuns()
+    {
+        const string code = """
+let tuple = (42, 2)
+let foo = tuple.Item1
+let tuple2 = (42, "Bar")
+let name = tuple2.Item2
+let x: bool | (flag: bool, text: string) = false
+
+let r = x match {
+    (flag: bool, text: string) => "tuple"
+    _ => "none"
+}
+
+System.Console.WriteLine(r)
+""";
+
+        var output = EmitAndRun(code, "match_union_tuple_fallback");
+        if (output is null)
+            return;
+
+        Assert.Equal("none", output);
+    }
+
     private static string? EmitAndRun(string code, string assemblyName, params string[] additionalSources)
     {
         var syntaxTrees = new List<RavenSyntaxTree> { RavenSyntaxTree.ParseText(code) };


### PR DESCRIPTION
## Summary
- adjust tuple pattern code generation to rely on stack duplication instead of temporary locals so union scrutinee checks no longer emit invalid IL
- add a regression test that exercises a union match with preceding tuple operations to ensure the fallback arm executes

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter MatchExpression_WithUnionTupleFallback_EmitsAndRuns`
- `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj` *(fails: pre-existing diagnostic mismatch in ObjectCreationTests.InvocationFallsBackToConstructorWhenMethodNotApplicable)*

------
https://chatgpt.com/codex/tasks/task_e_68dc06759ca0832f82e6d4bae71f76a9