### PR TITLE
Implement semantic binding for yield statements

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -414,6 +414,8 @@ partial class BlockBinder : Binder
             GotoStatementSyntax gotoStatement => BindGotoStatement(gotoStatement),
             BreakStatementSyntax breakStatement => BindBreakStatement(breakStatement),
             ContinueStatementSyntax continueStatement => BindContinueStatement(continueStatement),
+            YieldReturnStatementSyntax yieldReturn => BindYieldReturnStatement(yieldReturn),
+            YieldBreakStatementSyntax yieldBreak => BindYieldBreakStatement(yieldBreak),
             EmptyStatementSyntax emptyStatement => new BoundExpressionStatement(new BoundUnitExpression(Compilation.GetSpecialType(SpecialType.System_Unit))),
             _ => throw new NotSupportedException($"Unsupported statement: {statement.Kind}")
         };

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeRewriter.cs
@@ -59,6 +59,8 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
             BoundForStatement forStmt => (BoundStatement)VisitForStatement(forStmt)!,
             BoundBlockStatement blockStmt => (BoundStatement)VisitBlockStatement(blockStmt)!,
             BoundAssignmentStatement assignmentStmt => (BoundStatement)VisitAssignmentStatement(assignmentStmt)!,
+            BoundYieldReturnStatement yieldReturn => (BoundStatement)VisitYieldReturnStatement(yieldReturn)!,
+            BoundYieldBreakStatement yieldBreak => (BoundStatement)VisitYieldBreakStatement(yieldBreak)!,
             _ => statement,
         };
     }
@@ -97,7 +99,6 @@ abstract partial class BoundTreeRewriter : BoundTreeVisitor<BoundNode?>
     public virtual BoundNode? VisitBreakStatement(BoundBreakStatement node) => node;
 
     public virtual BoundNode? VisitContinueStatement(BoundContinueStatement node) => node;
-
 
     public virtual INamespaceSymbol VisitNamespace(INamespaceSymbol @namespace)
     {

--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreeWalker.cs
@@ -158,6 +158,12 @@ internal class BoundTreeWalker : BoundTreeVisitor
             case BoundBlockStatement blockStmt:
                 VisitBlockStatement(blockStmt);
                 break;
+            case BoundYieldReturnStatement yieldReturn:
+                VisitYieldReturnStatement(yieldReturn);
+                break;
+            case BoundYieldBreakStatement yieldBreak:
+                VisitYieldBreakStatement(yieldBreak);
+                break;
         }
     }
 
@@ -182,6 +188,15 @@ internal class BoundTreeWalker : BoundTreeVisitor
     }
 
     public virtual void VisitContinueStatement(BoundContinueStatement node)
+    {
+    }
+
+    public virtual void VisitYieldReturnStatement(BoundYieldReturnStatement node)
+    {
+        VisitExpression(node.Expression);
+    }
+
+    public virtual void VisitYieldBreakStatement(BoundYieldBreakStatement node)
     {
     }
 

--- a/src/Raven.CodeAnalysis/BoundTree/BoundYieldBreakStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundYieldBreakStatement.cs
@@ -1,0 +1,16 @@
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class BoundYieldBreakStatement : BoundStatement
+{
+    public BoundYieldBreakStatement(ITypeSymbol elementType, IteratorMethodKind iteratorKind)
+    {
+        ElementType = elementType;
+        IteratorKind = iteratorKind;
+    }
+
+    public ITypeSymbol ElementType { get; }
+
+    public IteratorMethodKind IteratorKind { get; }
+}

