### PR TITLE
Align nullable symbol equality with C# semantics

### DIFF
--- a/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
+++ b/src/Raven.CodeAnalysis/SymbolEqualityComparer.cs
@@ -246,12 +246,6 @@ public sealed class SymbolEqualityComparer : IEqualityComparer<ISymbol>
                 continue;
             }
 
-            if (!_includeNullability && current is NullableTypeSymbol nullable)
-            {
-                current = nullable.UnderlyingType;
-                continue;
-            }
-
             return current;
         }
     }

--- a/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
@@ -169,6 +169,9 @@ internal partial class PENamedTypeSymbol : PESymbol, INamedTypeSymbol
             if (type.FullName == "System.Type")
                 return SpecialType.System_Type;
 
+            if (type.FullName == "System.Nullable`1")
+                return SpecialType.System_Nullable_T;
+
             if (type.Namespace == "System" && type.Name.StartsWith("ValueTuple`"))
             {
                 return type.GetGenericArguments().Length switch

--- a/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs
@@ -25,6 +25,16 @@ public class NullableTypeTests : CompilationTestBase
     }
 
     [Fact]
+    public void MetadataNullableDefinition_ReportsNullableSpecialType()
+    {
+        var compilation = CreateCompilation();
+        var nullableDefinition = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            compilation.GetTypeByMetadataName("System.Nullable`1"));
+
+        Assert.Equal(SpecialType.System_Nullable_T, nullableDefinition.SpecialType);
+    }
+
+    [Fact]
     public void ReferencedLibrary_NullabilityAnnotations_AreRead()
     {
         var compilation = CreateCompilation();

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SymbolEqualityComparerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SymbolEqualityComparerTests.cs
@@ -31,7 +31,7 @@ public class SymbolEqualityComparerTests
     }
 
     [Fact]
-    public void IgnoringNullabilityComparer_TreatsNullableAndUnderlyingAsEqual()
+    public void IgnoringNullabilityComparer_DistinguishesNullableValueTypes()
     {
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddReferences(TestMetadataReferences.Default);
@@ -40,14 +40,14 @@ public class SymbolEqualityComparerTests
         var nullableInt = new NullableTypeSymbol(intType, null, null, null, []);
 
         var comparer = SymbolEqualityComparer.IgnoringNullability;
-        Assert.True(comparer.Equals(intType, nullableInt));
+        Assert.False(comparer.Equals(intType, nullableInt));
 
         var dictionary = new Dictionary<ISymbol, int>(comparer)
         {
             [intType] = 1,
         };
 
-        Assert.True(dictionary.ContainsKey(nullableInt));
+        Assert.False(dictionary.ContainsKey(nullableInt));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- stop unwrapping `NullableTypeSymbol` instances when nullability is ignored so value-type nullables remain distinct, matching C#
- recognize metadata `System.Nullable`1` as `SpecialType.System_Nullable_T` and document the behavior with unit coverage
- update symbol equality tests to reflect the stricter comparison semantics

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: TypeMetadataNameTests.GetClrType_ResolvesConstructedGenericFromMetadata currently reports Action<string> mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2c1df914832fa04667fe6d1fed64