### PR TITLE
Document TypeUnionAnalyzer as external component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,5 @@ If documentation-only changes don’t need verification, you may skip build/test
 **Contribution checklist:** format code with `dotnet format <solution|project> --include <files>`; run build/test (unless docs-only); keep generated files up to date; add/update tests; write concise commit messages; summarize PRs with relevant diagnostics; update specs/grammar/docs alongside feature changes.
 
 **Additional notes:** focus on incremental, additive changes; review `docs/` before altering syntax/semantics; ask Codex to collapse large diffs; inspect `ravc` outputs with `ilspycmd` (install via `dotnet tool install --global ilspycmd`); prefer implementing new features via lowering where possible.
+
+**External components:** `TypeUnionAnalyzer` lives in a separate project; ignore it unless explicitly instructed.


### PR DESCRIPTION
## Summary
- note that `TypeUnionAnalyzer` is a separate project and should be ignored unless requested

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68dc36d36d50832fa2a391a9d37ec4b8