### PR TITLE
Support signed numeric patterns

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -82,6 +82,23 @@ let result = value match {
     }
 
     [Fact]
+    public void MatchExpression_WithNegativeNumericPattern_AllowsConstantArm()
+    {
+        const string code = """
+let value: int = -1
+
+let result = value match {
+    -1 => "minus one"
+    _ => "other"
+}
+""";
+
+        var verifier = CreateVerifier(code);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void MatchExpression_WithDiscardArm_BindsDesignation()
     {
         const string code = """

--- a/test/Raven.CodeAnalysis.Tests/Syntax/PatternSyntaxParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/PatternSyntaxParserTests.cs
@@ -25,6 +25,22 @@ public class PatternSyntaxParserTests
     }
 
     [Fact]
+    public void DeclarationPattern_WithNegativeNumericLiteral_Parses()
+    {
+        var (pattern, tree) = ParsePattern("-1");
+        var sourceText = tree.GetText() ?? throw new InvalidOperationException("Missing source text.");
+
+        var declaration = Assert.IsType<DeclarationPatternSyntax>(pattern);
+        Assert.Equal("-1", sourceText.ToString(declaration.Span));
+
+        var literal = Assert.IsType<LiteralTypeSyntax>(declaration.Type);
+        Assert.Equal(SyntaxKind.NumericLiteralType, literal.Kind);
+        Assert.Equal("-1", literal.Token.Text);
+
+        AssertNoErrors(tree);
+    }
+
+    [Fact]
     public void DiscardPattern_Parses()
     {
         var (pattern, tree) = ParsePattern("_");


### PR DESCRIPTION
## Summary
- update the name parser to fold a leading sign and numeric literal token into a single literal type so patterns can target negative numbers
- add syntax and semantic regression tests that cover negative numeric patterns

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: pre-existing compiler and codegen tests)*

------
https://chatgpt.com/codex/tasks/task_e_68de52744690832f92213cc2f978294f