### PR TITLE
Add await expression syntax support

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -193,6 +193,7 @@ MultiplicativeExpression ::= UnaryExpression {('*' | '/' | '%') UnaryExpression}
 UnaryExpression          ::= LambdaExpression
                            | PostfixExpression
                            | ('+' | '-' | '!') UnaryExpression
+                           | 'await' UnaryExpression
                            | CastExpression ;
 
 LambdaExpression         ::= LambdaParameterClause ReturnTypeClause? '=>' Expression ;

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -51,7 +51,7 @@ classifies each keyword as either reserved or contextual.
 
 | Kind | Keywords |
 | --- | --- |
-| Reserved | `and`, `as`, `base`, `bool`, `catch`, `char`, `class`, `double`, `each`, `else`, `enum`, `false`, `finally`, `for`, `func`, `if`, `int`, `interface`, `is`, `let`, `match`, `new`, `not`, `null`, `object`, `or`, `return`, `self`, `string`, `struct`, `true`, `try`, `var`, `when`, `while` |
+| Reserved | `and`, `as`, `await`, `base`, `bool`, `catch`, `char`, `class`, `double`, `each`, `else`, `enum`, `false`, `finally`, `for`, `func`, `if`, `int`, `interface`, `is`, `let`, `match`, `new`, `not`, `null`, `object`, `or`, `return`, `self`, `string`, `struct`, `true`, `try`, `var`, `when`, `while` |
 | Contextual | `abstract`, `alias`, `get`, `import`, `in`, `init`, `internal`, `namespace`, `open`, `partial`, `out`, `override`, `private`, `protected`, `public`, `ref`, `sealed`, `set`, `static`, `unit`, `using`, `virtual` |
 
 Reserved keywords are always treated as keywords and therefore unavailable for use as identifiers—even when a construct makes
@@ -325,6 +325,15 @@ let pet = if flag { Dog() } else { Cat() } // Dog | Cat
 let a: Animal = pet   // ok: Dog and Cat derive from Animal
 let s: string = pet   // error: neither member converts to string
 ```
+
+### Await expressions
+
+The `await` keyword introduces a unary expression with the grammar `await`
+*expression*. Await expressions participate in the same precedence as other
+prefix unary operators. Because `await` is reserved, the identifier form must be
+escaped as `@await` when used outside this construct. The asynchronous behaviour
+of `await` will be defined alongside coroutine semantics; the current
+specification reserves the syntax.
 
 ### Cast expressions
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -356,6 +356,12 @@ internal class ExpressionSyntaxParser : SyntaxParser
                 expr = ParseTryExpression();
                 break;
 
+            case SyntaxKind.AwaitKeyword:
+                ReadToken();
+                expr = ParseFactorExpression();
+                expr = UnaryExpression(SyntaxKind.AwaitExpression, token, expr);
+                break;
+
             case SyntaxKind.OpenBraceToken:
                 expr = ParseBlockSyntax();
                 break;

--- a/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
+++ b/src/Raven.CodeAnalysis/Syntax/NodeKinds.xml
@@ -27,6 +27,7 @@
   <NodeKind Name="UnaryMinusExpression" Type="UnaryExpression" />
   <NodeKind Name="LogicalNotExpression" Type="UnaryExpression" />
   <NodeKind Name="AddressOfExpression" Type="UnaryExpression" />
+  <NodeKind Name="AwaitExpression" Type="UnaryExpression" />
   <NodeKind Name="AddExpression" Type="BinaryExpression" />
   <NodeKind Name="SubtractExpression" Type="BinaryExpression" />
   <NodeKind Name="MultiplyExpression" Type="BinaryExpression" />

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -28,6 +28,7 @@
   <TokenKind Name="TryKeyword" Text="try" IsReservedWord="true" />
   <TokenKind Name="CatchKeyword" Text="catch" IsReservedWord="true" />
   <TokenKind Name="FinallyKeyword" Text="finally" IsReservedWord="true" />
+  <TokenKind Name="AwaitKeyword" Text="await" IsReservedWord="true" />
   <TokenKind Name="WhileKeyword" Text="while" IsReservedWord="true" />
   <TokenKind Name="ForKeyword" Text="for" IsReservedWord="true" />
   <TokenKind Name="EachKeyword" Text="each" IsReservedWord="true" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/AwaitExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/AwaitExpressionTests.cs
@@ -1,0 +1,29 @@
+using System.IO;
+
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Syntax.InternalSyntax;
+using Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class AwaitExpressionTests
+{
+    [Fact]
+    public void AwaitExpression_ParsesAsUnaryExpression()
+    {
+        var lexer = new Lexer(new StringReader("await foo"));
+        var context = new BaseParseContext(lexer);
+        var parser = new ExpressionSyntaxParser(context);
+
+        var expression = Assert.IsAssignableFrom<ExpressionSyntax>(parser.ParseExpression().CreateRed());
+        var awaitExpression = Assert.IsType<UnaryExpressionSyntax>(expression);
+
+        Assert.Equal(SyntaxKind.AwaitExpression, awaitExpression.Kind);
+        Assert.Equal(SyntaxKind.AwaitKeyword, awaitExpression.OperatorToken.Kind);
+
+        var operand = Assert.IsType<IdentifierNameSyntax>(awaitExpression.Expression);
+        Assert.Equal("foo", operand.Identifier.ValueText);
+    }
+}


### PR DESCRIPTION
## Summary
- add the `await` keyword token and corresponding unary expression kind to the syntax model
- teach the expression parser to recognize prefix `await` expressions
- document the reserved keyword and grammar updates and add a parser unit test

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: AliasDirective_UsesAlias_InsideClass was already failing; logger aborted after reporting the test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68e0491ad2d0832f9680e02bcdbb932b