### PR TITLE
Fix captured locals boxing for lambda closures

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -451,7 +451,7 @@ internal class TypeGenerator
         if (symbol is ILocalSymbol localSymbol && localSymbol.Type is not null)
         {
             var elementType = ResolveClrType(localSymbol.Type);
-            return typeof(System.Runtime.CompilerServices.StrongBox<>).MakeGenericType(elementType);
+            return CodeGen.GetStrongBoxType(elementType);
         }
 
         return ResolveClrType(typeSymbol);


### PR DESCRIPTION
## Summary
- synthesize a reusable `<>StrongBox<T>` type in the code generator
- ensure captured locals are discovered when lambdas appear in declarations and expression statements
- resolve captured-local field types with the synthesized strongbox

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: known MethodGroup diagnostics expectation / MSBuild logger issue)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4f210d44832fb122b9c998723b44