--- a/src/Raven.CodeAnalysis/BoundTree/BoundYieldReturnStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundYieldReturnStatement.cs
@@ -1,0 +1,21 @@
+using System;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal sealed partial class BoundYieldReturnStatement : BoundStatement
+{
+    public BoundYieldReturnStatement(BoundExpression expression, ITypeSymbol elementType, IteratorMethodKind iteratorKind)
+    {
+        Expression = expression ?? throw new ArgumentNullException(nameof(expression));
+        ElementType = elementType;
+        IteratorKind = iteratorKind;
+    }
+
+    public BoundExpression Expression { get; }
+
+    public ITypeSymbol ElementType { get; }
+
+    public IteratorMethodKind IteratorKind { get; }
+}

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -1157,6 +1157,30 @@ public class Compilation
         {
             return GetTypeByMetadataName("System.Type");
         }
+        else if (specialType is SpecialType.System_Collections_IEnumerable)
+        {
+            return GetTypeByMetadataName("System.Collections.IEnumerable");
+        }
+        else if (specialType is SpecialType.System_Collections_Generic_IEnumerable_T)
+        {
+            return GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
+        }
+        else if (specialType is SpecialType.System_Collections_Generic_IList_T)
+        {
+            return GetTypeByMetadataName("System.Collections.Generic.IList`1");
+        }
+        else if (specialType is SpecialType.System_Collections_Generic_ICollection_T)
+        {
+            return GetTypeByMetadataName("System.Collections.Generic.ICollection`1");
+        }
+        else if (specialType is SpecialType.System_Collections_IEnumerator)
+        {
+            return GetTypeByMetadataName("System.Collections.IEnumerator");
+        }
+        else if (specialType is SpecialType.System_Collections_Generic_IEnumerator_T)
+        {
+            return GetTypeByMetadataName("System.Collections.Generic.IEnumerator`1");
+        }
 
         throw new InvalidOperationException("Special type is not supported.");
     }

--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -273,6 +273,12 @@ internal sealed class AliasMethodSymbol : AliasSymbol, IMethodSymbol
 
     public bool IsVirtual => _method.IsVirtual;
 
+    public bool IsIterator => _method.IsIterator;
+
+    public IteratorMethodKind IteratorKind => _method.IteratorKind;
+
+    public ITypeSymbol? IteratorElementType => _method.IteratorElementType;
+
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => _method.ExplicitInterfaceImplementations;
 
     public ImmutableArray<ITypeParameterSymbol> TypeParameters => _method.TypeParameters;

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -73,6 +73,9 @@ internal sealed class ConstructedMethodSymbol : IMethodSymbol
     public bool IsReadOnly => _definition.IsReadOnly;
     public bool IsSealed => _definition.IsSealed;
     public bool IsVirtual => _definition.IsVirtual;
+    public bool IsIterator => _definition.IsIterator;
+    public IteratorMethodKind IteratorKind => _definition.IteratorKind;
+    public ITypeSymbol? IteratorElementType => _definition.IteratorElementType;
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => _definition.ExplicitInterfaceImplementations;
     public ImmutableArray<ITypeParameterSymbol> TypeParameters => _definition.TypeParameters;
     public ImmutableArray<ITypeSymbol> TypeArguments => _typeArguments;

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
@@ -262,6 +262,9 @@ internal sealed class SubstitutedMethodSymbol : IMethodSymbol
     public bool IsReadOnly => _original.IsReadOnly;
     public bool IsSealed => _original.IsSealed;
     public bool IsVirtual => _original.IsVirtual;
+    public bool IsIterator => _original.IsIterator;
+    public IteratorMethodKind IteratorKind => _original.IteratorKind;
+    public ITypeSymbol? IteratorElementType => _original.IteratorElementType;
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => _original.ExplicitInterfaceImplementations;
     public ImmutableArray<ITypeParameterSymbol> TypeParameters => _original.TypeParameters;
     public ImmutableArray<ITypeSymbol> TypeArguments => _original.TypeArguments;

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -266,6 +266,9 @@ public interface IMethodSymbol : ISymbol
     bool IsReadOnly { get; }
     bool IsSealed { get; }
     bool IsVirtual { get; }
