### PR TITLE
Add regression test for nested lambda return types

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
@@ -227,6 +227,22 @@ class Calculator {
     }
 
     [Fact]
+    public void Lambda_ReturningLambda_WithExplicitReturnType_ComposesSuccessfully()
+    {
+        const string code = """
+import System.*
+import System.Console.*
+
+let makeAdder = (x: int) -> Func<int, int> => (a: int) => x + a
+""";
+
+        var (compilation, _) = CreateCompilation(code);
+        var diagnostics = compilation.GetDiagnostics();
+
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+    }
+
+    [Fact]
     public void MetadataDelegate_PreservesDelegateTypeKind_WhenConstructed()
     {
         const string code = "class Container { }";


### PR DESCRIPTION
## Summary
- add a regression test covering lambdas that return another lambda with an explicit Func return type

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter Lambda_ReturningLambda_WithExplicitReturnType_ComposesSuccessfully --logger "console;verbosity=minimal"


------
https://chatgpt.com/codex/tasks/task_e_68dd61a1ae18832fa22847a638b43b6f