### PR TITLE
Allow lambda return type inference when annotation is omitted

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
@@ -115,8 +115,8 @@ partial class BlockBinder
 
         TypeSyntax? returnTypeSyntax = syntax switch
         {
-            SimpleLambdaExpressionSyntax s => s.ReturnType.Type,
-            ParenthesizedLambdaExpressionSyntax p => p.ReturnType.Type,
+            SimpleLambdaExpressionSyntax s => s.ReturnType?.Type,
+            ParenthesizedLambdaExpressionSyntax p => p.ReturnType?.Type,
             _ => null
         };
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -416,11 +416,6 @@ internal class ExpressionSyntaxParser : SyntaxParser
 
         var body = new ExpressionSyntaxParser(this).ParseExpression();
 
-        returnType ??= ArrowTypeClause(
-            SyntaxList.Empty,
-            MissingToken(SyntaxKind.ArrowToken),
-            IdentifierName(MissingToken(SyntaxKind.IdentifierToken)));
-
         lambda = ParenthesizedLambdaExpression(
             parameterList,
             returnType,
@@ -471,11 +466,6 @@ internal class ExpressionSyntaxParser : SyntaxParser
         ConsumeTokenOrMissing(SyntaxKind.FatArrowToken, out var fatArrowToken);
 
         var body = new ExpressionSyntaxParser(this).ParseExpression();
-
-        returnType ??= ArrowTypeClause(
-            SyntaxList.Empty,
-            MissingToken(SyntaxKind.ArrowToken),
-            IdentifierName(MissingToken(SyntaxKind.IdentifierToken)));
 
         var parameter = Parameter(attributeLists, modifiers, identifier, typeAnnotation, defaultValue);
 

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -478,7 +478,7 @@
   </Node>
   <Node Name="SimpleLambdaExpression" Inherits="LambdaExpression">
     <Slot Name="Parameter" Type="Parameter" />
-    <Slot Name="ReturnType" Type="ArrowTypeClause" />
+    <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="ArrowToken" Type="Token" IsInherited="true"  DefaultToken="ArrowToken"/>
     <Slot Name="ExpressionBody" Type="Expression" IsInherited="true" />
   </Node>
@@ -647,7 +647,7 @@
   </Node>
   <Node Name="ParenthesizedLambdaExpression" Inherits="LambdaExpression">
     <Slot Name="ParameterList" Type="ParameterList" />
-    <Slot Name="ReturnType" Type="ArrowTypeClause" />
+    <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="ArrowToken" Type="Token" IsInherited="true"  DefaultToken="ArrowToken"/>
     <Slot Name="ExpressionBody" Type="Expression" IsInherited="true" />
   </Node>


### PR DESCRIPTION
## Summary
- allow simple and parenthesized lambda return types to be omitted in the syntax model and parser
- update lambda binding to treat the missing return annotation as nullable so delegate targets can drive inference

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: AttributeUsageTests currently expect RAV0502/RAV0503 diagnostics that are not emitted in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7b732a04832fb918045798210dae