### PR TITLE
Support casting with fully qualified type names

### DIFF
--- a/docs/compiler/details.md
+++ b/docs/compiler/details.md
@@ -19,3 +19,31 @@ The compiler API doesn't keep track of what framework to target.
 What version you are targeting depend on the core libraries that you reference.
 
 You can add the `TargetFrameworkAttribute` to an assembly to indicate what version.
+
+## Reflection FAQ
+
+### Why does casting a `MemberInfo` to `MethodInfo` fail?
+
+`Type.GetMembers()` (and similar APIs) return heterogeneous collections of `MemberInfo`
+instances: constructors, events, fields, properties, and methods. Only the entries
+that actually represent methods derive from `System.Reflection.MethodInfo`. Attempting
+to cast every `MemberInfo` to `MethodInfo` therefore throws an `InvalidCastException`
+for the non-method members. Filter the list first, for example:
+
+```raven
+import System.Reflection.*
+
+let type = typeof(System.String)
+let members = type.GetMembers()
+
+for member in members {
+    if member is MethodInfo method {
+        // Pass the instance the method should execute on (or null for static methods)
+        method.Invoke(null, System.Array.Empty<object>())
+    }
+}
+```
+
+Here the pattern guard ensures that only `MethodInfo` instances flow into `Invoke` so the
+cast never fails. Notice that the first argument to `Invoke` must be the object instance on
+which to invoke the method (or `null` for static methods), not the `MemberInfo` itself.

--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -506,12 +506,22 @@ internal abstract class Binder
 
     private ITypeSymbol? ResolveQualifiedType(QualifiedNameSyntax qualified)
     {
+        var symbol = ResolveQualifiedNamespaceOrType(qualified);
+        return symbol as ITypeSymbol;
+    }
+
+    private INamespaceOrTypeSymbol? ResolveQualifiedNamespaceOrType(QualifiedNameSyntax qualified)
+    {
         var left = ResolveQualifiedLeft(qualified.Left);
 
         if (left is INamespaceSymbol ns)
         {
             if (qualified.Right is IdentifierNameSyntax id)
             {
+                var namespaceMember = ns.LookupNamespace(id.Identifier.ValueText);
+                if (namespaceMember is not null)
+                    return namespaceMember;
+
                 var type = SelectByArity(ns.GetMembers(id.Identifier.ValueText)
                         .OfType<INamedTypeSymbol>(), 0)
                     ?? ns.LookupType(id.Identifier.ValueText);
@@ -549,10 +559,10 @@ internal abstract class Binder
             return null;
         }
 
-        return null;
+        return left;
     }
 
-    private object? ResolveQualifiedLeft(TypeSyntax left)
+    private INamespaceOrTypeSymbol? ResolveQualifiedLeft(TypeSyntax left)
     {
         if (left is IdentifierNameSyntax id)
         {
@@ -603,7 +613,7 @@ internal abstract class Binder
 
         if (left is QualifiedNameSyntax qualified)
         {
-            return ResolveQualifiedType(qualified);
+            return ResolveQualifiedNamespaceOrType(qualified);
         }
 
         return null;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/CastExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/CastExpressionTests.cs
@@ -43,4 +43,18 @@ public class CastExpressionTests : DiagnosticTestBase
         var verifier = CreateVerifier(code);
         verifier.Verify();
     }
+
+    [Fact]
+    public void ExplicitCast_DowncastReferenceType_FullyQualified_NoDiagnostic()
+    {
+        string code = """
+        let type = typeof(System.String)
+        let members = type.GetMembers()
+        let first = members[0]
+        let method = (System.Reflection.MethodInfo)first
+        """;
+
+        var verifier = CreateVerifier(code);
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- allow qualified namespace resolution to return namespaces so casts can use fully qualified type names
- add a regression test that casts a `MemberInfo` to `System.Reflection.MethodInfo` without imports

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter CastExpressionTests

------
https://chatgpt.com/codex/tasks/task_e_68dc6052a378832fb13b4243d34298d0