### PR TITLE
Ensure pattern locals are immutable

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
@@ -477,7 +477,7 @@ internal partial class BlockBinder
         var name = singleVariableDesignation.Identifier.ValueText;
         var type = ResolveType(declaration.Type);
 
-        var local = CreateLocalSymbol(singleVariableDesignation, name, true, type);
+        var local = CreateLocalSymbol(singleVariableDesignation, name, isMutable: false, type);
 
         return new BoundSingleVariableDesignator(local);
     }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/IsPatternSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/IsPatternSemanticTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Testing;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class IsPatternSemanticTests : DiagnosticTestBase
+{
+    [Fact]
+    public void IsPattern_WithQualifiedMetadataType_BindsDeclaredType()
+    {
+        const string source = """
+let member: object = 0
+let result = member is System.Reflection.MethodInfo method
+""";
+
+        var verifier = CreateVerifier(source);
+        var result = verifier.GetResult();
+
+        Assert.Empty(result.UnexpectedDiagnostics);
+        Assert.Empty(result.MissingDiagnostics);
+
+        var tree = result.Compilation.SyntaxTrees.Single();
+        var model = result.Compilation.GetSemanticModel(tree);
+
+        var isPattern = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<IsPatternExpressionSyntax>()
+            .Single();
+
+        var bound = Assert.IsType<BoundIsPatternExpression>(model.GetBoundNode(isPattern));
+        var declaration = Assert.IsType<BoundDeclarationPattern>(bound.Pattern);
+        var designator = Assert.IsType<BoundSingleVariableDesignator>(declaration.Designator);
+
+        var methodInfoType = result.Compilation.GetTypeByMetadataName("System.Reflection.MethodInfo");
+        Assert.NotNull(methodInfoType);
+
+        var declaredDisplay = declaration.DeclaredType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var expectedDisplay = methodInfoType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        Assert.Equal(expectedDisplay, declaredDisplay); // ensure diagnostic clarity
+        Assert.Equal("method", designator.Local.Name);
+        Assert.False(designator.Local.IsMutable);
+
+        var declaredAssembly = declaration.DeclaredType.ContainingAssembly;
+        Assert.NotNull(declaredAssembly);
+
+        var expectedType = declaredAssembly!.GetTypeByMetadataName("System.Reflection.MethodInfo");
+        Assert.NotNull(expectedType);
+        Assert.True(
+            SymbolEqualityComparer.Default.Equals(expectedType, declaration.DeclaredType),
+            declaredDisplay);
+
+        var localAssembly = designator.Local.Type.ContainingAssembly;
+        Assert.NotNull(localAssembly);
+        Assert.Equal(declaredAssembly, localAssembly);
+    }
+}


### PR DESCRIPTION
## Summary
- mark locals produced by declaration patterns as immutable
- add a regression test covering `System.Reflection.MethodInfo` patterns

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter IsPattern

------
https://chatgpt.com/codex/tasks/task_e_68e014382ddc832f9df7f4cd66a42e7a