### PR TITLE
Fix yield detection for metadata IEnumerable types

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.Statements.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.Statements.cs
@@ -441,7 +441,7 @@ partial class BlockBinder
         elementType = Compilation.ErrorTypeSymbol;
 
         if (returnType is INamedTypeSymbol named &&
-            named.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T &&
+            (named.OriginalDefinition ?? named).SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T &&
             named.TypeArguments.Length == 1)
         {
             elementType = named.TypeArguments[0];

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.cs
@@ -122,7 +122,7 @@ internal sealed partial class Lowerer : BoundTreeRewriter
         elementType = GetCompilation().ErrorTypeSymbol;
 
         if (returnType is INamedTypeSymbol named &&
-            named.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T &&
+            (named.OriginalDefinition ?? named).SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T &&
             named.TypeArguments.Length == 1)
         {
             elementType = named.TypeArguments[0];

--- a/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
@@ -172,6 +172,24 @@ internal partial class PENamedTypeSymbol : PESymbol, INamedTypeSymbol
             if (type.FullName == "System.Nullable`1")
                 return SpecialType.System_Nullable_T;
 
+            if (type.FullName == "System.Collections.IEnumerable")
+                return SpecialType.System_Collections_IEnumerable;
+
+            if (type.FullName == "System.Collections.IEnumerator")
+                return SpecialType.System_Collections_IEnumerator;
+
+            if (type.FullName == "System.Collections.Generic.IEnumerable`1")
+                return SpecialType.System_Collections_Generic_IEnumerable_T;
+
+            if (type.FullName == "System.Collections.Generic.IEnumerator`1")
+                return SpecialType.System_Collections_Generic_IEnumerator_T;
+
+            if (type.FullName == "System.Collections.Generic.ICollection`1")
+                return SpecialType.System_Collections_Generic_ICollection_T;
+
+            if (type.FullName == "System.Collections.Generic.IList`1")
+                return SpecialType.System_Collections_Generic_IList_T;
+
             if (type.Namespace == "System" && type.Name.StartsWith("ValueTuple`"))
             {
                 return type.GetGenericArguments().Length switch


### PR DESCRIPTION
## Summary
- mark System.Collections iterator interfaces as special types when loading metadata so yield detection works for IEnumerable<T>
- guard iterator element resolution against missing OriginalDefinition values to avoid null references during binding and lowering

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Raven.CodeAnalysis.Tests.SemanticFactsTests.ImplementsInterface_HandlesContravariantInterfaceArguments)*

------
https://chatgpt.com/codex/tasks/task_e_68de6db2e3ac832f99500f7e3e0faf73