### PR TITLE
Implement yield statement binding and lowering

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -407,6 +407,8 @@ partial class BlockBinder : Binder
             TryStatementSyntax tryStmt => BindTryStatement(tryStmt),
             FunctionStatementSyntax function => BindFunction(function),
             ReturnStatementSyntax returnStatement => BindReturnStatement(returnStatement),
+            YieldReturnStatementSyntax yieldReturnStatement => BindYieldReturnStatement(yieldReturnStatement),
+            YieldBreakStatementSyntax yieldBreakStatement => BindYieldBreakStatement(yieldBreakStatement),
             ThrowStatementSyntax throwStatement => BindThrowStatement(throwStatement),
             BlockStatementSyntax blockStmt => BindBlockStatement(blockStmt),
             ForStatementSyntax forStmt => BindForStatement(forStmt),

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -57,6 +57,8 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundContinueStatement continueStmt => (BoundStatement)VisitContinueStatement(continueStmt)!,
             BoundWhileStatement whileStmt => (BoundStatement)VisitWhileStatement(whileStmt)!,
             BoundForStatement forStmt => (BoundStatement)VisitForStatement(forStmt)!,
+            BoundYieldReturnStatement yieldReturn => (BoundStatement)VisitYieldReturnStatement(yieldReturn)!,
+            BoundYieldBreakStatement yieldBreak => (BoundStatement)VisitYieldBreakStatement(yieldBreak)!,
             BoundBlockStatement blockStmt => (BoundStatement)VisitBlockStatement(blockStmt)!,
             BoundAssignmentStatement assignmentStmt => (BoundStatement)VisitAssignmentStatement(assignmentStmt)!,
             _ => statement,
@@ -97,6 +99,10 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
     public virtual BoundNode? VisitBreakStatement(BoundBreakStatement node) => node;
 
     public virtual BoundNode? VisitContinueStatement(BoundContinueStatement node) => node;
+
+    public virtual BoundNode? VisitYieldReturnStatement(BoundYieldReturnStatement node) => node;
+
+    public virtual BoundNode? VisitYieldBreakStatement(BoundYieldBreakStatement node) => node;
 
 
     public virtual INamespaceSymbol VisitNamespace(INamespaceSymbol @namespace)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeVisitor.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeVisitor.cs
@@ -12,6 +12,16 @@ partial class BoundTreeVisitor
     {
         boundNode.Accept(this);
     }
+
+    public virtual void VisitYieldReturnStatement(BoundYieldReturnStatement node)
+    {
+        DefaultVisit(node);
+    }
+
+    public virtual void VisitYieldBreakStatement(BoundYieldBreakStatement node)
+    {
+        DefaultVisit(node);
+    }
 }
 
 partial class BoundTreeVisitor<TResult>
@@ -25,5 +35,15 @@ partial class BoundTreeVisitor<TResult>
     public virtual TResult Visit(BoundNode boundNode)
     {
         return boundNode.Accept(this);
+    }
+
+    public virtual TResult VisitYieldReturnStatement(BoundYieldReturnStatement node)
+    {
+        return DefaultVisit(node);
+    }
+
+    public virtual TResult VisitYieldBreakStatement(BoundYieldBreakStatement node)
+    {
+        return DefaultVisit(node);
     }
 }

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -158,6 +158,12 @@ internal class BoundTreeWalker : BoundTreeVisitor
             case BoundBlockStatement blockStmt:
                 VisitBlockStatement(blockStmt);
                 break;
+            case BoundYieldReturnStatement yieldReturn:
+                VisitYieldReturnStatement(yieldReturn);
+                break;
+            case BoundYieldBreakStatement yieldBreak:
+                VisitYieldBreakStatement(yieldBreak);
+                break;
         }
     }
 
