### PR TITLE
Project Unit to void during metadata lookups

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -19,12 +19,38 @@ internal class CodeGenerator
     readonly Dictionary<ITypeSymbol, TypeGenerator> _typeGenerators = new Dictionary<ITypeSymbol, TypeGenerator>(SymbolEqualityComparer.Default);
     readonly Dictionary<SourceSymbol, MemberInfo> _mappings = new Dictionary<SourceSymbol, MemberInfo>(SymbolEqualityComparer.Default);
     readonly Dictionary<ITypeParameterSymbol, Type> _genericParameterMap = new Dictionary<ITypeParameterSymbol, Type>(SymbolEqualityComparer.Default);
+    readonly Dictionary<IMethodSymbol, MethodInfo> _runtimeMethodCache = new Dictionary<IMethodSymbol, MethodInfo>(SymbolEqualityComparer.Default);
+    readonly Dictionary<IMethodSymbol, ConstructorInfo> _runtimeConstructorCache = new Dictionary<IMethodSymbol, ConstructorInfo>(SymbolEqualityComparer.Default);
 
     public IILBuilderFactory ILBuilderFactory { get; set; } = ReflectionEmitILBuilderFactory.Instance;
 
     public void AddMemberBuilder(SourceSymbol symbol, MemberInfo memberInfo) => _mappings[symbol] = memberInfo;
 
     public MemberInfo? GetMemberBuilder(SourceSymbol symbol) => _mappings[symbol];
+
+    internal bool TryGetRuntimeMethod(IMethodSymbol symbol, out MethodInfo methodInfo)
+        => _runtimeMethodCache.TryGetValue(symbol, out methodInfo);
+
+    internal MethodInfo CacheRuntimeMethod(IMethodSymbol symbol, MethodInfo methodInfo)
+    {
+        _runtimeMethodCache[symbol] = methodInfo;
+        return methodInfo;
+    }
+
+    internal bool TryGetRuntimeConstructor(IMethodSymbol symbol, out ConstructorInfo constructorInfo)
+        => _runtimeConstructorCache.TryGetValue(symbol, out constructorInfo);
+
+    internal ConstructorInfo CacheRuntimeConstructor(IMethodSymbol symbol, ConstructorInfo constructorInfo)
+    {
+        _runtimeConstructorCache[symbol] = constructorInfo;
+        return constructorInfo;
+    }
+
+    internal Type CacheRuntimeTypeParameter(ITypeParameterSymbol symbol, Type type)
+    {
+        _genericParameterMap[symbol] = type;
+        return type;
+    }
 
     internal void RegisterGenericParameters(ImmutableArray<ITypeParameterSymbol> parameters, GenericTypeParameterBuilder[] builders)
     {
@@ -998,7 +1024,54 @@ internal class CodeGenerator
 
     internal bool TryGetRuntimeTypeForTypeParameter(ITypeParameterSymbol symbol, out Type type)
     {
-        return _genericParameterMap.TryGetValue(symbol, out type!);
+        if (_genericParameterMap.TryGetValue(symbol, out type!))
+            return true;
+
+        if (symbol is PETypeParameterSymbol peTypeParameter && TryResolveMetadataTypeParameter(peTypeParameter, out var resolved))
+        {
+            type = CacheRuntimeTypeParameter(symbol, resolved);
+            return true;
+        }
+
+        type = null!;
+        return false;
+    }
+
+    private bool TryResolveMetadataTypeParameter(PETypeParameterSymbol symbol, out Type type)
+    {
+        if (symbol.ContainingSymbol is INamedTypeSymbol containingType)
+        {
+            var runtimeType = containingType.GetClrTypeTreatingUnitAsVoid(this);
+            var parameters = runtimeType.IsGenericTypeDefinition
+                ? runtimeType.GetTypeInfo().GenericTypeParameters
+                : runtimeType.GetGenericTypeDefinition().GetTypeInfo().GenericTypeParameters;
+
+            var ordinal = symbol.Ordinal;
+            if ((uint)ordinal < (uint)parameters.Length)
+            {
+                type = parameters[ordinal];
+                return true;
+            }
+        }
+        else if (symbol.ContainingSymbol is IMethodSymbol containingMethod)
+        {
+            if (TryGetRuntimeMethod(containingMethod, out var methodInfo))
+            {
+                var parameters = methodInfo.IsGenericMethodDefinition
+                    ? methodInfo.GetGenericArguments()
+                    : methodInfo.GetGenericMethodDefinition().GetGenericArguments();
+
+                var ordinal = symbol.Ordinal;
+                if ((uint)ordinal < (uint)parameters.Length)
+                {
+                    type = parameters[ordinal];
+                    return true;
+                }
+            }
+        }
+
+        type = null!;
+        return false;
     }
 
 }

