### PR TITLE
Add parser support for yield statements

### DIFF
--- a/docs/lang/spec/control-flow.md
+++ b/docs/lang/spec/control-flow.md
@@ -131,6 +131,48 @@ func log(msg: string) {
 }
 ```
 
+## `yield return` statements
+
+Iterator-like members may suspend execution with `yield return expression`.
+Each `yield return` produces the next element in the enumerator sequence while
+preserving the generator's state so execution can resume on the next
+iteration. The `yield` keyword must be immediately followed by `return`, and an
+expression is required.
+
+```raven
+func numbers() -> IEnumerable<int> {
+    var i = 0
+    while i < 3 {
+        yield return i
+        i += 1
+    }
+}
+```
+
+Like explicit `return` statements, `yield return` is limited to statement
+positions and cannot appear in expression context.
+
+## `yield break` statements
+
+`yield break` terminates an iterator early. Any remaining statements in the
+member are skipped, and the enumerator completes without producing additional
+values.
+
+```raven
+func firstOrNone(values: IEnumerable<int>) -> IEnumerable<int> {
+    for each value in values {
+        yield return value
+        yield break
+    }
+
+    yield break
+}
+```
+
+The `yield break` form follows the same placement rules as `yield return` and
+`break`—it must appear in statement position and is illegal outside iterator
+bodies.
+
 ## `break` statements
 
 `break` exits the innermost enclosing loop statement immediately. Execution

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -285,6 +285,17 @@
     <Slot Name="Expression" Type="Expression" IsNullable="true" />
     <Slot Name="TerminatorToken" Type="Token" IsOptionalToken="true"/>
   </Node>
+  <Node Name="YieldReturnStatement" Inherits="Statement">
+    <Slot Name="YieldKeyword" Type="Token" DefaultToken="YieldKeyword"/>
+    <Slot Name="ReturnKeyword" Type="Token" DefaultToken="ReturnKeyword"/>
+    <Slot Name="Expression" Type="Expression" />
+    <Slot Name="TerminatorToken" Type="Token" IsOptionalToken="true"/>
+  </Node>
+  <Node Name="YieldBreakStatement" Inherits="Statement">
+    <Slot Name="YieldKeyword" Type="Token" DefaultToken="YieldKeyword"/>
+    <Slot Name="BreakKeyword" Type="Token" DefaultToken="BreakKeyword"/>
+    <Slot Name="TerminatorToken" Type="Token" IsOptionalToken="true"/>
+  </Node>
   <Node Name="CatchClause" Inherits="Node">
     <Slot Name="CatchKeyword" Type="Token" DefaultToken="CatchKeyword"/>
     <Slot Name="Declaration" Type="CatchDeclaration" IsNullable="true" />

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -36,6 +36,7 @@
   <TokenKind Name="ContinueKeyword" Text="continue" IsReservedWord="true" />
   <TokenKind Name="MatchKeyword" Text="match" IsReservedWord="true" />
   <TokenKind Name="ReturnKeyword" Text="return" IsReservedWord="true" />
+  <TokenKind Name="YieldKeyword" Text="yield" IsReservedWord="true" />
   <TokenKind Name="ThrowKeyword" Text="throw" IsReservedWord="true" />
   <TokenKind Name="NewKeyword" Text="new" IsReservedWord="true" />
   <TokenKind Name="TrueKeyword" Text="true" IsReservedWord="true" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/YieldStatementSyntaxTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/YieldStatementSyntaxTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Tests;
+
+public class YieldStatementSyntaxTests
+{
+    [Fact]
+    public void ParsesYieldReturnStatement()
+    {
+        var tree = SyntaxTree.ParseText("yield return value\n");
+        var yieldReturn = tree.GetRoot().DescendantNodes().OfType<YieldReturnStatementSyntax>().Single();
+
+        Assert.Equal(SyntaxKind.YieldReturnStatement, yieldReturn.Kind);
+        Assert.Equal("value", ((IdentifierNameSyntax)yieldReturn.Expression).Identifier.Text);
+    }
+
+    [Fact]
+    public void ParsesYieldBreakStatement()
+    {
+        var tree = SyntaxTree.ParseText("yield break\n");
+        var yieldBreak = tree.GetRoot().DescendantNodes().OfType<YieldBreakStatementSyntax>().Single();
+
+        Assert.Equal(SyntaxKind.YieldBreakStatement, yieldBreak.Kind);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `yield` keyword token plus syntax node definitions for `yield return` and `yield break`
- teach the statement parser about both yield forms and cover them with syntax tests
- document the new statements in the control-flow specification

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: TypeSymbolInterfacesTests.Array_AllInterfaces_IncludeIEnumerables)*

------
https://chatgpt.com/codex/tasks/task_e_68de59e0519c832f8c322921584d4882