### PR TITLE
Fix resolving qualified types in cast expressions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -578,6 +578,13 @@ internal abstract class Binder
             return null;
         }
 
+        var metadataName = qualified.ToString();
+        if (!string.IsNullOrEmpty(metadataName))
+        {
+            if (Compilation.GetTypeByMetadataName(metadataName) is { } metadataType)
+                return metadataType;
+        }
+
         return left;
     }
 


### PR DESCRIPTION
## Summary
- fall back to metadata-based lookup when resolving qualified type names
- ensure fully qualified casts like System.Reflection.MethodInfo succeed even when scope lookups fail

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: existing TypeOfExpression_MethodReturnTypeAndOperandAgree test)*

------
https://chatgpt.com/codex/tasks/task_e_68dcefd0f308832fbc8e1802e0e4a0aa