### PR TITLE
Fix lambda binder local lookup

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -4398,6 +4398,13 @@ partial class BlockBinder : Binder
                         yield return param;
             }
 
+            if (current is LambdaBinder lambdaBinder)
+            {
+                foreach (var param in lambdaBinder.GetParameters())
+                    if (param.Name == name && seen.Add(param))
+                        yield return param;
+            }
+
             if (current is TypeMemberBinder typeMemberBinder)
             {
                 foreach (var member in typeMemberBinder.ContainingSymbol.GetMembers(name))

--- a/src/Raven.CodeAnalysis/Binder/LambdaBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/LambdaBinder.cs
@@ -1,4 +1,4 @@
-
+using System.Collections.Generic;
 
 namespace Raven.CodeAnalysis;
 
@@ -12,6 +12,8 @@ class LambdaBinder : BlockBinder
     {
         _parameters[param.Name] = param;
     }
+
+    public IEnumerable<IParameterSymbol> GetParameters() => _parameters.Values;
 
     public override ISymbol? LookupSymbol(string name)
     {
@@ -34,9 +36,9 @@ class LambdaBinder : BlockBinder
         if (_parameters.Values.Contains(symbol))
             return true;
 
-        foreach (var local in _locals)
+        foreach (var local in _locals.Values)
         {
-            if (ReferenceEquals(local.Value, symbol))
+            if (ReferenceEquals(local.Symbol, symbol))
                 return true;
         }
 


### PR DESCRIPTION
## Summary
- fix lambda captured-local checks to compare against the stored symbol rather than the tuple wrapper

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter Lambda_ReturningLambda_WithExplicitReturnType_ComposesSuccessfully

------
https://chatgpt.com/codex/tasks/task_e_68dd81711580832fb8481271eec5da0f