--- a/src/Raven.CodeAnalysis/MethodSymbolExtensionsForCodeGen.cs
+++ b/src/Raven.CodeAnalysis/MethodSymbolExtensionsForCodeGen.cs
@@ -111,7 +111,7 @@ internal static class MethodSymbolExtensionsForCodeGen
         if (methodSymbol.ContainingType is null)
             throw new InvalidOperationException($"Method symbol '{methodSymbol}' is missing a containing type.");
 
-        return methodSymbol.ContainingType.GetClrType(codeGen);
+        return methodSymbol.ContainingType.GetClrTypeTreatingUnitAsVoid(codeGen);
     }
 
     private static BindingFlags GetBindingFlags(IMethodSymbol methodSymbol)
@@ -128,9 +128,6 @@ internal static class MethodSymbolExtensionsForCodeGen
             return false;
 
         if (!RuntimeTypeMatches(candidate.DeclaringType, methodSymbol.ContainingType, codeGen))
-            return false;
-
-        if (!candidate.IsGenericMethodDefinition && candidate.ContainsGenericParameters)
             return false;
 
         if (candidate.IsGenericMethodDefinition)
@@ -304,7 +301,7 @@ internal static class MethodSymbolExtensionsForCodeGen
                 ?? throw new InvalidOperationException($"Unable to map constructed constructor '{constructedConstructor}' to runtime info.");
 
         var parameterTypes = constructedConstructor.Parameters
-            .Select(p => p.Type.GetClrType(codeGen))
+            .Select(p => p.Type.GetClrTypeTreatingUnitAsVoid(codeGen))
             .ToArray();
 
         var resolved = constructedRuntimeType.GetConstructor(

--- a/src/Raven.CodeAnalysis/MethodSymbolExtensionsForCodeGen.cs
+++ b/src/Raven.CodeAnalysis/MethodSymbolExtensionsForCodeGen.cs
@@ -179,7 +179,7 @@ internal static class MethodSymbolExtensionsForCodeGen
         return false;
     }
 
-    private static bool ParametersMatch(ParameterInfo[] runtimeParameters, ImmutableArray<IParameterSymbol> parameterSymbols, CodeGenerator codeGen)
+    internal static bool ParametersMatch(ParameterInfo[] runtimeParameters, ImmutableArray<IParameterSymbol> parameterSymbols, CodeGenerator codeGen)
     {
         if (runtimeParameters.Length != parameterSymbols.Length)
             return false;
@@ -207,7 +207,7 @@ internal static class MethodSymbolExtensionsForCodeGen
         return TypesEquivalent(runtimeParameter.ParameterType, symbolParameter.Type, codeGen);
     }
 
-    private static bool ReturnTypesMatch(Type runtimeReturnType, ITypeSymbol symbolReturnType, CodeGenerator codeGen)
+    internal static bool ReturnTypesMatch(Type runtimeReturnType, ITypeSymbol symbolReturnType, CodeGenerator codeGen)
     {
         if (symbolReturnType.SpecialType == SpecialType.System_Void)
             return runtimeReturnType == typeof(void);
@@ -226,7 +226,7 @@ internal static class MethodSymbolExtensionsForCodeGen
         return TypesEquivalent(runtimeReturnType, symbolReturnType, codeGen);
     }
 
