### PR TITLE
Add SemanticFacts constraint helper

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticFacts.cs
+++ b/src/Raven.CodeAnalysis/SemanticFacts.cs
@@ -66,6 +66,45 @@ public static class SemanticFacts
         return false;
     }
 
+    public static bool SatisfiesConstraints(
+        ITypeSymbol? typeArgument,
+        ITypeParameterSymbol? typeParameter)
+    {
+        if (typeArgument is null || typeParameter is null)
+            return false;
+
+        if (typeArgument is IErrorTypeSymbol)
+            return true;
+
+        var constraintKind = typeParameter.ConstraintKind;
+
+        if ((constraintKind & TypeParameterConstraintKind.ReferenceType) != 0 &&
+            !Binder.SatisfiesReferenceTypeConstraint(typeArgument))
+        {
+            return false;
+        }
+
+        if ((constraintKind & TypeParameterConstraintKind.ValueType) != 0 &&
+            !Binder.SatisfiesValueTypeConstraint(typeArgument))
+        {
+            return false;
+        }
+
+        if ((constraintKind & TypeParameterConstraintKind.TypeConstraint) != 0)
+        {
+            foreach (var constraintType in typeParameter.ConstraintTypes)
+            {
+                if (constraintType is IErrorTypeSymbol)
+                    continue;
+
+                if (!Binder.SatisfiesTypeConstraint(typeArgument, constraintType))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
     private static bool IsDerivedFromTypeParameter(
         ITypeParameterSymbol typeParameter,
         ITypeSymbol potentialBase,

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SemanticFactsTests.cs
@@ -94,6 +94,100 @@ public class SemanticFactsTests
     }
 
     [Fact]
+    public void SatisfiesConstraints_ReturnsTrueForClassConstraint()
+    {
+        var source = "class Base {} class Derived : Base {} class Container<T : Base> {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container")!;
+        var typeParameter = container.TypeParameters[0];
+        var derived = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Derived")!;
+
+        Assert.True(SemanticFacts.SatisfiesConstraints(derived, typeParameter));
+    }
+
+    [Fact]
+    public void SatisfiesConstraints_ReturnsFalseForClassConstraint()
+    {
+        var source = "class Base {} class Other {} class Container<T : Base> {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container")!;
+        var typeParameter = container.TypeParameters[0];
+        var other = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Other")!;
+
+        Assert.False(SemanticFacts.SatisfiesConstraints(other, typeParameter));
+    }
+
+    [Fact]
+    public void SatisfiesConstraints_ReturnsTrueForInterfaceConstraint()
+    {
+        var source = "interface IMarker {} class Container<T : IMarker> {} class Implementation : IMarker {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container")!;
+        var typeParameter = container.TypeParameters[0];
+        var implementation = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Implementation")!;
+
+        Assert.True(SemanticFacts.SatisfiesConstraints(implementation, typeParameter));
+    }
+
+    [Fact]
+    public void SatisfiesConstraints_HonorsStructConstraint()
+    {
+        var source = "class Container<T : struct> {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container")!;
+        var typeParameter = container.TypeParameters[0];
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
+        Assert.True(SemanticFacts.SatisfiesConstraints(intType, typeParameter));
+        Assert.False(SemanticFacts.SatisfiesConstraints(stringType, typeParameter));
+    }
+
+    [Fact]
+    public void SatisfiesConstraints_HonorsReferenceTypeConstraint()
+    {
+        var source = "class Container<T : class> {}";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create(
+            "test",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var container = (INamedTypeSymbol)compilation.GetTypeByMetadataName("Container")!;
+        var typeParameter = container.TypeParameters[0];
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+
+        Assert.True(SemanticFacts.SatisfiesConstraints(stringType, typeParameter));
+        Assert.False(SemanticFacts.SatisfiesConstraints(intType, typeParameter));
+    }
+
+    [Fact]
     public void ImplementsInterface_ReturnsTrueForArrayInterfaces()
     {
         var tree = SyntaxTree.ParseText("class C {}");


### PR DESCRIPTION
## Summary
- add `SemanticFacts.SatisfiesConstraints` to surface binder constraint validation for type arguments
- cover common constraint kinds with new semantic facts unit tests

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests --no-build *(fails: Lambda_WithoutParameterTypes_UsesTargetDelegateSignature in LambdaInferenceTests)*
- dotnet test test/Raven.CodeAnalysis.Tests --no-build --filter "FullyQualifiedName=Raven.CodeAnalysis.Tests.SemanticFactsTests.SatisfiesConstraints_ReturnsTrueForClassConstraint"

------
https://chatgpt.com/codex/tasks/task_e_68de3bf7caac832f94cda3d94b927eba