@@ -188,6 +194,15 @@ internal class BoundTreeWalker : BoundTreeVisitor
     public virtual void VisitConditionalGotoStatement(BoundConditionalGotoStatement node)
     {
         VisitExpression(node.Condition);
+    }
+
+    public virtual void VisitYieldReturnStatement(BoundYieldReturnStatement node)
+    {
+        VisitExpression(node.Expression);
+    }
+
+    public virtual void VisitYieldBreakStatement(BoundYieldBreakStatement node)
+    {
     }
 
     public override void VisitBinaryExpression(BoundBinaryExpression node)

--- a/src/Raven.CodeAnalysis/BoundTree/BoundYieldBreakStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundYieldBreakStatement.cs
@@ -1,0 +1,8 @@
+namespace Raven.CodeAnalysis;
+
+internal sealed class BoundYieldBreakStatement : BoundStatement
+{
+    public override void Accept(BoundTreeVisitor visitor) => visitor.VisitYieldBreakStatement(this);
+
+    public override TResult Accept<TResult>(BoundTreeVisitor<TResult> visitor) => visitor.VisitYieldBreakStatement(this);
+}

--- a/src/Raven.CodeAnalysis/BoundTree/BoundYieldReturnStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundYieldReturnStatement.cs
@@ -1,0 +1,15 @@
+namespace Raven.CodeAnalysis;
+
+internal sealed class BoundYieldReturnStatement : BoundStatement
+{
+    public BoundYieldReturnStatement(BoundExpression expression)
+    {
+        Expression = expression;
+    }
+
+    public BoundExpression Expression { get; }
+
+    public override void Accept(BoundTreeVisitor visitor) => visitor.VisitYieldReturnStatement(this);
+
+    public override TResult Accept<TResult>(BoundTreeVisitor<TResult> visitor) => visitor.VisitYieldReturnStatement(this);
+}

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Blocks.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Blocks.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Raven.CodeAnalysis;
 
@@ -6,6 +7,9 @@ internal sealed partial class Lowerer
 {
     public override BoundNode? VisitBlockStatement(BoundBlockStatement node)
     {
+        if (_iteratorState is null && ContainsYield(node))
+            return RewriteIteratorBlock(node);
+
         var statements = new List<BoundStatement>();
 
         foreach (var statement in node.Statements)
@@ -43,6 +47,94 @@ internal sealed partial class Lowerer
                 CreateLabelStatement(endLabel),
             ]);
         }
