### PR TITLE
Fix recursion when creating top-level program namespaces

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -357,7 +357,7 @@ public partial class Compilation
             currentSourceNamespace = next;
         }
 
-        return this.GetNamespaceSymbol(ns) ?? currentSourceNamespace;
+        return currentSourceNamespace;
     }
 
     private void AnalyzeMemberDeclaration(SyntaxTree syntaxTree, ISymbol declaringSymbol, MemberDeclarationSyntax memberDeclaration)


### PR DESCRIPTION
## Summary
- avoid re-entering compilation setup when creating namespaces for synthesized top-level programs by returning the source namespace directly

## Testing
- dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/classes.rav -o test.dll
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Lambda_WithoutParameterTypes_UsesTargetDelegateSignature is currently failing in main)*

------
https://chatgpt.com/codex/tasks/task_e_68e515ace098832fb40c12719927987d