### PR TITLE
Capture metadata for generated members

### DIFF
--- a/docs/investigations/metadata-emission-migration.md
+++ b/docs/investigations/metadata-emission-migration.md
@@ -1,0 +1,178 @@
+# System.Reflection.Metadata transition plan
+
+## Background
+
+Raven's back end currently relies on `System.Reflection.Emit` to materialize
+runtime `TypeBuilder`, `MethodBuilder`, and related artifacts while lowering
+bound trees into IL. The generator caches the runtime builders in several
+places: `TypeGenerator` stores the active `TypeBuilder` and exposes generated
+`Type` instances, and it manipulates builder APIs to configure inheritance,
+interfaces, and nested types.【F:src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs†L1-L160】
+`CodeGenerator` keeps global maps from compiler symbols to runtime
+`MemberInfo` objects, uses `GenericTypeParameterBuilder` to encode constraints,
+and resolves attributes and literal values by asking symbols for their CLR
+`Type` instances.【F:src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs†L1-L175】
+
+The symbol layer mirrors this dependency: the `PE*Symbol` family wraps
+reflection metadata (`Assembly`, `Module`, `TypeInfo`, etc.) and resolves
+metadata members by walking runtime types. `PEAssemblySymbol` forwards queries
+through a real `Assembly`, and `PEModuleSymbol` manufactures symbols by caching
+`System.Type` instances. `PENamedTypeSymbol` itself dereferences a
+`System.Reflection.TypeInfo` to answer almost every shape question.【F:src/Raven.CodeAnalysis/Symbols/PE/PEAssemblySymbol.cs†L1-L80】【F:src/Raven.CodeAnalysis/Symbols/PE/PEModuleSymbol.cs†L1-L187】【F:src/Raven.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs†L1-L120】
+
+Finally, helper layers turn compiler symbols back into runtime `System.Type`
+values. `TypeSymbolExtensionsForCodeGen` and `TypeSymbolExtensions` stitch
+runtime types together for generics, tuples, attributes, and unions, while
+`TypeResolver` walks `System.Reflection` metadata when binding references.
+These helpers are pervasive and assume the presence of runtime type objects.
+【F:src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs†L1-L200】【F:src/Raven.CodeAnalysis/TypeSymbolExtensions.cs†L1-L120】【F:src/Raven.CodeAnalysis/TypeResolver.cs†L1-L194】
+
+Switching to `System.Reflection.Metadata` (SRM) requires a structural change:
+SRM only manipulates metadata rows and IL blobs. It neither produces runtime
+types nor accepts them as input. Therefore we need an intermediate model that
+captures metadata handles instead of `System.Type` and a new writer that
+serializes those handles into a PE file.
+
+## Goals
+
+* Emit assemblies using SRM (`MetadataBuilder`, `BlobBuilder`,
+  `InstructionEncoder`) instead of `System.Reflection.Emit`.
+* Stop depending on `System.Reflection`/`System.Type` in the symbol layer and
+  code generation pipeline.
+* Maintain feature parity (custom attributes, generics, async/iterator support,
+  unions, etc.) throughout the migration.
+
+## Proposed architecture
+
+### 1. Introduce a metadata-centric emission model
+
+Create a set of lightweight data structures that capture the information
+currently spread across `TypeGenerator`, `MethodGenerator`, `FieldBuilder`, and
+friends:
+
+* `MetadataModuleBuilder` – owns an SRM `MetadataBuilder`, a `BlobBuilder` for
+  IL, and tables for string/user strings. Responsible for final PE assembly
+  layout.
+* `MetadataType` – represents a type definition being emitted. Stores symbolic
+  references to base types, interface implementations, layout flags, generic
+  parameter descriptors, field and method collections, and custom attribute
+  data (in compiler-friendly form).
+* `MetadataMethod`/`MetadataField`/`MetadataProperty` – hold signature
+  descriptors, IL streams (via `InstructionEncoder`), locals, exception
+  regions, and attribute lists.
+
+This intermediate model lets the generator stage the entire assembly without
+committing to runtime builders. It also provides a natural location to cache SRM
+`EntityHandle` values once they are assigned.
+
+Refactor `CodeGenerator` and `TypeGenerator` to populate these metadata objects
+instead of creating `TypeBuilder` instances. The `IILBuilder` abstraction
+already isolates IL emission; we can replace its backing implementation with an
+SRM encoder that writes directly into a `BlobBuilder` while still supporting the
+existing visitor pipeline. During migration we can keep both implementations by
+introducing a new `SrmILBuilderFactory` behind the same interface until the
+Reflection.Emit path is removed.
+
+### 2. Replace `System.Type` lookups with symbol/handle resolution
+
+The helpers that currently call `GetClrType` need to stop materializing runtime
+`Type` objects. Instead, introduce services that can translate compiler symbols
+into:
+
+* `EntityHandle` for definitions (types defined in the current compilation).
+* `EntityHandle` or `Handle` wrappers for references (types/methods from
+  metadata references).
+* `StandaloneSignatureHandle` for method/field signatures used by call sites.
+
+A dedicated `MetadataReferenceMapper` can provide these handles by consulting
+symbol tables and SRM metadata readers. This mapper replaces usages of
+`TypeSymbolExtensionsForCodeGen.GetClrType` and mirrors Roslyn's
+`MetadataBuilder` pipeline, but scoped to Raven's needs.
+
+Custom attribute emission should operate on compiler-level `AttributeData`
+only. Rather than building `CustomAttributeBuilder`, resolve constructor and
+property handles using the mapper, then build the attribute blob with
+`BlobEncoder`. The existing analysis (which already inspects `AttributeData`)
+remains valid; only the serialization step changes.
+
+### 3. Rework metadata binding (`PE*Symbol`)
+
+Swap the reflection-backed symbol classes for SRM readers:
+
+* Wrap each referenced assembly in a `MetadataReader`/`PEReader` pair instead of
+  `Assembly`/`Module`. Persist tables such as `TypeDefinitionHandle` → symbol
+  mapping inside `PEModuleSymbol`.
+* Reimplement `PENamedTypeSymbol` to read shape data from the `MetadataReader`
+  (flags, base type, layout, generics, nested types) rather than asking a
+  `TypeInfo`. Keep the symbol surface identical so the rest of the compiler does
+  not change.
+* Replace `TypeResolver` with a reader that walks SRM handles. For example,
+  retrieving parameter types should decode the method signature via
+  `SignatureDecoder`, honoring nullability attributes by consulting the relevant
+  custom attribute blobs.
+
+SRM access requires caching handles to avoid repeatedly decoding the same
+signature. Introduce dictionary caches keyed by handles instead of `System.Type`
+instances (e.g., `Dictionary<TypeDefinitionHandle, INamedTypeSymbol>`).
+
+### 4. Stage the migration
+
+A safe migration plan can proceed in phases:
+
+1. **Abstraction phase:** Add new metadata model types and teach the code
+   generator to populate them while still producing Reflection.Emit builders.
+   Use the metadata structures as the single source of truth for symbol → member
+   mappings; the Reflection.Emit integration becomes a thin adapter.
+2. **Emission phase:** Implement the SRM writer that walks the metadata model,
+   assigning `EntityHandle`s, emitting IL via `InstructionEncoder`, and
+   generating the final PE stream (headers, section tables, resources). Introduce
+   a feature flag so both back ends can coexist during validation.
+3. **Binding phase:** Rewrite `PE*Symbol` classes and `TypeResolver` to consume
+   SRM metadata directly. Provide a shim that can fall back to reflection when a
+   metadata reference lacks SRM (for example, during bootstrap) so the transition
+   does not break existing tests immediately.
+4. **Removal phase:** Once both emission and binding use SRM, delete the
+   Reflection.Emit adapters, the `GetClrType` helpers, and any remaining
+   `System.Type` caches. Update tests to operate purely on emitted metadata (for
+   example by inspecting the PE with SRM or ILSpy rather than runtime loading).
+
+### 5. Testing and tooling
+
+* Extend existing IL verification tests to accept SRM-produced IL blobs. The
+  current tests instantiate `System.Reflection.Emit` builders to re-run IL; they
+  will need to read the emitted PE via `PEReader` and decode method bodies.
+* Provide diagnostic dumps (e.g., via `MetadataVisualizer` or a custom
+  visitor) to compare metadata rows between the old and new pipelines during the
+  transition.
+* Ensure custom attribute encoding for unions and nullable metadata matches the
+  expectations of `TypeResolver`'s replacement.
+
+## Open questions / risks
+
+* **Nullability and union metadata:** `TypeResolver` currently relies on
+  `NullabilityInfoContext` and ad-hoc decoding of `TypeUnionAttribute` using
+  runtime reflection.【F:src/Raven.CodeAnalysis/TypeResolver.cs†L14-L118】 We need
+  SRM-based readers for these attributes, which implies rethinking how we encode
+  nullability annotations during emission.
+* **Dynamic loading scenarios:** The existing pipeline can execute emitted
+  assemblies in-memory via `AssemblyBuilder`. After the SRM switch we must either
+  write to disk and load via `AssemblyLoadContext` or embed a lightweight
+  metadata reader for validation. Clarify whether in-memory execution is still a
+  requirement.
+* **Third-party dependencies:** Some tests use `RecordingILBuilderFactory` and
+  similar helpers that wrap `System.Reflection.Emit`. They will require SRM-aware
+  equivalents once the primary pipeline moves away from runtime builders.
+
+## Status checklist
+
+- ✅ Seed metadata module/type definition model and populate it from the existing `TypeGenerator`.
+- ✅ Add metadata method/field/property representations and switch generation to populate them instead of Reflection.Emit builders.
+- ⬜ Implement SRM-backed IL/PE writer that consumes the metadata model.
+- ⬜ Replace reflection-backed `PE*Symbol` readers and `TypeResolver` with SRM handle decoding.
+- ⬜ Introduce handle-based mappers for definitions/references and remove `GetClrType` helpers.
+- ⬜ Update IL/codegen tests (and supporting tooling) to validate SRM output directly.
+- ⬜ Delete the remaining Reflection.Emit adapters and any residual `System.Type` usage once SRM emission/binding ships.
+
+Executing this plan will let Raven emit and consume assemblies without touching
+`System.Reflection.Emit`, aligning the compiler with modern metadata tooling and
+reducing runtime coupling.

