### PR TITLE
Refactor constraint helpers into SemanticFacts

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -824,13 +824,13 @@ internal abstract class Binder
             var typeArgument = typeArguments[i];
             var constraintKind = typeParameter.ConstraintKind;
 
-            if ((constraintKind & TypeParameterConstraintKind.ReferenceType) != 0 && !SatisfiesReferenceTypeConstraint(typeArgument))
+            if ((constraintKind & TypeParameterConstraintKind.ReferenceType) != 0 && !SemanticFacts.SatisfiesReferenceTypeConstraint(typeArgument))
             {
                 ReportConstraintViolation(typeArgument, "class", typeParameter, displayName, getArgumentLocation(i));
                 allSatisfied = false;
             }
 
-            if ((constraintKind & TypeParameterConstraintKind.ValueType) != 0 && !SatisfiesValueTypeConstraint(typeArgument))
+            if ((constraintKind & TypeParameterConstraintKind.ValueType) != 0 && !SemanticFacts.SatisfiesValueTypeConstraint(typeArgument))
             {
                 ReportConstraintViolation(typeArgument, "struct", typeParameter, displayName, getArgumentLocation(i));
                 allSatisfied = false;
@@ -845,7 +845,7 @@ internal abstract class Binder
 
                     if (constraintType is INamedTypeSymbol namedConstraint)
                     {
-                        if (SatisfiesNamedTypeConstraint(typeArgument, namedConstraint))
+                        if (SemanticFacts.SatisfiesNamedTypeConstraint(typeArgument, namedConstraint))
                             continue;
 
                         var constraintDisplay = namedConstraint.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
@@ -854,7 +854,7 @@ internal abstract class Binder
                         continue;
                     }
 
-                    if (SatisfiesTypeConstraint(typeArgument, constraintType))
+                    if (SemanticFacts.SatisfiesTypeConstraint(typeArgument, constraintType))
                         continue;
 
                     var display = constraintType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
@@ -912,93 +912,6 @@ internal abstract class Binder
         return fallback;
     }
 
