### PR TITLE
Handle nullable type member lookups gracefully

### DIFF
--- a/docs/binding-infrastructure-findings.md
+++ b/docs/binding-infrastructure-findings.md
@@ -1,0 +1,43 @@
+# Binding Infrastructure Findings
+
+## Overview
+This document captures several risks uncovered while reviewing the binder and related symbol implementations. Each subsection lists the observation, the potential fallout, and ideas for mitigation.
+
+## Findings
+
+### 1. Namespace lookup favors globals over the current scope
+*Observation.* `Binder.LookupNamespace` queries the global namespace before the binder's current namespace, and only afterwards walks outward through parent binders.【F:src/Raven.CodeAnalysis/Binder/Binder.cs†L164-L175】
+
+*Why it matters.* If a compilation defines `namespace Company { namespace Diagnostics { … } }` alongside a top-level `namespace Diagnostics`, any lookup for `Diagnostics` inside `Company` will resolve to the global declaration, making the nested namespace effectively unreachable without a fully qualified name. That contradicts typical name lookup rules where the innermost scope should win.
+
+*Potential direction.* Reverse the lookup order (current → parents → global), or otherwise ensure the active namespace scope is checked before falling back to globals.
+
+### 2. Qualified name resolution prefers namespaces over types
+*Observation.* When resolving the left side of a qualified name, the binder probes for a namespace before attempting to resolve a type with the same name.【F:src/Raven.CodeAnalysis/Binder/Binder.cs†L567-L593】
+
+*Status.* **Resolved.** `ResolveQualifiedNamespaceOrType` now consults type symbols before namespaces so nested/aliased types win over equally named namespaces, producing diagnostics when type arguments are omitted rather than silently binding to the namespace.【F:src/Raven.CodeAnalysis/Binder/Binder.cs†L567-L593】
+
+*Why it matters.* In languages that allow a namespace and type to share a simple name, this ordering causes the namespace to shadow the type. As a result, constructs such as `Container.NestedType` can bind to the namespace path instead of the intended nested type, breaking member lookup and leading to confusing diagnostics.
+
+*Potential direction.* Evaluate whether type symbols should be preferred (or at least considered on equal footing) when both a namespace and a type are viable matches. Adjusting the resolution order or reporting ambiguity would prevent silent misbinding.
+
+### 3. By-ref syntax loses ref/out information during binding
+*Observation.* Originally, `ResolveType` simply returned the element type for `ByRefTypeSyntax` nodes, ignoring the presence of the ref/out modifier even though a `ByRefTypeSymbol` exists in the type system.【F:src/Raven.CodeAnalysis/Symbols/Constructed/ByRefTypeSymbol.cs†L5-L55】
+
+*Status.* **Resolved.** `Binder.ResolveType` now constructs `ByRefTypeSymbol` instances (using contextual `RefKind` hints when supplied) so by-ref declarations retain their metadata through binding.【F:src/Raven.CodeAnalysis/Binder/Binder.cs†L328-L438】
+
+*Why it matters.* Any code that relies on tracking ref, in, or out semantics during binding (for overload resolution, assignment checks, or emission) will see those types as plain value types. That can lead to incorrect conversions, missed diagnostics, or invalid IL generation.
+
+*Potential direction.* Construct the appropriate `ByRefTypeSymbol` (respecting `RefKind`) when encountering `ByRefTypeSyntax`, so downstream phases receive accurate type information.
+
+### 4. Nullable type symbols expose unfinished APIs
+*Observation.* Nullable type syntax is lowered to `NullableTypeSymbol`, but that implementation throws `NotImplementedException` from its `LookupType` member (and other members rely on the underlying type).【F:src/Raven.CodeAnalysis/Binder/Binder.cs†L383-L387】【F:src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs†L6-L52】
+
+*Status.* **Resolved.** `NullableTypeSymbol` now delegates member and type lookups to its underlying and base types so the binder reports missing-member diagnostics instead of throwing.【F:src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs†L23-L68】【F:test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs†L44-L70】
+
+*Why it matters.* Any attempt to bind members or nested types on a nullable instance (for example via `T?.Nested`) will hit the unimplemented path at runtime, crashing the compilation process instead of producing diagnostics.
+
+*Potential direction.* Either forbid such lookups explicitly during binding with clear diagnostics or flesh out the nullable symbol implementation so that member lookup is well-defined.
+
+## Next steps
+Prioritize fixes based on how frequently these scenarios occur in real-world code. A small suite of targeted unit tests around namespace shadowing, by-ref parameter binding, and nullable member access would help lock in the expected behavior once the issues are addressed.

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -1273,12 +1273,12 @@ public partial class SemanticModel
                 refKind = RefKind.Ref;
 
             var typeSyntax = parameterSyntax.TypeAnnotation?.Type;
