### PR TITLE
Ensure target-typed member access participates in overload resolution

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/TargetTypedExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TargetTypedExpressionTests.cs
@@ -58,4 +58,21 @@ class Program {
         var verifier = CreateVerifier(testCode);
         verifier.Verify();
     }
+
+    [Fact]
+    public void TargetTypedMemberAccess_ParticipatesInOverloadResolution()
+    {
+        string testCode = """
+import System.*
+import System.Reflection.*
+
+class Program {
+    static Run() -> unit {
+        let members = typeof(System.Object).GetMembers(.NonPublic)
+    }
+}
+""";
+        var verifier = CreateVerifier(testCode);
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- filter overload candidates that don't support the provided argument count before using them for target-typed lookup
- add a regression test that covers invoking Type.GetMembers with a target-typed BindingFlags argument

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "TargetTypedMemberAccess_ParticipatesInOverloadResolution"


------
https://chatgpt.com/codex/tasks/task_e_68dfe9ca9a38832fb0d770131a24ab62