### PR TITLE
Normalize lambda return type inference

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
@@ -141,6 +141,12 @@ partial class BlockBinder
         var bodyExpr = lambdaBinder.BindExpression(syntax.ExpressionBody, allowReturn: true);
 
         var inferred = bodyExpr.Type;
+        if (returnTypeSyntax is null &&
+            inferred is not null &&
+            inferred.TypeKind != TypeKind.Error)
+        {
+            inferred = TypeSymbolNormalization.NormalizeForInference(inferred);
+        }
         var unitType = Compilation.GetSpecialType(SpecialType.System_Unit);
         if (inferred is null || SymbolEqualityComparer.Default.Equals(inferred, unitType))
         {
@@ -658,6 +664,8 @@ partial class BlockBinder
 
         var body = lambdaBinder.BindExpression(syntax.ExpressionBody, allowReturn: true);
         var inferred = body.Type ?? ReturnTypeCollector.Infer(body);
+        if (inferred is not null && inferred.TypeKind != TypeKind.Error)
+            inferred = TypeSymbolNormalization.NormalizeForInference(inferred);
         var returnType = invoke.ReturnType;
 
         if (inferred is not null &&


### PR DESCRIPTION
## Summary
- normalize lambda return type inference to collapse literal results when no explicit annotation is present
- apply the same normalization when replaying lambdas against delegate candidates
- add a regression test to assert the inferred return type is surfaced on both the bound lambda and its symbol

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: AttributeParsingTests.IndexerDeclaration_WithAttributeList_ParsesAttributes throws ArgumentNullException in generated parser code)*
- dotnet test test/Raven.CodeAnalysis.Tests --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.LambdaInferenceTests.Lambda_WithoutReturnType_InferredFromBody"

------
https://chatgpt.com/codex/tasks/task_e_68dd7e0125a8832f84bde88dbaf36707