### PR TITLE
Remove func keyword from lambda syntax

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -190,9 +190,13 @@ TypeTestExpression       ::= AdditiveExpression {('is' | 'as') Type} ;
 AdditiveExpression       ::= MultiplicativeExpression {('+' | '-') MultiplicativeExpression} ;
 MultiplicativeExpression ::= UnaryExpression {('*' | '/' | '%') UnaryExpression} ;
 
-UnaryExpression          ::= PostfixExpression
+UnaryExpression          ::= LambdaExpression
+                           | PostfixExpression
                            | ('+' | '-' | '!') UnaryExpression
                            | CastExpression ;
+
+LambdaExpression         ::= LambdaParameterClause ReturnTypeClause? '=>' Expression ;
+LambdaParameterClause    ::= '(' ParameterList? ')' | Parameter ;
 
 CastExpression           ::= '(' Type ')' UnaryExpression ;
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -811,7 +811,7 @@ import System.Linq.*
 let odds = List<int>()
 odds.Add(1)
 odds.Add(3)
-let filtered = odds.Where(func (value) => value % 2 == 1)
+let filtered = odds.Where(value => value % 2 == 1)
 ```
 
 The compiler treats `Where` as an instance-style invocation even though it is
@@ -1012,9 +1012,10 @@ func outer() {
 
 ### Lambda expressions and captured variables
 
-Lambda expressions use the `func` keyword followed by a parameter list, an
-arrow, and either an expression or block body. Lambdas may appear wherever a
-function value is expected. When a lambda references a local defined in an
+Lambda expressions start with either a parenthesized parameter list or a single
+identifier, optionally followed by a return-type arrow, and then the `=>` token
+with either an expression or block body. Lambdas may appear wherever a function
+value is expected. When a lambda references a local defined in an
 outer scope, the compiler lifts that local into shared closure storage so both
 the outer scope and the lambda observe the same value. Each captured local is
 wrapped in a reference cell (implemented with `System.Runtime.CompilerServices.StrongBox<T>`)

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -477,7 +477,6 @@
     <Slot Name="ColonToken" Type="Token" DefaultToken="ColonToken"/>
   </Node>
   <Node Name="SimpleLambdaExpression" Inherits="LambdaExpression">
-    <Slot Name="FuncKeyword" Type="Token" IsInherited="true"  DefaultToken="FuncKeyword"/>
     <Slot Name="Parameter" Type="Parameter" />
     <Slot Name="ReturnType" Type="ArrowTypeClause" />
     <Slot Name="ArrowToken" Type="Token" IsInherited="true"  DefaultToken="ArrowToken"/>
@@ -519,7 +518,6 @@
     <Slot Name="Declarators" Type="SeparatedList" ElementType="VariableDeclarator" />
   </Node>
   <Node Name="LambdaExpression" Inherits="Expression" IsAbstract="true">
-    <Slot Name="FuncKeyword" Type="Token" IsAbstract="true"  DefaultToken="FuncKeyword"/>
     <Slot Name="ArrowToken" Type="Token" IsAbstract="true"  DefaultToken="ArrowToken"/>
     <Slot Name="ExpressionBody" Type="Expression" IsAbstract="true" />
   </Node>
@@ -648,7 +646,6 @@
     <Slot Name="Type" Type="Type" />
   </Node>
   <Node Name="ParenthesizedLambdaExpression" Inherits="LambdaExpression">
-    <Slot Name="FuncKeyword" Type="Token" IsInherited="true"  DefaultToken="FuncKeyword"/>
     <Slot Name="ParameterList" Type="ParameterList" />
     <Slot Name="ReturnType" Type="ArrowTypeClause" />
     <Slot Name="ArrowToken" Type="Token" IsInherited="true"  DefaultToken="ArrowToken"/>

--- a/src/Raven.Compiler/samples/lambda.rav
+++ b/src/Raven.Compiler/samples/lambda.rav
@@ -5,12 +5,12 @@
 import System.Console.*
 
 // Expression-bodied lambda assigned to a local delegate
-let add = func (a: int, b: int) -> int => a + b
+let add = (a: int, b: int) -> int => a + b
 WriteLine("2 + 3 = " + add(2, 3).ToString())
 
 // Block-bodied lambda that captures and mutates an outer variable
 var offset = 10
-let adjust = func (value: int) -> int => {
+let adjust = (value: int) -> int => {
     let result = value + offset
     offset = offset + 1
     result
@@ -20,10 +20,10 @@ WriteLine("adjust(5) = " + adjust(5).ToString())
 WriteLine("offset after adjust = " + offset.ToString())
 
 // Nested lambda returning a closure that shares captured state
-let makeIncrementer = func (start: int) => {
+let makeIncrementer = (start: int) => {
     var current = start
 
-    let increment = func (delta: int) -> int => {
+    let increment = (delta: int) -> int => {
         current = current + delta
         current
     }

--- a/src/Raven.Compiler/samples/linq.rav
+++ b/src/Raven.Compiler/samples/linq.rav
@@ -9,7 +9,7 @@ numbers.Add(-1)
 numbers.Add(2)
 numbers.Add(1)
 
-let positives = numbers.Where(func (value: int) -> bool => value > 0)
+let positives = numbers.Where((value: int) -> bool => value > 0)
 
 for each value in positives {
     WriteLine(value)

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/LambdaCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/LambdaCodeGenTests.cs
@@ -13,7 +13,7 @@ public class LambdaCodeGenTests
         var code = """
 class Calculator {
     Add() -> int {
-        let add = func (x: int, y: int) -> int => x + y
+        let add = (x: int, y: int) -> int => x + y
         return add(2, 3)
     }
 }
@@ -46,7 +46,7 @@ class Calculator {
         var code = """
 class Checker {
     AreEqual(left: int, right: int) -> bool {
-        let equals = func (x: int, y: int) -> bool => x == y
+        let equals = (x: int, y: int) -> bool => x == y
         return equals(left, right)
     }
 }
@@ -82,7 +82,7 @@ class Checker {
         var code = """
 class Calculator {
     Sum() -> int {
-        let make = func (x: int, y: int) -> int => {
+        let make = (x: int, y: int) -> int => {
             let total = x + y
             total
         }
@@ -119,7 +119,7 @@ class Calculator {
         var code = """
 class Calculator {
     Combine(x: int) -> int {
-        let add = func (y: int) -> int => x + y
+        let add = (y: int) -> int => x + y
         return add(4)
     }
 }
@@ -153,7 +153,7 @@ class Calculator {
 class Counter {
     Multiply() -> int {
         let factor = 5
-        let multiply = func (value: int) -> int => factor * value
+        let multiply = (value: int) -> int => factor * value
         return multiply(3)
     }
 }
@@ -188,7 +188,7 @@ class Holder {
     value: int = 8
 
     Compute() -> int {
-        let add = func (offset: int) -> int => self.value + offset
+        let add = (offset: int) -> int => self.value + offset
         return add(7)
     }
 }
@@ -222,7 +222,7 @@ class Holder {
 class Counter {
     Run() -> int {
         var total = 1
-        let add = func (delta: int) -> int => {
+        let add = (delta: int) -> int => {
             total = total + delta
             total
         }
@@ -262,8 +262,8 @@ class Counter {
 class Counter {
     Run() -> int {
         var total = 1
-        let make = func () => {
-            let inner = func (delta: int) -> int => {
+        let make = () => {
+            let inner = (delta: int) -> int => {
                 total = total + delta
                 return total
             }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/BinderAndLowererTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/BinderAndLowererTests.cs
@@ -163,7 +163,7 @@ class C {
         const string source = """
 class C {
     Test(flag: bool) {
-        let lambda = func () => {
+        let lambda = () => {
             while flag {
                 ()
             }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ExtensionMethodSemanticTests.cs
@@ -225,7 +225,7 @@ import System.Collections.Generic.*
 import System.Linq.*
 
 let numbers = [1, 2, 3]
-let result = numbers.Where(func (value) => value == 2)
+let result = numbers.Where(value => value == 2)
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -303,7 +303,7 @@ import System.Collections.Generic.*
 import System.Linq.*
 
 let numbers = [1, 2, 3]
-let result = numbers.Where(func (value: int) -> bool => value == 2)
+let result = numbers.Where((value: int) -> bool => value == 2)
 """;
 
         var (compilation, _) = CreateCompilation(source);

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LambdaCapturedVariablesTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LambdaCapturedVariablesTests.cs
@@ -14,7 +14,7 @@ public class LambdaCapturedVariablesTests
         var code = """
 class Calculator {
     Apply(base: int) -> int {
-        let lambda = func (offset: int) -> int => base + offset
+        let lambda = (offset: int) -> int => base + offset
         return lambda(2)
     }
 }
@@ -45,7 +45,7 @@ class Calculator {
 class Calculator {
     Apply() -> int {
         let factor = 3
-        let lambda = func (value: int) -> int => factor * value
+        let lambda = (value: int) -> int => factor * value
         return lambda(4)
     }
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
@@ -22,7 +22,7 @@ class Calculator {
     }
 
     Apply() -> int {
-        return Transform(5, func (delta) => delta + 1)
+        return Transform(5, delta => delta + 1)
     }
 }
 """;
@@ -134,7 +134,7 @@ class Container {
 import System.*
 class Calculator {
     Compute() -> int {
-        let add = func (left: int, right: int) -> int => left + right
+        let add = (left: int, right: int) -> int => left + right
         return add(2, 3)
     }
 }
@@ -169,7 +169,7 @@ public class LambdaInferenceDiagnosticsTests : DiagnosticTestBase
         const string code = """
 class Container {
     Provide() -> unit {
-        let lambda = func (value) => value
+        let lambda = (value) => value
     }
 }
 """;

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MetadataExtensionMethodSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MetadataExtensionMethodSemanticTests.cs
@@ -86,7 +86,7 @@ import System.Collections.Generic.*
 import Raven.MetadataFixtures.Linq.*
 
 let numbers = List<int>()
-let projection = numbers.Select(func (value) => value)
+let projection = numbers.Select(value => value)
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -221,7 +221,7 @@ import System.Collections.Generic.*
 import Raven.MetadataFixtures.Linq.*
 
 let numbers = List<int>()
-let anyPositive = numbers.Any(func (value: int) => value > 0)
+let anyPositive = numbers.Any((value: int) => value > 0)
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -321,7 +321,7 @@ import System.Collections.Generic.*
 import Raven.MetadataFixtures.Linq.*
 
 let numbers = List<int>()
-let projection = numbers.Select(func (value) => value.ToString())
+let projection = numbers.Select(value => value.ToString())
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -375,7 +375,7 @@ import System.Collections.Generic.*
 import Raven.MetadataFixtures.Linq.*
 
 let numbers = List<int>()
-let positives = numbers.Where(func (value) => value > 0)
+let positives = numbers.Where(value => value > 0)
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -422,7 +422,7 @@ import System.*
 import System.Linq.*
 
 let numbers: int[] = [1, 2, 3]
-let result = numbers.Where(func (value) => value == 2)
+let result = numbers.Where(value => value == 2)
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -472,7 +472,7 @@ import System.*
 import System.Linq.*
 
 let numbers: int[] = [1, 2, 3]
-let result = numbers.Where(func (value) => value > 0)
+let result = numbers.Where(value => value > 0)
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -535,7 +535,7 @@ import System.*
 import System.Linq.*
 
 let numbers: int[] = [1, 2, 3]
-let result = numbers.Where(func (value) => value > 0)
+let result = numbers.Where(value => value > 0)
 """;
 
         var (compilation, tree) = CreateCompilation(source);
@@ -608,7 +608,7 @@ import System.Collections.Generic.*
 import Raven.MetadataFixtures.Linq.*
 
 let numbers = List<int>()
-let positives = numbers.Where(func (value: int, index: int) => value > index)
+let positives = numbers.Where((value: int, index: int) => value > index)
 """;
 
         var (compilation, tree) = CreateCompilation(source);

--- a/test/Raven.CodeAnalysis.Tests/Syntax/LambdaExpressionSyntaxTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/LambdaExpressionSyntaxTests.cs
@@ -1,0 +1,72 @@
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+public class LambdaExpressionSyntaxTests
+{
+    [Fact]
+    public void SimpleLambda_WithIdentifierParameter_Parses()
+    {
+        var expression = ParseExpression("value => value");
+
+        var lambda = Assert.IsType<SimpleLambdaExpressionSyntax>(expression);
+        Assert.Equal("value", lambda.Parameter.Identifier.Text);
+    }
+
+    [Fact]
+    public void ParenthesizedLambda_WithMultipleParameters_Parses()
+    {
+        var expression = ParseExpression("(left, right) => left + right");
+
+        var lambda = Assert.IsType<ParenthesizedLambdaExpressionSyntax>(expression);
+        Assert.Collection(
+            lambda.ParameterList.Parameters,
+            parameter => Assert.Equal("left", parameter.Identifier.Text),
+            parameter => Assert.Equal("right", parameter.Identifier.Text));
+    }
+
+    [Fact]
+    public void ParenthesizedLambda_WithoutParameters_Parses()
+    {
+        var expression = ParseExpression("() => 42");
+
+        Assert.IsType<ParenthesizedLambdaExpressionSyntax>(expression);
+    }
+
+    [Fact]
+    public void ParenthesizedExpression_WithSingleIdentifier_DoesNotParseAsLambda()
+    {
+        var expression = ParseExpression("(value)");
+
+        Assert.IsType<ParenthesizedExpressionSyntax>(expression);
+    }
+
+    [Fact]
+    public void TupleExpression_WithMultipleElements_DoesNotParseAsLambda()
+    {
+        var expression = ParseExpression("(first, second)");
+
+        Assert.IsType<TupleExpressionSyntax>(expression);
+    }
+
+    [Fact]
+    public void UnitExpression_WithoutArrow_DoesNotParseAsLambda()
+    {
+        var expression = ParseExpression("()");
+
+        Assert.IsType<UnitExpressionSyntax>(expression);
+    }
+
+    private static ExpressionSyntax ParseExpression(string code)
+    {
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+
+        Assert.Single(root.Members);
+        var globalStatement = Assert.IsType<GlobalStatementSyntax>(root.Members[0]);
+        var statement = Assert.IsType<ExpressionStatementSyntax>(globalStatement.Statement);
+
+        return statement.Expression;
+    }
+}


### PR DESCRIPTION
## Summary
- teach the expression parser to detect simple and parenthesized lambdas without a leading `func`
- drop the `FuncKeyword` slot from lambda syntax nodes and refresh docs, grammar, and samples for the new syntax
- update lambda-focused semantic and codegen tests to use the keyword-free form

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: InvocationFallsBackToConstructorWhenMethodNotApplicable reports RAV1501 and triggers TerminalLogger out-of-range error)*

------
https://chatgpt.com/codex/tasks/task_e_68dcec68e650832fbd8e82c3a1879598