### PR TITLE
Avoid pre-emitting lambda method bodies

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -215,6 +215,9 @@ internal class TypeGenerator
             {
                 case IMethodSymbol methodSymbol when methodSymbol.MethodKind is not (MethodKind.PropertyGet or MethodKind.PropertySet):
                     {
+                        if (methodSymbol.MethodKind == MethodKind.LambdaMethod)
+                            break;
+
                         var methodGenerator = new MethodGenerator(this, methodSymbol);
 
                         if (methodSymbol is SourceLambdaSymbol sourceLambda && sourceLambda.HasCaptures)


### PR DESCRIPTION
## Summary
- skip registering lambda methods during initial member builder generation
- allow lambda bodies to be emitted when their delegates are synthesized during expression lowering so extension calls compile successfully

## Testing
- dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/linq.rav
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Raven.CodeAnalysis.Tests.UsingDeclarationCodeGenTests.TopLevelUsingDeclaration_DisposesAtEndOfScript)*

------
https://chatgpt.com/codex/tasks/task_e_68de4d013dd8832f98a66a78d8acd66e