### PR TITLE
Improve lexing of negative numeric literals

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Lexer.cs
@@ -200,7 +200,7 @@ internal class Lexer : ILexer
                             ReadChar();
                             return new Token(SyntaxKind.ArrowToken, "->");
                         }
-                        else if (PeekChar(out ch2) && char.IsDigit(ch2))
+                        else if (PeekChar(out ch2) && (char.IsDigit(ch2) || ch2 == '.'))
                         {
                             return ParseNumber(diagnostics, ref ch, true);
                         }
@@ -540,7 +540,17 @@ internal class Lexer : ILexer
 
         if (negative)
         {
-            ReadChar();
+            _stringBuilder.Append('-');
+
+            if (ReadChar(out ch))
+            {
+                _stringBuilder.Append(ch);
+                hasDecimal |= ch == '.';
+            }
+            else
+            {
+                ch = '\0';
+            }
         }
 
         if (ch != '.')

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/LexerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
@@ -18,6 +19,24 @@ public class LexerTests
         Assert.Equal(".12", token.Text);
         var value = Assert.IsType<double>(token.Value);
         Assert.Equal(0.12d, value);
+    }
+
+    [Theory]
+    [InlineData("-42", typeof(int), -42)]
+    [InlineData("-2147483649", typeof(long), -2147483649L)]
+    [InlineData("-1.5", typeof(double), -1.5d)]
+    [InlineData("-.5", typeof(double), -0.5d)]
+    [InlineData("-1.5f", typeof(float), -1.5f)]
+    [InlineData("-1.5e2", typeof(double), -150d)]
+    public void NegativeNumericLiteral_IsParsedWithCorrectValue(string text, Type expectedType, object expectedValue)
+    {
+        var lexer = new Lexer(new StringReader(text));
+        var token = lexer.ReadToken();
+
+        Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind);
+        Assert.Equal(text, token.Text);
+        Assert.Equal(expectedType, token.Value?.GetType());
+        Assert.Equal(expectedValue, token.Value);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- allow the lexer to treat '-' followed by a digit or decimal point as part of a numeric literal
- ensure negative literals preserve decimal detection when consuming the first character
- add lexer tests covering negative int, long, float, and double literals (including leading decimal and exponent forms)

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: ExtensionMethodSemanticTests.LambdaArgument_WithMultipleExtensionCandidates_RecordsAllDelegateTargets assertion in current baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68e04ccfe054832f9452e61deea4f0a8