### PR TITLE
Fix async metadata emission for state machine types

### DIFF
--- a/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
@@ -56,6 +56,12 @@ public static class TypeSymbolExtensionsForCodeGen
                 : elementClrType.MakeArrayType(arrayType.Rank);
         }
 
+        if (typeSymbol is ByRefTypeSymbol byRefType)
+        {
+            var elementClrType = byRefType.ElementType.GetClrType(codeGen);
+            return elementClrType.MakeByRefType();
+        }
+
         // Handle arrays
         if (typeSymbol is ITupleTypeSymbol tupleSymbol)
         {


### PR DESCRIPTION
## Summary
- serialize AsyncStateMachine/AsyncMethodBuilder metadata using custom attribute blobs so synthesized state machine types no longer break attribute emission
- ensure codegen can materialize CLR types for by-ref symbols when lowering async state machines
- normalize runtime types when reflecting constructed metadata methods so builder generics can be resolved

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: pre-existing AccessibilityTests failure reported by TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_68e160da69e0832f9fd0bfcb750f2d06