-            if (typeSyntax is ByRefTypeSyntax byRefType)
-                typeSyntax = byRefType.ElementType;
-
+            var refKindForType = refKind == RefKind.None && typeSyntax is ByRefTypeSyntax ? RefKind.Ref : refKind;
             var parameterType = typeSyntax is null
                 ? Compilation.ErrorTypeSymbol
-                : classBinder.ResolveType(typeSyntax);
+                : refKindForType is RefKind.Ref or RefKind.Out or RefKind.In or RefKind.RefReadOnly or RefKind.RefReadOnlyParameter
+                    ? classBinder.ResolveType(typeSyntax, refKindForType)
+                    : classBinder.ResolveType(typeSyntax);
 
             var hasDefaultValue = TypeMemberBinder.TryEvaluateParameterDefaultValue(parameterSyntax, parameterType, out var defaultValue);
             var parameterSymbol = new SourceParameterSymbol(

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/NullableTypeSymbol.cs
@@ -35,20 +35,43 @@ internal sealed class NullableTypeSymbol : SourceSymbol, ITypeSymbol
 
     public ImmutableArray<INamedTypeSymbol> AllInterfaces => UnderlyingType.AllInterfaces;
 
-    public ImmutableArray<ISymbol> GetMembers() => BaseType!.GetMembers();
+    public ImmutableArray<ISymbol> GetMembers()
+    {
+        if (BaseType is not null)
+            return BaseType.GetMembers();
 
-    public ImmutableArray<ISymbol> GetMembers(string name) => BaseType!.GetMembers(name);
+        return UnderlyingType.GetMembers();
+    }
+
+    public ImmutableArray<ISymbol> GetMembers(string name)
+    {
+        if (BaseType is not null)
+            return BaseType.GetMembers(name);
+
+        return UnderlyingType.GetMembers(name);
+    }
 
     public ITypeSymbol? LookupType(string name)
     {
-        throw new NotImplementedException();
+        var nested = UnderlyingType.LookupType(name);
+        if (nested is not null)
+            return nested;
+
+        return BaseType?.LookupType(name);
     }
 
     public override string ToString() => Name;
 
     public bool IsMemberDefined(string name, out ISymbol? symbol)
     {
-        throw new NotSupportedException();
+        if (UnderlyingType.IsMemberDefined(name, out symbol))
+            return true;
+
+        if (BaseType is not null && BaseType.IsMemberDefined(name, out symbol))
+            return true;
+
+        symbol = null;
+        return false;
     }
 
     public override void Accept(SymbolVisitor visitor)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ByRefParameterTests.cs
@@ -23,6 +23,8 @@ class C {
         var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
         var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(method)!;
         var symbol = methodSymbol.Parameters.Single();
+        var type = Assert.IsType<ByRefTypeSymbol>(symbol.Type);
+        Assert.Equal(RefKind.Ref, type.RefKind);
         Assert.Equal(RefKind.Ref, symbol.RefKind);
     }
 
@@ -40,6 +42,8 @@ class C {
         var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
         var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(method)!;
         var symbol = methodSymbol.Parameters.Single();
+        var type = Assert.IsType<ByRefTypeSymbol>(symbol.Type);
+        Assert.Equal(RefKind.Out, type.RefKind);
         Assert.Equal(RefKind.Out, symbol.RefKind);
     }
 
@@ -57,6 +61,8 @@ class C {
         var ctor = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
         var ctorSymbol = (IMethodSymbol)model.GetDeclaredSymbol(ctor)!;
         var parameter = ctorSymbol.Parameters.Single();
+        var type = Assert.IsType<ByRefTypeSymbol>(parameter.Type);
+        Assert.Equal(RefKind.Ref, type.RefKind);
         Assert.Equal(RefKind.Ref, parameter.RefKind);
     }
 
@@ -74,6 +80,8 @@ class C {
         var ctor = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
         var ctorSymbol = (IMethodSymbol)model.GetDeclaredSymbol(ctor)!;
         var parameter = ctorSymbol.Parameters.Single();
+        var type = Assert.IsType<ByRefTypeSymbol>(parameter.Type);
+        Assert.Equal(RefKind.Out, type.RefKind);
         Assert.Equal(RefKind.Out, parameter.RefKind);
     }
 
@@ -91,6 +99,8 @@ func outer() {
         var inner = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().Single(l => l.Identifier.Text == "inner");
         var symbol = (IMethodSymbol)model.GetDeclaredSymbol(inner)!;
         var parameter = symbol.Parameters.Single();
+        var type = Assert.IsType<ByRefTypeSymbol>(parameter.Type);
+        Assert.Equal(RefKind.Ref, type.RefKind);
         Assert.Equal(RefKind.Ref, parameter.RefKind);
     }
 
@@ -108,6 +118,8 @@ func outer() {
         var inner = tree.GetRoot().DescendantNodes().OfType<FunctionStatementSyntax>().Single(l => l.Identifier.Text == "inner");
         var symbol = (IMethodSymbol)model.GetDeclaredSymbol(inner)!;
         var parameter = symbol.Parameters.Single();
+        var type = Assert.IsType<ByRefTypeSymbol>(parameter.Type);
+        Assert.Equal(RefKind.Out, type.RefKind);
         Assert.Equal(RefKind.Out, parameter.RefKind);
     }
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
@@ -61,6 +61,29 @@ public class NullableTypeTests : CompilationTestBase
     }
 
     [Fact]