-    internal static bool SatisfiesReferenceTypeConstraint(ITypeSymbol type)
-    {
-        if (type.IsReferenceType)
-            return true;
-
-        if (type is ITypeParameterSymbol typeParameter)
-            return (typeParameter.ConstraintKind & TypeParameterConstraintKind.ReferenceType) != 0;
-
-        return false;
-    }
-
-    internal static bool SatisfiesTypeConstraint(ITypeSymbol typeArgument, ITypeSymbol constraintType)
-    {
-        if (typeArgument is IErrorTypeSymbol || constraintType is IErrorTypeSymbol)
-            return true;
-
-        if (SymbolEqualityComparer.Default.Equals(typeArgument, constraintType))
-            return true;
-
-        if (constraintType is INamedTypeSymbol namedConstraint)
-            return SatisfiesNamedTypeConstraint(typeArgument, namedConstraint);
-
-        return true;
-    }
-
-    internal static bool SatisfiesNamedTypeConstraint(ITypeSymbol typeArgument, INamedTypeSymbol constraintType)
-    {
-        if (SymbolEqualityComparer.Default.Equals(typeArgument, constraintType))
-            return true;
-
-        if (constraintType.TypeKind == TypeKind.Interface)
-        {
-            if (typeArgument is INamedTypeSymbol namedArgument &&
-                namedArgument.TypeKind == TypeKind.Interface &&
-                SymbolEqualityComparer.Default.Equals(namedArgument, constraintType))
-            {
-                return true;
-            }
-
-            foreach (var implemented in typeArgument.AllInterfaces)
-            {
-                if (SymbolEqualityComparer.Default.Equals(implemented, constraintType))
-                    return true;
-            }
-
-            return false;
-        }
-
-        if (typeArgument is INamedTypeSymbol namedType)
-        {
-            for (var current = namedType; current is not null; current = current.BaseType)
-            {
-                if (SymbolEqualityComparer.Default.Equals(current, constraintType))
-                    return true;
-            }
-
-            return false;
-        }
-
-        if (typeArgument is ITypeParameterSymbol typeParameter)
-        {
-            foreach (var nestedConstraint in typeParameter.ConstraintTypes)
-            {
-                if (nestedConstraint is INamedTypeSymbol nestedNamed && SatisfiesNamedTypeConstraint(nestedNamed, constraintType))
-                    return true;
-            }
-
-            return false;
-        }
-
-        return false;
-    }
-
-    internal static bool SatisfiesValueTypeConstraint(ITypeSymbol type)
-    {
-        if (type.TypeKind == TypeKind.Nullable)
-            return false;
-
-        if (type.IsValueType)
-            return true;
-
-        if (type is ITypeParameterSymbol typeParameter)
-            return (typeParameter.ConstraintKind & TypeParameterConstraintKind.ValueType) != 0;
-
-        return false;
-    }
-
     protected bool ValidateMethodTypeArgumentConstraints(
         IMethodSymbol method,
         ImmutableArray<ITypeSymbol> typeArguments,
@@ -1017,13 +930,13 @@ internal abstract class Binder
             var typeArgument = typeArguments[i];
             var constraintKind = typeParameter.ConstraintKind;
 
-            if ((constraintKind & TypeParameterConstraintKind.ReferenceType) != 0 && !SatisfiesReferenceTypeConstraint(typeArgument))
+            if ((constraintKind & TypeParameterConstraintKind.ReferenceType) != 0 && !SemanticFacts.SatisfiesReferenceTypeConstraint(typeArgument))
             {
                 ReportConstraintViolation(typeArgument, "class", typeParameter, displayName, getArgumentLocation(i));
                 allSatisfied = false;
             }
 
-            if ((constraintKind & TypeParameterConstraintKind.ValueType) != 0 && !SatisfiesValueTypeConstraint(typeArgument))
+            if ((constraintKind & TypeParameterConstraintKind.ValueType) != 0 && !SemanticFacts.SatisfiesValueTypeConstraint(typeArgument))
             {
                 ReportConstraintViolation(typeArgument, "struct", typeParameter, displayName, getArgumentLocation(i));
                 allSatisfied = false;
@@ -1038,7 +951,7 @@ internal abstract class Binder
 
                     if (constraintType is INamedTypeSymbol namedConstraint)
                     {
-                        if (SatisfiesNamedTypeConstraint(typeArgument, namedConstraint))
+                        if (SemanticFacts.SatisfiesNamedTypeConstraint(typeArgument, namedConstraint))
                             continue;
 
                         var constraintDisplay = namedConstraint.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
@@ -1047,7 +960,7 @@ internal abstract class Binder
                         continue;
                     }
 
-                    if (SatisfiesTypeConstraint(typeArgument, constraintType))
+                    if (SemanticFacts.SatisfiesTypeConstraint(typeArgument, constraintType))
                         continue;
 
                     var display = constraintType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);

--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -296,13 +296,13 @@ internal sealed class OverloadResolver
             var constraintKind = typeParameter.ConstraintKind;
 
             if ((constraintKind & TypeParameterConstraintKind.ReferenceType) != 0 &&
-                !Binder.SatisfiesReferenceTypeConstraint(typeArgument))
+                !SemanticFacts.SatisfiesReferenceTypeConstraint(typeArgument))
             {
                 return false;
             }
 
             if ((constraintKind & TypeParameterConstraintKind.ValueType) != 0 &&
-                !Binder.SatisfiesValueTypeConstraint(typeArgument))
+                !SemanticFacts.SatisfiesValueTypeConstraint(typeArgument))
             {
                 return false;
             }
@@ -317,13 +317,13 @@ internal sealed class OverloadResolver
 
                 if (constraintType is INamedTypeSymbol namedConstraint)
                 {
-                    if (!Binder.SatisfiesNamedTypeConstraint(typeArgument, namedConstraint))
+                    if (!SemanticFacts.SatisfiesNamedTypeConstraint(typeArgument, namedConstraint))
                         return false;
 
                     continue;
                 }
 
-                if (!Binder.SatisfiesTypeConstraint(typeArgument, constraintType))
+                if (!SemanticFacts.SatisfiesTypeConstraint(typeArgument, constraintType))
                     return false;
             }
         }


### PR DESCRIPTION
## Summary
- move generic constraint helper logic from Binder into SemanticFacts so it can be reused without a circular dependency
- update Binder and OverloadResolver to invoke the new SemanticFacts helpers when validating type parameter constraints

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: CompletionServiceTests expect completion items that are absent in the current build)*

------
https://chatgpt.com/codex/tasks/task_e_68de4a26c9bc832fbfa079882c915a9b