### PR TITLE
Document implicit delegate synthesis for lambdas

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -278,6 +278,21 @@ func example(x: int) -> {
 // inferred return type: int | string
 ```
 
+When a lambda expression is assigned to a binding without an explicit type, Raven
+still materialises a concrete delegate. The compiler synthesises an appropriate
+`System.Func`/`System.Action` definition using the lambda's parameter types and
+the inferred return type (treating `unit`/`void` as an action). Captured
+variables participate in the enclosing flow analysis before the delegate type is
+constructed, so the lambda observes the same declared type as any other use of
+the variable.
+
+```raven
+let a = 42
+let makeAdder = () => a + 3
+
+makeAdder() // returns 45, makeAdder : System.Func<int>
+```
+
 ### Additional type inference rules (normative)
 
 The following clarifications extend the type inference model:


### PR DESCRIPTION
## Summary
- document how typeless lambda bindings synthesize System.Func/System.Action delegates
- add an example showing a capture infers System.Func<int>

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: pre-existing TypeOf and conversion assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6a0eadcc832f9ad8e349c9a02a9c