+    public void NullableTypeSymbol_LookupType_DoesNotThrow()
+    {
+        var compilation = CreateCompilation();
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var nullable = new NullableTypeSymbol(intType, null, null, null, []);
+
+        var exception = Record.Exception(() => nullable.LookupType("DoesNotExist"));
+        Assert.Null(exception);
+
+        Assert.Null(nullable.LookupType("DoesNotExist"));
+        Assert.False(nullable.IsMemberDefined("DoesNotExist", out _));
+    }
+
+    [Fact]
+    public void NullableQualifiedName_ReportsMissingType()
+    {
+        var (compilation, _) = CreateCompilation("let x: string?.Nested = null");
+
+        var diagnostic = Assert.Single(compilation.GetDiagnostics());
+        Assert.Equal(CompilerDiagnostics.TheNameDoesNotExistInTheCurrentContext, diagnostic.Descriptor);
+    }
+
+    [Fact]
     public void NonNullable_To_Nullable_Conversion_IsImplicit()
     {
         var compilation = CreateCompilation();

--- a/test/Raven.CodeAnalysis.Tests/Semantics/QualifiedNameBindingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/QualifiedNameBindingTests.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public sealed class QualifiedNameBindingTests : CompilationTestBase
+{
+    [Fact]
+    public void QualifiedName_PrefersTypeOverNamespace()
+    {
+        const string source = """
+using Lib;
+
+namespace Lib
+{
+    class Container
+    {
+        public class Inner {}
+    }
+}
+
+namespace Container
+{
+    class Inner {}
+}
+
+class Holder
+{
+    public Value: Container.Inner { get; }
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var property = root.DescendantNodes().OfType<PropertyDeclarationSyntax>().Single();
+        var propertySymbol = Assert.IsAssignableFrom<IPropertySymbol>(model.GetDeclaredSymbol(property));
+
+        Assert.Equal(
+            "Lib.Container.Inner",
+            propertySymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+
+        Assert.Empty(compilation.GetDiagnostics());
+    }
+}


### PR DESCRIPTION
## Summary
- delegate nullable type member and nested-type queries to the underlying symbol so lookups return null instead of throwing
- add regression tests to cover nullable lookup behavior and ensure qualified nullable names report missing-type diagnostics
- mark the nullable lookup finding in the binding report as resolved

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter NullableTypeTests` *(fails: generated syntax/model sources are not refreshed, leaving many syntax node types undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6694c100832f93d990c6402ad56d