### PR TITLE
Fix iterator lowering locals for codegen

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -113,7 +113,10 @@ internal class MethodBodyGenerator
         };
 
         if (boundBody != null)
+        {
+            boundBody = Lowerer.LowerBlock(MethodSymbol, boundBody);
             DeclareLocals(boundBody);
+        }
 
         switch (syntax)
         {
@@ -280,7 +283,8 @@ internal class MethodBodyGenerator
 
             if (lambda.Body is BoundBlockExpression blockExpression)
             {
-                var block = new BoundBlockStatement(blockExpression.Statements);
+                var block = new BoundBlockStatement(blockExpression.Statements, blockExpression.LocalsToDispose);
+                block = Lowerer.LowerBlock(MethodSymbol, block);
                 DeclareLocals(block);
                 EmitBoundBlock(block);
                 return;
@@ -456,7 +460,6 @@ internal class MethodBodyGenerator
 
     private void EmitBoundBlock(BoundBlockStatement block, bool withReturn = true)
     {
-        block = Lowerer.LowerBlock(MethodSymbol, block);
         var blockScope = new Scope(scope, block.LocalsToDispose);
 
         for (var i = 0; i < block.Statements.Count(); i++)


### PR DESCRIPTION
## Summary
- lower method bodies before locals are declared so iterator builders are collected
- ensure lambda block bodies are lowered prior to declaration and emission
- stop double-lowering blocks during emission to keep symbols consistent

## Testing
- dotnet run --project src/Raven.Compiler/Raven.Compiler.csproj -- samples/generator.rav -o test.dll -d pretty
- dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj *(fails: pre-existing completion tests and logger issue)*

------
https://chatgpt.com/codex/tasks/task_e_68de7201ecd0832f8f7d818cd0071a34