+    bool IsIterator { get; }
+    IteratorMethodKind IteratorKind { get; }
+    ITypeSymbol? IteratorElementType { get; }
 
     ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations { get; }
 
@@ -299,6 +302,13 @@ public enum MethodKind
     BuiltinOperator,
     Function,
     FunctionPointerSignature
+}
+
+public enum IteratorMethodKind
+{
+    None,
+    Enumerable,
+    Enumerator
 }
 
 public interface IParameterSymbol : ISymbol

--- a/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
@@ -214,6 +214,12 @@ internal partial class PEMethodSymbol : PESymbol, IMethodSymbol
 
     public bool IsVirtual => _methodInfo.IsVirtual;
 
+    public bool IsIterator => false;
+
+    public IteratorMethodKind IteratorKind => IteratorMethodKind.None;
+
+    public ITypeSymbol? IteratorElementType => null;
+
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<IMethodSymbol>.Empty;
 
     public ImmutableArray<ITypeParameterSymbol> TypeParameters =>

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
@@ -57,6 +57,9 @@ internal sealed partial class SourceLambdaSymbol : SourceSymbol, ILambdaSymbol
     public bool IsReadOnly => false;
     public bool IsSealed => false;
     public bool IsVirtual => false;
+    public bool IsIterator => false;
+    public IteratorMethodKind IteratorKind => IteratorMethodKind.None;
+    public ITypeSymbol? IteratorElementType => null;
 
     public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<IMethodSymbol>.Empty;
 

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
@@ -19,6 +19,9 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
     private bool _isSealed;
     private ImmutableArray<AttributeData> _lazyReturnTypeAttributes;
     private bool? _lazyIsExtensionMethod;
+    private IteratorMethodKind _iteratorKind;
+    private ITypeSymbol? _iteratorElementType;
+    private bool _isIterator;
 
     public SourceMethodSymbol(
         string name,
@@ -103,6 +106,12 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
 
     public IMethodSymbol? ConstructedFrom => this;
 
+    public bool IsIterator => _isIterator;
+
+    public IteratorMethodKind IteratorKind => _iteratorKind;
+
+    public ITypeSymbol? IteratorElementType => _iteratorElementType;
+
     public void SetParameters(IEnumerable<SourceParameterSymbol> parameters) => _parameters = parameters;
 
     internal void SetOverriddenMethod(IMethodSymbol overriddenMethod) => OverriddenMethod = overriddenMethod;
@@ -132,6 +141,16 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
         _isOverride = isOverride;
         _isVirtual = isVirtual || isOverride;
         _isSealed = isSealed;
+    }
+
+    internal void MarkIterator(IteratorMethodKind kind, ITypeSymbol elementType)
+    {
+        if (kind == IteratorMethodKind.None)
+            return;
+
+        _isIterator = true;
+        _iteratorKind = kind;
+        _iteratorElementType = elementType;
     }
 
     public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/OverloadResolverTests.cs
@@ -412,6 +412,12 @@ public sealed class OverloadResolverTests : CompilationTestBase
 
         public bool IsVirtual => false;
 
+        public bool IsIterator => false;
+
+        public IteratorMethodKind IteratorKind => IteratorMethodKind.None;
+
+        public ITypeSymbol? IteratorElementType => null;
+
         public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<IMethodSymbol>.Empty;
 
         public ImmutableArray<ITypeParameterSymbol> TypeParameters => ImmutableArray<ITypeParameterSymbol>.Empty;


### PR DESCRIPTION
## Summary
- add binder support for `yield return` and `yield break`, computing iterator metadata and conversions
- introduce bound node representations for yields and extend visitors to traverse them
- expose iterator metadata on method symbols and extend special type lookup for enumerable abstractions
- update tests to satisfy the expanded method symbol interface

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: outstanding diagnostics prior to yield lowering support)*

------
https://chatgpt.com/codex/tasks/task_e_68de7e4a3c44832f9960386d5fc4fe26