### PR TITLE
Fix lambda capture detection for nested locals

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/LambdaBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/LambdaBinder.cs
@@ -39,8 +39,17 @@ class LambdaBinder : BlockBinder
 
         foreach (var local in _locals.Values)
         {
-            if (ReferenceEquals(local.Symbol, symbol))
+            if (SymbolEqualityComparer.Default.Equals(local.Symbol, symbol))
                 return true;
+        }
+
+        if (symbol is ILocalSymbol or IParameterSymbol)
+        {
+            if (symbol.ContainingSymbol is { } containing &&
+                SymbolEqualityComparer.Default.Equals(containing, ContainingSymbol))
+            {
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
## Summary
- ensure lambda-local variables are recognized as declared in the lambda so they are not treated as captures

## Testing
- dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/lambda.rav

------
https://chatgpt.com/codex/tasks/task_e_68de3db4aa1c832fa155d36903980858