### PR TITLE
Teach the emitter to follow binder for-loop iteration info

### DIFF
--- a/docs/investigations/for-loop-enumerator-generics.md
+++ b/docs/investigations/for-loop-enumerator-generics.md
@@ -1,0 +1,87 @@
+# Why `for` loops fall back to non-generic enumerators
+
+When Raven lowers a `for each` loop it first inspects the type of the
+collection expression to decide which of the three lowering paths to use:
+arrays, generic enumerables, or the legacy non-generic enumerator pattern.
+The dispatcher lives in `StatementGenerator.EmitForStatement`, which now
+switches on the binder-provided `ForIterationInfo` to choose the iteration
+strategy. When the binder identifies an `IEnumerable<T>` implementation the
+emitter grabs the cached enumerable/enumerator interfaces and emits the
+generic lowering directly, otherwise it falls back to the non-generic path
+intentionally.【F:src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs†L236-L272】
+
+In the example from the investigation (`members.Where(...)`) the bound
+collection expression ultimately has the non-generic
+`System.Collections.IEnumerable` type, so the probe reports no generic support
+and the backend emits the legacy lowering. This happens because the binder is
+still conservative when inferring the element type for a `for` loop:
+`InferForElementType` only keeps a concrete `IEnumerable<T>` when it can see
+that interface directly on the bound expression's type. For iterator helpers
+produced by LINQ extension methods we used to lose that specific interface
+information, so the inferred element type collapsed to `object`. Once the loop
+variable was typed as `object`, the generator could not construct a matching
+`IEnumerator<T>` and therefore fell back to the non-generic lowering that
+produced the `System.Collections.IEnumerator` local observed in the IL dump.
+The new iteration metadata keeps hold of the discovered interface so the
+emitter can lower to the generic pattern.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.Statements.cs†L206-L244】【F:src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs†L236-L272】
+
+Improving the binder so it preserves the exact `IEnumerable<T>` interface for
+extension-method iterators would let `TryGetGenericEnumeratorInfo` succeed and
+unblock generic enumerator lowering. Until then, loops over helpers like
+`Enumerable.Where` continue to use the non-generic pattern even though the
+runtime iterator implements `IEnumerator<T>`.
+
+## Strategy to fix the lowering
+
+1. **Teach the binder to classify the iteration pattern.** Instead of
+   returning only the loop variable symbol, have `BindForStatement` compute a
+   small "iteration info" record that captures the element type plus the best
+   matching enumerable/enumerator pair (array, `IEnumerable<T>`, or
+   non-generic). This logic can reuse the existing `InferForElementType`
+   helper while also surfacing the specific `IEnumerable<T>` interface that it
+   discovers.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.Statements.cs†L206-L244】
+2. **Plumb the iteration info through the bound tree.** Extend
+   `BoundForStatement` so it stores the chosen iteration kind alongside the
+   bound collection expression. That way the lowering step does not have to
+   re-run type discovery and risk ending up with a less-precise interface than
+   the binder already found.【F:src/Raven.CodeAnalysis/BoundTree/BoundForStatement.cs†L5-L15】
+3. **Update code generation to respect the binder's choice.** Replace the
+   ad-hoc probe in `StatementGenerator.EmitForStatement` with a switch on the
+   new iteration info. When the binder says the loop can enumerate via
+   `IEnumerable<T>`/`IEnumerator<T>`, emit the generic lowering directly and
+   avoid the non-generic fallback that currently injects the
+   `System.Collections.IEnumerable` cast.【F:src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs†L236-L415】
+4. **Add regression coverage.** Introduce an end-to-end test that lowers a
+   `for` loop over a LINQ helper (e.g. `members.Where(...)`) and verifies that
+   the emitted IL declares a generic enumerator local. This guards the new
+   plumbing and prevents future regressions that would reintroduce the
+   `IEnumerator` fallback.
+
+## Step 1 – binder iteration metadata
+
+`BindForStatement` now asks a new `ClassifyForIteration` helper to describe the
+best iteration strategy before it creates the loop variable. The helper wraps
+the existing `InferForElementType` logic so it can forward the precise
+`IEnumerable<T>` interface symbol the binder already discovered instead of
+forcing the emitter to re-run reflection-based probing. The classification is
+captured in a new `ForIterationInfo` record that distinguishes array, generic,
+and non-generic patterns and remembers the matching enumerable/enumerator pair
+when present.【F:src/Raven.CodeAnalysis/Binder/BlockBinder.Statements.cs†L206-L244】【F:src/Raven.CodeAnalysis/ForIterationInfo.cs†L5-L32】
+
+## Step 2 – bound tree iteration plumbing
+
+`BoundForStatement` now stores the `ForIterationInfo` produced by the binder so
+lowering can rely on the binder's classification instead of rediscovering the
+enumeration pattern. This ensures the chosen `IEnumerable<T>` interface flows
+through semantic analysis unchanged and keeps the upcoming emitter updates
+focused on code generation rather than repeated type inspection.【F:src/Raven.CodeAnalysis/BoundTree/BoundForStatement.cs†L1-L21】【F:src/Raven.CodeAnalysis/Binder/BlockBinder.Statements.cs†L206-L218】
+
+## Step 3 – emitter honors iteration metadata
+
+`StatementGenerator.EmitForStatement` now switches over
+`BoundForStatement.Iteration` to decide which lowering to emit. Array loops
+continue to use the optimized indexed form, while generic enumerable loops use
+the cached `IEnumerable<T>`/`IEnumerator<T>` symbols provided by the binder and
+avoid re-probing the collection type. Only loops that the binder explicitly
+marks as non-generic flow through the legacy cast-heavy lowering, eliminating
+the accidental `System.Collections.IEnumerator` locals for LINQ helpers.【F:src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs†L236-L415】

