### PR TITLE
Support typeof open generic definitions

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/TypeOfTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/TypeOfTests.cs
@@ -49,4 +49,44 @@ class TypeInspector {
         Assert.Equal(typeof(int), intType);
         Assert.Equal(typeof(System.Collections.Generic.List<int>), listType);
     }
+
+    [Fact]
+    public void TypeOfExpression_AllowsOpenGenericTypes()
+    {
+        const string code = """
+class OpenGenericInspector {
+    static GetFuncArity1() -> System.Type {
+        typeof(System.Func<>)
+    }
+
+    static GetFuncArity2() -> System.Type {
+        typeof(System.Func<,>)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("OpenGenericInspector", throwOnError: true)!;
+
+        var getFunc1 = type.GetMethod("GetFuncArity1")!;
+        var getFunc2 = type.GetMethod("GetFuncArity2")!;
+
+        var func1 = (Type)getFunc1.Invoke(null, Array.Empty<object>())!;
+        var func2 = (Type)getFunc2.Invoke(null, Array.Empty<object>())!;
+
+        Assert.Equal(typeof(System.Func<>), func1);
+        Assert.Equal(typeof(System.Func<,>), func2);
+    }
 }


### PR DESCRIPTION
## Summary
- handle open generic arity when binding typeof expressions, including namespace lookups
- allow `BindTypeName` to honor explicit arity overrides when resolving generic definitions
- add code generation coverage for `typeof(System.Func<>)` and `typeof(System.Func<,>)`

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --filter "TypeOfExpression_AllowsOpenGenericTypes"


------
https://chatgpt.com/codex/tasks/task_e_68dc5861a80c832faaf0095a6ffb217d