### PR TITLE
Fix tuple pattern match codegen

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/MatchExpressionCodeGenTests.cs
@@ -133,6 +133,36 @@ System.Console.WriteLine(r)
         Assert.Equal("none", output);
     }
 
+    [Fact]
+    public void MatchExpression_WithMixedPrimitiveAndTupleArms_EmitsAndRuns()
+    {
+        const string code = """
+let describer = Describer()
+let boolResult = describer.Describe(false)
+let tupleValue: bool | (flag: bool, text: string) = (false, "tuple")
+let tupleResult = describer.Describe(tupleValue)
+
+System.Console.WriteLine(boolResult + "," + tupleResult)
+
+class Describer {
+    Describe(value: bool | (flag: bool, text: string)) -> string {
+        return value match {
+            false => "false"
+            true => "true"
+            (flag: bool, text: string) => text
+            _ => "none"
+        }
+    }
+}
+""";
+
+        var output = EmitAndRun(code, "match_union_mixed_tuple");
+        if (output is null)
+            return;
+
+        Assert.Equal("false,tuple", output);
+    }
+
     private static string? EmitAndRun(string code, string assemblyName, params string[] additionalSources)
     {
         var syntaxTrees = new List<RavenSyntaxTree> { RavenSyntaxTree.ParseText(code) };


### PR DESCRIPTION
## Summary
- fix the tuple pattern code generation so the scrutinee is stored in a local and the success/failure paths preserve a balanced stack
- always stash the final block-expression value in a temporary before disposing locals so the value survives clean-up
- add a regression test that exercises a match expression with primitive and tuple arms

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter MatchExpression_WithMixedPrimitiveAndTupleArms_EmitsAndRuns`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68dc0e5faeb8832f894fd19ce72fb6cb