--- a/src/Raven.CodeAnalysis/BoundTree/BoundForStatement.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundForStatement.cs
@@ -5,12 +5,18 @@ namespace Raven.CodeAnalysis;
 internal partial class BoundForStatement : BoundStatement
 {
     public ILocalSymbol Local { get; }
+    public ForIterationInfo Iteration { get; }
     public BoundExpression Collection { get; }
     public BoundStatement Body { get; }
 
-    public BoundForStatement(ILocalSymbol local, BoundExpression collection, BoundStatement body)
+    public BoundForStatement(
+        ILocalSymbol local,
+        ForIterationInfo iteration,
+        BoundExpression collection,
+        BoundStatement body)
     {
         Local = local;
+        Iteration = iteration;
         Collection = collection;
         Body = body;
     }

--- a/src/Raven.CodeAnalysis/ForIterationInfo.cs
+++ b/src/Raven.CodeAnalysis/ForIterationInfo.cs
@@ -1,0 +1,33 @@
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis;
+
+internal enum ForIterationKind
+{
+    Array,
+    Generic,
+    NonGeneric,
+}
+
+internal sealed record ForIterationInfo(
+    ForIterationKind Kind,
+    ITypeSymbol ElementType,
+    IArrayTypeSymbol? ArrayType = null,
+    INamedTypeSymbol? EnumerableInterface = null,
+    INamedTypeSymbol? EnumeratorInterface = null)
+{
+    public static ForIterationInfo ForArray(IArrayTypeSymbol arrayType) =>
+        new(ForIterationKind.Array, arrayType.ElementType, arrayType);
+
+    public static ForIterationInfo ForGeneric(
+        INamedTypeSymbol enumerableInterface,
+        INamedTypeSymbol enumeratorInterface) =>
+        new(ForIterationKind.Generic,
+            enumerableInterface.TypeArguments[0],
+            null,
+            enumerableInterface,
+            enumeratorInterface);
+
+    public static ForIterationInfo ForNonGeneric(ITypeSymbol elementType) =>
+        new(ForIterationKind.NonGeneric, elementType);
+}


### PR DESCRIPTION
## Summary
- switch `StatementGenerator.EmitForStatement` to dispatch on the binder-provided `ForIterationInfo`, using the cached enumerable/enumerator pair for generic loops and the array descriptor for indexed loops
- remove the redundant runtime probing helper so non-generic lowering only occurs when the binder explicitly requests it
- document the completion of strategy step 3 in the generic enumerator investigation, noting that the emitter now honors the iteration metadata

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68dfd6363518832f9ceead4d35391c9f