### PR TITLE
Fix closure method generation for captured lambdas

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
@@ -34,7 +34,7 @@ internal sealed partial class SourceLambdaSymbol : SourceSymbol, ILambdaSymbol
 
     public bool IsConstructor => false;
 
-    public override bool IsStatic => true;
+    public override bool IsStatic => !HasCaptures;
 
     public MethodKind MethodKind => MethodKind.LambdaMethod;
 


### PR DESCRIPTION
## Summary
- treat captured lambdas as instance members of their generated closure classes instead of static helpers
- resolve lambda statics by reflecting capture state so delegate construction mirrors the C# closure pattern

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: QualifiedNameBindingTests.QualifiedName_PrefersTypeOverNamespace, TypeOfTests.TypeOfExpression_EmitsSystemType, CompletionServiceTests.GetCompletions_InImportDirective_ReturnsNamespacesAndTypesOnly, TypeOfTests.TypeOfExpression_AllowsOpenGenericTypes)*

------
https://chatgpt.com/codex/tasks/task_e_68de2df3e0d8832fa0c2b17cb8377801