### PR TITLE
Fix repeated rewriting of named constructor bodies

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
@@ -8,6 +8,7 @@ namespace Raven.CodeAnalysis;
 class MethodBodyBinder : BlockBinder
 {
     private readonly IMethodSymbol _methodSymbol;
+    private bool _namedConstructorRewritten;
 
     public MethodBodyBinder(IMethodSymbol methodSymbol, Binder parent)
         : base(methodSymbol, parent)
@@ -19,7 +20,7 @@ class MethodBodyBinder : BlockBinder
     {
         var bound = base.BindBlockStatement(block);
 
-        if (_methodSymbol.IsNamedConstructor)
+        if (_methodSymbol.IsNamedConstructor && !_namedConstructorRewritten)
         {
             var selfLocal = new SourceLocalSymbol(
                 "__self",
@@ -33,6 +34,7 @@ class MethodBodyBinder : BlockBinder
 
             var rewriter = new NamedConstructorRewriter(_methodSymbol, selfLocal);
             bound = rewriter.Rewrite(bound);
+            _namedConstructorRewritten = true;
         }
 
         var unit = Compilation.GetSpecialType(SpecialType.System_Unit);


### PR DESCRIPTION
## Summary
- track whether a named constructor body has already been rewritten so the binder only injects the synthetic `__self` local once

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: requires runtime assemblies when inspecting generated IL)*

------
https://chatgpt.com/codex/tasks/task_e_68e52f132878832f8f001a341d605cc4