-    private static bool TypesEquivalent(Type runtimeType, ITypeSymbol symbolType, CodeGenerator codeGen)
+    internal static bool TypesEquivalent(Type runtimeType, ITypeSymbol symbolType, CodeGenerator codeGen)
     {
         if (symbolType is ITypeParameterSymbol typeParameter)
             return RuntimeTypeMatchesTypeParameter(runtimeType, typeParameter);

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -188,9 +188,9 @@ internal sealed class ConstructedMethodSymbol : IMethodSymbol
         var containingType = _definition.ContainingType
             ?? throw new InvalidOperationException("Constructed method is missing a containing type.");
 
-        var containingClrType = containingType.GetClrType(codeGen);
+        var containingClrType = containingType.GetClrTypeTreatingUnitAsVoid(codeGen);
         var expectedParameterTypes = Parameters
-            .Select(parameter => parameter.Type.GetClrType(codeGen))
+            .Select(parameter => parameter.Type.GetClrTypeTreatingUnitAsVoid(codeGen))
             .ToArray();
         var returnTypeSymbol = ReturnType;
         var expectedReturnType = returnTypeSymbol.GetClrTypeTreatingUnitAsVoid(codeGen);

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs
@@ -345,7 +345,9 @@ internal sealed class SubstitutedMethodSymbol : IMethodSymbol
             var constructedType = _constructed.GetTypeInfo(codeGen).AsType();
 
             // Use metadata name and parameter types to resolve the method on the constructed type
-            var parameterTypes = Parameters.Select(x => x.Type.GetClrType(codeGen)).ToArray();
+            var parameterTypes = Parameters
+                .Select(x => x.Type.GetClrTypeTreatingUnitAsVoid(codeGen))
+                .ToArray();
             var method = constructedType.GetMethod(
                 baseMethod.Name,
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static,
@@ -378,7 +380,7 @@ internal sealed class SubstitutedMethodSymbol : IMethodSymbol
                 return definitionMethod;
 
             var parameterTypes = sourceMethod.Parameters
-                .Select(p => p.Type.GetClrType(codeGen))
+                .Select(p => p.Type.GetClrTypeTreatingUnitAsVoid(codeGen))
                 .ToArray();
 
             var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;

--- a/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
@@ -250,10 +250,6 @@ internal partial class PEMethodSymbol : PESymbol, IMethodSymbol
 
     public IMethodSymbol? ConstructedFrom => this;
 
-    public MethodInfo GetMethodInfo() => (MethodInfo)_methodInfo;
-
-    public ConstructorInfo GetConstructorInfo() => (ConstructorInfo)_methodInfo;
-
     public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
     {
         if (typeArguments is null)

--- a/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
@@ -110,14 +110,28 @@ internal partial class PEMethodSymbol : PESymbol, IMethodSymbol
 
     public override SymbolKind Kind => SymbolKind.Method;
     public override string Name => _methodInfo.Name;
+
+    public override string MetadataName => _methodInfo.Name;
     public ITypeSymbol ReturnType
     {
         get
         {
             if (_returnType == null)
             {
-                var returnParam = ((MethodInfo)_methodInfo).ReturnParameter;
-                _returnType = _typeResolver.ResolveType(returnParam.ParameterType, _methodInfo)!;
+                if (_methodInfo is MethodInfo methodInfo)
+                {
+                    var returnParam = methodInfo.ReturnParameter;
+                    _returnType = _typeResolver.ResolveType(returnParam.ParameterType, _methodInfo)!;
+                }
+                else if (MethodKind is MethodKind.Constructor or MethodKind.StaticConstructor)
+                {
+                    var declaringType = _methodInfo.DeclaringType ?? throw new InvalidOperationException($"Constructor '{_methodInfo}' is missing a declaring type.");
+                    _returnType = _typeResolver.ResolveType(declaringType, _methodInfo)!;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unsupported method base type '{_methodInfo.GetType()}'.");
+                }
             }
             return _returnType;
         }

--- a/src/Raven.CodeAnalysis/TypeResolver.cs
+++ b/src/Raven.CodeAnalysis/TypeResolver.cs
@@ -9,7 +9,7 @@ internal class TypeResolver(Compilation compilation)
     private readonly Dictionary<Type, ITypeSymbol> _cache = new();
     private readonly NullabilityInfoContext _nullabilityContext = new();
     private readonly Dictionary<MethodBase, PEMethodSymbol> _methodSymbols = new();
-    private readonly Dictionary<(MethodBase method, Type parameter), ITypeParameterSymbol> _methodTypeParameters = new();
+    private readonly Dictionary<(PEMethodSymbol method, Type parameter), ITypeParameterSymbol> _methodTypeParameters = new();
 
     public ITypeSymbol? ResolveType(ParameterInfo parameterInfo)
     {
@@ -195,7 +195,7 @@ internal class TypeResolver(Compilation compilation)
 
     internal ITypeParameterSymbol ResolveMethodTypeParameter(Type type, PEMethodSymbol methodSymbol)
     {
-        var key = (methodSymbol.GetMethodInfo(), type);
+        var key = (methodSymbol, type);
 
         if (_methodTypeParameters.TryGetValue(key, out var existing))
             return existing;

--- a/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolExtensionsForCodeGen.cs
@@ -52,9 +52,6 @@ public static class TypeSymbolExtensionsForCodeGen
             if (codeGen.TryGetRuntimeTypeForTypeParameter(typeParameterSymbol, out var parameterType))
                 return parameterType;
 
-            if (typeParameterSymbol is PETypeParameterSymbol peTypeParameter)
-                return peTypeParameter.GetTypeInfo();
-
             throw new InvalidOperationException($"Unable to resolve runtime type for type parameter: {typeParameterSymbol.Name}");
         }
 


### PR DESCRIPTION
## Summary
- normalize constructed method lookups to treat Unit parameters like void to ensure metadata matches
- resolve constructed metadata methods and constructors using Unit-as-void projections when locating runtime members

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e3fd7a5da4832fb5ee1a249fd56320