--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -9,6 +9,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.CodeGen.Metadata;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
 
@@ -21,6 +22,8 @@ internal class CodeGenerator
     readonly Dictionary<ITypeParameterSymbol, Type> _genericParameterMap = new Dictionary<ITypeParameterSymbol, Type>(SymbolEqualityComparer.Default);
 
     public IILBuilderFactory ILBuilderFactory { get; set; } = ReflectionEmitILBuilderFactory.Instance;
+
+    public MetadataModuleBuilder MetadataModule { get; }
 
     public void AddMemberBuilder(SourceSymbol symbol, MemberInfo memberInfo) => _mappings[symbol] = memberInfo;
 
@@ -307,6 +310,7 @@ internal class CodeGenerator
     public CodeGenerator(Compilation compilation)
     {
         _compilation = compilation;
+        MetadataModule = new MetadataModuleBuilder();
     }
 
     public Type? GetTypeBuilder(INamedTypeSymbol namedTypeSymbol)

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -374,7 +374,8 @@ internal class ExpressionGenerator : Generator
 
         if (lambdaGenerator is null)
         {
-            lambdaGenerator = new MethodGenerator(typeGenerator, lambdaSymbol, typeGenerator.CodeGen.ILBuilderFactory);
+            var metadataMethod = typeGenerator.MetadataType.GetOrAddMethodDefinition(lambdaSymbol);
+            lambdaGenerator = new MethodGenerator(typeGenerator, lambdaSymbol, metadataMethod, typeGenerator.CodeGen.ILBuilderFactory);
 
             if (hasCaptures && lambdaSymbol is SourceLambdaSymbol sourceLambda)
             {

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataFieldDefinition.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataFieldDefinition.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Immutable;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal sealed class MetadataFieldDefinition
+{
+    private ImmutableArray<AttributeData> _customAttributes = ImmutableArray<AttributeData>.Empty;
+
+    public MetadataFieldDefinition(IFieldSymbol symbol)
+    {
+        Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+        FieldType = symbol.Type;
+    }
+
+    public IFieldSymbol Symbol { get; }
+
+    public string Name => Symbol.Name;
+
+    public FieldAttributes Attributes { get; private set; }
+
+    public ITypeSymbol FieldType { get; private set; }
+
+    public bool RequiresNullableAttribute { get; private set; }
+
+    public object? ConstantValue { get; private set; }
+
+    public ImmutableArray<AttributeData> CustomAttributes => _customAttributes;
+
+    public void SetAttributes(FieldAttributes attributes)
+    {
+        Attributes = attributes;
+    }
+
+    public void SetFieldType(ITypeSymbol fieldType)
+    {
+        FieldType = fieldType ?? throw new ArgumentNullException(nameof(fieldType));
+    }
+
+    public void SetRequiresNullableAttribute(bool requiresNullableAttribute)
+    {
+        RequiresNullableAttribute = requiresNullableAttribute;
+    }
+
+    public void SetConstantValue(object? value)
+    {
+        ConstantValue = value;
+    }
+
+    public void SetCustomAttributes(ImmutableArray<AttributeData> attributes)
+    {
+        _customAttributes = attributes.IsDefault ? ImmutableArray<AttributeData>.Empty : attributes;
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataMethodDefinition.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataMethodDefinition.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal sealed class MetadataMethodDefinition
+{
+    private ImmutableArray<MetadataParameterDefinition> _parameters = ImmutableArray<MetadataParameterDefinition>.Empty;
+    private ImmutableArray<AttributeData> _customAttributes = ImmutableArray<AttributeData>.Empty;
+    private ImmutableArray<AttributeData> _returnAttributes = ImmutableArray<AttributeData>.Empty;
+
+    public MetadataMethodDefinition(IMethodSymbol symbol)
+    {
+        Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+        ReturnType = symbol.ReturnType;
+    }
+
+    public IMethodSymbol Symbol { get; }
+
+    public string Name => Symbol.MetadataName;
+
+    public MethodAttributes Attributes { get; private set; }
+
+    public MethodImplAttributes ImplementationAttributes { get; private set; } = MethodImplAttributes.IL;
+
+    public ITypeSymbol ReturnType { get; private set; }
+
+    public bool RequiresNullableAttributeOnReturn { get; private set; }
+
+    public ImmutableArray<MetadataParameterDefinition> Parameters => _parameters;
+
+    public ImmutableArray<AttributeData> CustomAttributes => _customAttributes;
+
+    public ImmutableArray<AttributeData> ReturnAttributes => _returnAttributes;
+
+    public bool IsEntryPointCandidate { get; private set; }
+
+    public void SetAttributes(MethodAttributes attributes)
+    {
+        Attributes = attributes;
+    }
+
+    public void SetImplementationAttributes(MethodImplAttributes attributes)
+    {
+        ImplementationAttributes = attributes;
+    }
+
+    public void SetReturnType(ITypeSymbol returnType)
+    {
+        ReturnType = returnType ?? throw new ArgumentNullException(nameof(returnType));
+    }
+
+    public void SetRequiresNullableAttributeOnReturn(bool requiresNullableAttribute)
+    {
+        RequiresNullableAttributeOnReturn = requiresNullableAttribute;
+    }
+
+    public void SetParameters(IEnumerable<MetadataParameterDefinition> parameters)
+    {
+        if (parameters is null)
+            throw new ArgumentNullException(nameof(parameters));
+
+        _parameters = parameters is ImmutableArray<MetadataParameterDefinition> immutable
+            ? immutable
+            : parameters.ToImmutableArray();
+    }
+
+    public void SetCustomAttributes(ImmutableArray<AttributeData> attributes)
+    {
+        _customAttributes = attributes.IsDefault ? ImmutableArray<AttributeData>.Empty : attributes;
+    }
+
+    public void SetReturnAttributes(ImmutableArray<AttributeData> attributes)
+    {
+        _returnAttributes = attributes.IsDefault ? ImmutableArray<AttributeData>.Empty : attributes;
+    }
+
+    public void SetIsEntryPointCandidate(bool isEntryPointCandidate)
+    {
+        IsEntryPointCandidate = isEntryPointCandidate;
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataModuleBuilder.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataModuleBuilder.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal sealed class MetadataModuleBuilder
+{
+    private readonly Dictionary<ITypeSymbol, MetadataTypeDefinition> _types = new(SymbolEqualityComparer.Default);
+
+    public MetadataTypeDefinition GetOrAddTypeDefinition(ITypeSymbol type)
+    {
+        if (type is null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (!_types.TryGetValue(type, out var definition))
+        {
+            definition = new MetadataTypeDefinition(type);
+            _types.Add(type, definition);
+
+            if (type is INamedTypeSymbol named && named.ContainingType is not null)
+            {
+                var containingDefinition = GetOrAddTypeDefinition(named.ContainingType);
+                containingDefinition.AddNestedType(definition);
+            }
+        }
+
+        return definition;
+    }
+
+    public bool TryGetTypeDefinition(ITypeSymbol type, out MetadataTypeDefinition definition)
+    {
+        if (type is null)
+            throw new ArgumentNullException(nameof(type));
+
+        return _types.TryGetValue(type, out definition);
+    }
+
+    public IEnumerable<MetadataTypeDefinition> GetAllTypeDefinitions() => _types.Values;
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataNullability.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataNullability.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal static class MetadataNullability
+{
+    public static bool RequiresNullableAttribute(ITypeSymbol? type)
+    {
+        if (type is null)
+            return false;
+
+        if (type is NullableTypeSymbol nullable && !nullable.UnderlyingType.IsValueType)
+            return true;
+
+        if (type is IUnionTypeSymbol union)
+        {
+            var flattened = Flatten(union.Types).ToArray();
+            var hasNull = false;
+            var nonNull = new List<ITypeSymbol>();
+
+            foreach (var candidate in flattened)
+            {
+                if (candidate.TypeKind == TypeKind.Null)
+                {
+                    hasNull = true;
+                }
+                else
+                {
+                    nonNull.Add(candidate);
+                }
+            }
+
+            if (hasNull)
+            {
+                if (!(nonNull.Count == 1 && nonNull[0].IsValueType))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<ITypeSymbol> Flatten(IEnumerable<ITypeSymbol> types)
+    {
+        foreach (var type in types)
+        {
+            if (type is IUnionTypeSymbol union)
+            {
+                foreach (var nested in Flatten(union.Types))
+                    yield return nested;
+            }
+            else
+            {
+                yield return type;
+            }
+        }
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataParameterDefinition.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataParameterDefinition.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Immutable;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal sealed class MetadataParameterDefinition
+{
+    private ImmutableArray<AttributeData> _customAttributes = ImmutableArray<AttributeData>.Empty;
+
+    public MetadataParameterDefinition(IParameterSymbol symbol)
+    {
+        Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+    }
+
+    public IParameterSymbol Symbol { get; }
+
+    public string Name => Symbol.Name;
+
+    public ParameterAttributes Attributes { get; private set; }
+
+    public bool RequiresNullableAttribute { get; private set; }
+
+    public ImmutableArray<AttributeData> CustomAttributes => _customAttributes;
+
+    public void SetAttributes(ParameterAttributes attributes)
+    {
+        Attributes = attributes;
+    }
+
+    public void SetRequiresNullableAttribute(bool requiresNullableAttribute)
+    {
+        RequiresNullableAttribute = requiresNullableAttribute;
+    }
+
+    public void SetCustomAttributes(ImmutableArray<AttributeData> attributes)
+    {
+        _customAttributes = attributes.IsDefault ? ImmutableArray<AttributeData>.Empty : attributes;
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataPropertyDefinition.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataPropertyDefinition.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal sealed class MetadataPropertyDefinition
+{
+    private ImmutableArray<MetadataParameterDefinition> _parameters = ImmutableArray<MetadataParameterDefinition>.Empty;
+    private ImmutableArray<AttributeData> _customAttributes = ImmutableArray<AttributeData>.Empty;
+
+    public MetadataPropertyDefinition(IPropertySymbol symbol)
+    {
+        Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+        PropertyType = symbol.Type;
+    }
+
+    public IPropertySymbol Symbol { get; }
+
+    public string Name => Symbol.MetadataName;
+
+    public PropertyAttributes Attributes { get; private set; }
+
+    public ITypeSymbol PropertyType { get; private set; }
+
+    public bool RequiresNullableAttribute { get; private set; }
+
+    public ImmutableArray<MetadataParameterDefinition> Parameters => _parameters;
+
+    public ImmutableArray<AttributeData> CustomAttributes => _customAttributes;
+
+    public MetadataMethodDefinition? Getter { get; private set; }
+
+    public MetadataMethodDefinition? Setter { get; private set; }
+
+    public void SetAttributes(PropertyAttributes attributes)
+    {
+        Attributes = attributes;
+    }
+
+    public void SetPropertyType(ITypeSymbol propertyType)
+    {
+        PropertyType = propertyType ?? throw new ArgumentNullException(nameof(propertyType));
+    }
+
+    public void SetRequiresNullableAttribute(bool requiresNullableAttribute)
+    {
+        RequiresNullableAttribute = requiresNullableAttribute;
+    }
+
+    public void SetParameters(IEnumerable<MetadataParameterDefinition> parameters)
+    {
+        if (parameters is null)
+            throw new ArgumentNullException(nameof(parameters));
+
+        _parameters = parameters is ImmutableArray<MetadataParameterDefinition> immutable
+            ? immutable
+            : parameters.ToImmutableArray();
+    }
+
+    public void SetCustomAttributes(ImmutableArray<AttributeData> attributes)
+    {
+        _customAttributes = attributes.IsDefault ? ImmutableArray<AttributeData>.Empty : attributes;
+    }
+
+    public void SetGetAccessor(MetadataMethodDefinition? getter)
+    {
+        Getter = getter;
+    }
+
+    public void SetSetAccessor(MetadataMethodDefinition? setter)
+    {
+        Setter = setter;
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataTypeDefinition.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataTypeDefinition.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Symbols;
+
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal sealed class MetadataTypeDefinition
+{
+    private readonly List<MetadataTypeDefinition> _nestedTypes = new();
+    private readonly Dictionary<IMethodSymbol, MetadataMethodDefinition> _methods = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<IFieldSymbol, MetadataFieldDefinition> _fields = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<IPropertySymbol, MetadataPropertyDefinition> _properties = new(SymbolEqualityComparer.Default);
+    private ImmutableArray<ITypeSymbol> _interfaces = ImmutableArray<ITypeSymbol>.Empty;
+    private ImmutableArray<AttributeData> _customAttributes = ImmutableArray<AttributeData>.Empty;
+
+    public MetadataTypeDefinition(ITypeSymbol symbol)
+    {
+        Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+    }
+
+    public ITypeSymbol Symbol { get; }
+
+    public string Name => Symbol.MetadataName;
+
+    public MetadataTypeKind Kind { get; private set; } = MetadataTypeKind.Unknown;
+
+    public TypeAttributes Attributes { get; private set; }
+
+    public ITypeSymbol? BaseType { get; private set; }
+
+    public IReadOnlyList<MetadataTypeDefinition> NestedTypes => _nestedTypes;
+
+    public ImmutableArray<ITypeSymbol> Interfaces => _interfaces;
+
+    public ImmutableArray<AttributeData> CustomAttributes => _customAttributes;
+
+    public IEnumerable<MetadataMethodDefinition> Methods => _methods.Values;
+
+    public IEnumerable<MetadataFieldDefinition> Fields => _fields.Values;
+
+    public IEnumerable<MetadataPropertyDefinition> Properties => _properties.Values;
+
+    public void SetKind(MetadataTypeKind kind)
+    {
+        Kind = kind;
+    }
+
+    public void SetAttributes(TypeAttributes attributes)
+    {
+        Attributes = attributes;
+    }
+
+    public void SetBaseType(ITypeSymbol? baseType)
+    {
+        BaseType = baseType;
+    }
+
+    public void SetInterfaces(ImmutableArray<ITypeSymbol> interfaces)
+    {
+        _interfaces = interfaces.IsDefault ? ImmutableArray<ITypeSymbol>.Empty : interfaces;
+    }
+
+    public void SetInterfaces(IEnumerable<ITypeSymbol> interfaces)
+    {
+        _interfaces = interfaces is ImmutableArray<ITypeSymbol> immutable
+            ? immutable
+            : interfaces.ToImmutableArray();
+    }
+
+    public void SetCustomAttributes(ImmutableArray<AttributeData> attributes)
+    {
+        _customAttributes = attributes.IsDefault ? ImmutableArray<AttributeData>.Empty : attributes;
+    }
+
+    internal void AddNestedType(MetadataTypeDefinition nested)
+    {
+        if (nested is null)
+            throw new ArgumentNullException(nameof(nested));
+
+        if (!_nestedTypes.Contains(nested))
+            _nestedTypes.Add(nested);
+    }
+
+    public MetadataMethodDefinition GetOrAddMethodDefinition(IMethodSymbol method)
+    {
+        if (method is null)
+            throw new ArgumentNullException(nameof(method));
+
+        if (!_methods.TryGetValue(method, out var definition))
+        {
+            definition = new MetadataMethodDefinition(method);
+            _methods.Add(method, definition);
+        }
+
+        return definition;
+    }
+
+    public bool TryGetMethodDefinition(IMethodSymbol method, out MetadataMethodDefinition definition)
+    {
+        if (method is null)
+            throw new ArgumentNullException(nameof(method));
+
+        return _methods.TryGetValue(method, out definition);
+    }
+
+    public MetadataFieldDefinition GetOrAddFieldDefinition(IFieldSymbol field)
+    {
+        if (field is null)
+            throw new ArgumentNullException(nameof(field));
+
+        if (!_fields.TryGetValue(field, out var definition))
+        {
+            definition = new MetadataFieldDefinition(field);
+            _fields.Add(field, definition);
+        }
+
+        return definition;
+    }
+
+    public bool TryGetFieldDefinition(IFieldSymbol field, out MetadataFieldDefinition definition)
+    {
+        if (field is null)
+            throw new ArgumentNullException(nameof(field));
+
+        return _fields.TryGetValue(field, out definition);
+    }
+
+    public MetadataPropertyDefinition GetOrAddPropertyDefinition(IPropertySymbol property)
+    {
+        if (property is null)
+            throw new ArgumentNullException(nameof(property));
+
+        if (!_properties.TryGetValue(property, out var definition))
+        {
+            definition = new MetadataPropertyDefinition(property);
+            _properties.Add(property, definition);
+        }
+
+        return definition;
+    }
+
+    public bool TryGetPropertyDefinition(IPropertySymbol property, out MetadataPropertyDefinition definition)
+    {
+        if (property is null)
+            throw new ArgumentNullException(nameof(property));
+
+        return _properties.TryGetValue(property, out definition);
+    }
+}

--- a/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataTypeKind.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Metadata/MetadataTypeKind.cs
@@ -1,0 +1,11 @@
+namespace Raven.CodeAnalysis.CodeGen.Metadata;
+
+internal enum MetadataTypeKind
+{
+    Unknown = 0,
+    Class,
+    Struct,
+    Interface,
+    Delegate,
+    Enum
+}

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -563,7 +563,8 @@ internal class MethodBodyGenerator
         if (MethodGenerator.TypeGenerator.HasMethodGenerator(methodSymbol))
             return;
 
-        var methodGenerator = new MethodGenerator(MethodGenerator.TypeGenerator, methodSymbol, MethodGenerator.ILBuilderFactory);
+        var metadataMethod = MethodGenerator.TypeGenerator.MetadataType.GetOrAddMethodDefinition(methodSymbol);
+        var methodGenerator = new MethodGenerator(MethodGenerator.TypeGenerator, methodSymbol, metadataMethod, MethodGenerator.ILBuilderFactory);
         MethodGenerator.TypeGenerator.Add(methodSymbol, methodGenerator);
         methodGenerator.DefineMethodBuilder();
     }


### PR DESCRIPTION
## Summary
- add metadata definitions for methods, fields, properties, and parameters to the code generation metadata layer
- update TypeGenerator, MethodGenerator, and related helpers to populate the metadata model while still emitting Reflection.Emit builders
- track nullable annotations and accessor relationships so the metadata model is ready for SRM emission

## Testing
- `(cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f)`
- `(cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/BoundNodeGenerator -- -f)`
- `(cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/DiagnosticsGenerator -- -f)`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: existing diagnostics expectations mismatch in LambdaInferenceDiagnosticsTests and conversion tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e2510c2f5c832f84de6ae75824feee