### PR TITLE
Ensure symbol equality respects type kinds

### DIFF
--- a/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
+++ b/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
@@ -37,6 +37,9 @@ public sealed class SymbolEqualityComparer : IEqualityComparer<ISymbol>
 
         if (x is ITypeSymbol typeX && y is ITypeSymbol typeY)
         {
+            if (typeX.TypeKind != typeY.TypeKind)
+                return false;
+
             if (typeX.SpecialType != SpecialType.None &&
                 typeX.SpecialType == typeY.SpecialType &&
                 IsSimpleSpecialType(typeX.SpecialType))
@@ -162,6 +165,19 @@ public sealed class SymbolEqualityComparer : IEqualityComparer<ISymbol>
 
         var hash = new HashCode();
         hash.Add(obj.Kind);
+
+        if (obj is ITypeSymbol typeSymbol)
+        {
+            hash.Add(typeSymbol.TypeKind);
+
+            if (typeSymbol.SpecialType != SpecialType.None &&
+                IsSimpleSpecialType(typeSymbol.SpecialType))
+            {
+                hash.Add(typeSymbol.SpecialType);
+                return hash.ToHashCode();
+            }
+        }
+
         hash.Add(obj.Name, StringComparer.Ordinal);
         hash.Add(obj.MetadataName, StringComparer.Ordinal);
 

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SymbolEqualityComparerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SymbolEqualityComparerTests.cs
@@ -179,7 +179,21 @@ public class SymbolEqualityComparerTests
         Assert.DoesNotContain(stringArray, set);
     }
 
-    private sealed class StubSymbol : ISymbol
+    [Fact]
+    public void Comparer_DistinguishesTypeKinds()
+    {
+        var comparer = SymbolEqualityComparer.Default;
+
+        var delegateSymbol = new StubTypeSymbol(TypeKind.Delegate);
+        var classSymbol = new StubTypeSymbol(TypeKind.Class);
+
+        Assert.False(comparer.Equals(delegateSymbol, classSymbol));
+
+        var set = new HashSet<ISymbol>(comparer) { delegateSymbol };
+        Assert.DoesNotContain(classSymbol, set);
+    }
+
+    private class StubSymbol : ISymbol
     {
         public StubSymbol(
             SymbolKind kind,
@@ -240,5 +254,42 @@ public class SymbolEqualityComparerTests
         public void Accept(SymbolVisitor visitor) => visitor.DefaultVisit(this);
 
         public TResult Accept<TResult>(SymbolVisitor<TResult> visitor) => visitor.DefaultVisit(this);
+    }
+
+    private sealed class StubTypeSymbol : StubSymbol, ITypeSymbol
+    {
+        public StubTypeSymbol(TypeKind typeKind)
+            : base(SymbolKind.Type, "Processor", "Processor")
+        {
+            TypeKind = typeKind;
+        }
+
+        public INamedTypeSymbol? BaseType => null;
+
+        public ITypeSymbol? OriginalDefinition => this;
+
+        public SpecialType SpecialType => SpecialType.None;
+
+        public TypeKind TypeKind { get; }
+
+        public ImmutableArray<INamedTypeSymbol> Interfaces => ImmutableArray<INamedTypeSymbol>.Empty;
+
+        public ImmutableArray<INamedTypeSymbol> AllInterfaces => ImmutableArray<INamedTypeSymbol>.Empty;
+
+        public bool IsNamespace => false;
+
+        public bool IsType => true;
+
+        public ImmutableArray<ISymbol> GetMembers() => ImmutableArray<ISymbol>.Empty;
+
+        public ImmutableArray<ISymbol> GetMembers(string name) => ImmutableArray<ISymbol>.Empty;
+
+        public ITypeSymbol? LookupType(string name) => null;
+
+        public bool IsMemberDefined(string name, out ISymbol? symbol)
+        {
+            symbol = null;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- require type symbols to match `TypeKind` in `SymbolEqualityComparer`
- update comparer hashing to include `TypeKind` and special type shortcuts
- extend comparer tests with a stub type to verify type-kind distinctions

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests --filter SymbolEqualityComparerTests`
- `dotnet test test/Raven.CodeAnalysis.Tests --filter LambdaInferenceTests`


------
https://chatgpt.com/codex/tasks/task_e_68dd26a78204832fa1af1893a4aef3d7