+    }
+
+    private BoundNode RewriteIteratorBlock(BoundBlockStatement node)
+    {
+        if (_containingSymbol is not IMethodSymbol method)
+            return base.VisitBlockStatement(node);
+
+        if (!TryGetIteratorElementType(method.ReturnType, out var elementType))
+            return base.VisitBlockStatement(node);
+
+        var compilation = GetCompilation();
+        var listDefinition = compilation.GetTypeByMetadataName("System.Collections.Generic.List`1") as INamedTypeSymbol;
+        var constructedList = listDefinition?.Construct(elementType);
+        var constructedNamedList = constructedList as INamedTypeSymbol;
+
+        ITypeSymbol builderType = constructedList ?? compilation.ErrorTypeSymbol;
+
+        var builderLocal = CreateTempLocal("yieldResult", builderType, isMutable: true);
+
+        BoundExpression initializer;
+        if (constructedNamedList is not null)
+        {
+            var ctor = constructedNamedList.Constructors.FirstOrDefault(c => c.Parameters.Length == 0);
+            initializer = ctor is not null
+                ? new BoundObjectCreationExpression(ctor, Array.Empty<BoundExpression>())
+                : new BoundErrorExpression(builderType, null, BoundExpressionReason.OtherError);
+        }
+        else
+        {
+            initializer = new BoundErrorExpression(builderType, null, BoundExpressionReason.OtherError);
+        }
+
+        var statements = new List<BoundStatement>
+        {
+            new BoundLocalDeclarationStatement([new BoundVariableDeclarator(builderLocal, initializer)])
+        };
+
+        var previousState = _iteratorState;
+        var addMethod = constructedNamedList?
+            .GetMembers("Add")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.Parameters.Length == 1);
+        _iteratorState = new IteratorState(builderLocal, addMethod, elementType, method.ReturnType);
+
+        foreach (var statement in node.Statements)
+        {
+            var lowered = (BoundStatement)VisitStatement(statement);
+            statements.Add(lowered);
+        }
+
+        var compilationForReturn = GetCompilation();
+        BoundExpression returnExpression = new BoundLocalAccess(builderLocal);
+        returnExpression = ApplyConversionIfNeeded(returnExpression, method.ReturnType, compilationForReturn);
+        statements.Add(new BoundReturnStatement(returnExpression));
+
+        _iteratorState = previousState;
+
+        return new BoundBlockStatement(statements, node.LocalsToDispose);
+    }
+
+    public override BoundNode? VisitYieldReturnStatement(BoundYieldReturnStatement node)
+    {
+        if (_iteratorState is null)
+            return base.VisitYieldReturnStatement(node);
+
+        var expression = (BoundExpression)VisitExpression(node.Expression)!;
+        var state = _iteratorState.Value;
+        var compilation = GetCompilation();
+        expression = ApplyConversionIfNeeded(expression, state.ElementType, compilation);
+
+        if (state.AddMethod is null)
+            return new BoundExpressionStatement(expression);
+
+        var receiver = new BoundLocalAccess(state.BuilderLocal);
+        var invocation = new BoundInvocationExpression(state.AddMethod, new[] { expression }, receiver);
+        return new BoundExpressionStatement(invocation);
+    }
+
+    public override BoundNode? VisitYieldBreakStatement(BoundYieldBreakStatement node)
+    {
+        if (_iteratorState is null)
+            return base.VisitYieldBreakStatement(node);
+
+        var state = _iteratorState.Value;
+        BoundExpression returnExpression = new BoundLocalAccess(state.BuilderLocal);
+        var compilation = GetCompilation();
+        returnExpression = ApplyConversionIfNeeded(returnExpression, state.ReturnType, compilation);
+        return new BoundReturnStatement(returnExpression);
     }
 }
 

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -278,6 +278,14 @@
     Title="Throw statement not allowed here"
     Message="Throw statements are not valid in expressions; use a statement block instead"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV1908" Identifier="YieldReturnStatementInExpression"
+    Title="Yield return statement not allowed here"
+    Message="Yield return statements are not valid in expressions; use a statement block instead"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV1909" Identifier="YieldBreakStatementInExpression"
+    Title="Yield break statement not allowed here"
+    Message="Yield break statements are not valid in expressions; use a statement block instead"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV1906" Identifier="TryExpressionCannotBeNested"
     Title="Nested try expression"
     Message="Nested try expressions are not allowed"
@@ -348,5 +356,11 @@
     Description="" HelpLinkUri="" />
   <Descriptor Id="RAV2601" Identifier="ContinueStatementNotWithinLoop" Title="Continue statement not within loop"
     Message="Continue statements are only valid inside loops" Category="compiler" Severity="Error" EnabledByDefault="true"
+    Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV2602" Identifier="YieldStatementRequiresIteratorReturnType" Title="Yield statements require iterator return type"
+    Message="Yield statements are only valid in members returning IEnumerable or IEnumerable&lt;T&gt;; this member returns '{returnType}'"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV2603" Identifier="YieldStatementNotAllowedInConstructor" Title="Yield statements not allowed in constructors"
+    Message="Constructors cannot contain yield statements" Category="compiler" Severity="Error" EnabledByDefault="true"
     Description="" HelpLinkUri="" />
 </Diagnostics>


### PR DESCRIPTION
## Summary
- bind `yield return` and `yield break` with iterator-specific diagnostics and conversions
- add bound node representations for yield statements and extend tree visitors to cover them
- lower iterator bodies by accumulating into a list and returning it so the emitter receives normalized statements

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68de5caeb61c832fa8357fce724943fc