### PR TITLE
Fix lambda block return inference

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
@@ -140,7 +140,14 @@ partial class BlockBinder
 
         var bodyExpr = lambdaBinder.BindExpression(syntax.ExpressionBody, allowReturn: true);
 
-        var inferred = bodyExpr.Type ?? ReturnTypeCollector.Infer(bodyExpr);
+        var inferred = bodyExpr.Type;
+        var unitType = Compilation.GetSpecialType(SpecialType.System_Unit);
+        if (inferred is null || SymbolEqualityComparer.Default.Equals(inferred, unitType))
+        {
+            var collected = ReturnTypeCollector.Infer(bodyExpr);
+            if (collected is not null)
+                inferred = collected;
+        }
 
         ITypeSymbol returnType;
         if (returnTypeSyntax is not null)


### PR DESCRIPTION
## Summary
- ensure lambda block bodies re-run return type inference when their initial type is unit so explicit return statements satisfy annotated signatures
- add a regression test covering a lambda block with an explicit return expression

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "Lambda_BlockBody_WithExplicitReturn_ReturnsComputedValue"


------
https://chatgpt.com/codex/tasks/task_e_68dd59cc3be8832f9b45a1a5138c1f16