### PR TITLE
Ensure PENamedTypeSymbol honors TypeResolver definitions

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Symbols/SymbolEqualityComparerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SymbolEqualityComparerTests.cs
@@ -362,6 +362,54 @@ class Sample {{
     }
 
     [Fact]
+    public void Comparer_RecognizesMetadataDefinitions()
+    {
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        var listDefinition = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            compilation.GetTypeByMetadataName("System.Collections.Generic.List`1"));
+
+        var constructedFrom = Assert.IsAssignableFrom<INamedTypeSymbol>(listDefinition.ConstructedFrom);
+        var originalDefinition = Assert.IsAssignableFrom<INamedTypeSymbol>(listDefinition.OriginalDefinition);
+
+        Assert.Same(listDefinition, constructedFrom);
+        Assert.Same(listDefinition, originalDefinition);
+
+        var comparer = SymbolEqualityComparer.Default;
+        Assert.True(comparer.Equals(listDefinition, constructedFrom));
+        Assert.True(comparer.Equals(listDefinition, originalDefinition));
+    }
+
+    [Fact]
+    public void Comparer_RecognizesMetadataNestedDefinitions()
+    {
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddReferences(TestMetadataReferences.Default);
+
+        var dictionaryDefinition = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            compilation.GetTypeByMetadataName("System.Collections.Generic.Dictionary`2"));
+
+        var enumeratorDefinition = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            compilation.GetTypeByMetadataName("System.Collections.Generic.Dictionary`2+Enumerator"));
+
+        var nestedEnumerator = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            dictionaryDefinition.GetMembers("Enumerator").Single());
+
+        Assert.Same(enumeratorDefinition, nestedEnumerator);
+
+        var constructedFrom = Assert.IsAssignableFrom<INamedTypeSymbol>(enumeratorDefinition.ConstructedFrom);
+        var originalDefinition = Assert.IsAssignableFrom<INamedTypeSymbol>(enumeratorDefinition.OriginalDefinition);
+
+        Assert.Same(enumeratorDefinition, constructedFrom);
+        Assert.Same(enumeratorDefinition, originalDefinition);
+
+        var comparer = SymbolEqualityComparer.Default;
+        Assert.True(comparer.Equals(enumeratorDefinition, constructedFrom));
+        Assert.True(comparer.Equals(enumeratorDefinition, originalDefinition));
+    }
+
+    [Fact]
     public void Comparer_DistinguishesTypeKinds()
     {
         var comparer = SymbolEqualityComparer.Default;


### PR DESCRIPTION
## Summary
- resolve metadata named type `ConstructedFrom`/`OriginalDefinition` through the `TypeResolver` to keep symbols canonical
- cover metadata named types and nested metadata definitions in the symbol equality tests

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: AttributeUsageTests pre-existing diagnostics expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e00b542be4832f9ba839bdd64c0164