### PR TITLE
Cache top-level binder before binding global statements

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -632,18 +632,22 @@ public partial class SemanticModel
 
         var topLevelBinder = new TopLevelBinder(parentBinder, this, scriptMethod, mainMethod, cu);
 
-        // Cache the compilation unit and its global statements before binding.
-        //
-        // Binding the statements will request declared symbols, which rely on binder
-        // lookup through SemanticModel.GetBinder. Without priming the cache, any
-        // attempt to resolve the compilation unit binder re-enters
-        // BindCompilationUnit, causing unbounded recursion (see stack trace in bug
-        // report). By caching eagerly we guarantee re-entrant lookups retrieve the
-        // partially constructed top-level binder instead of rebuilding it.
-        _binderCache[cu] = topLevelBinder;
+        if (bindableGlobals.Count > 0)
+        {
+            // Cache the compilation unit and its global statements before binding.
+            //
+            // Binding the statements will request declared symbols, which rely on
+            // binder lookup through SemanticModel.GetBinder. Without priming the
+            // cache, any attempt to resolve the compilation unit binder re-enters
+            // BindCompilationUnit, causing unbounded recursion (see stack trace in
+            // bug report). By caching eagerly we guarantee re-entrant lookups
+            // retrieve the partially constructed top-level binder instead of
+            // rebuilding it.
+            _binderCache[cu] = topLevelBinder;
 
-        foreach (var stmt in bindableGlobals)
-            _binderCache[stmt] = topLevelBinder;
+            foreach (var stmt in bindableGlobals)
+                _binderCache[stmt] = topLevelBinder;
+        }
 
         topLevelBinder.BindGlobalStatements(bindableGlobals);
 

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -632,10 +632,20 @@ public partial class SemanticModel
 
         var topLevelBinder = new TopLevelBinder(parentBinder, this, scriptMethod, mainMethod, cu);
 
-        topLevelBinder.BindGlobalStatements(bindableGlobals);
+        // Cache the compilation unit and its global statements before binding.
+        //
+        // Binding the statements will request declared symbols, which rely on binder
+        // lookup through SemanticModel.GetBinder. Without priming the cache, any
+        // attempt to resolve the compilation unit binder re-enters
+        // BindCompilationUnit, causing unbounded recursion (see stack trace in bug
+        // report). By caching eagerly we guarantee re-entrant lookups retrieve the
+        // partially constructed top-level binder instead of rebuilding it.
+        _binderCache[cu] = topLevelBinder;
 
         foreach (var stmt in bindableGlobals)
             _binderCache[stmt] = topLevelBinder;
+
+        topLevelBinder.BindGlobalStatements(bindableGlobals);
 
         return topLevelBinder;
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/TopLevelGlobalStatementTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TopLevelGlobalStatementTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public sealed class TopLevelGlobalStatementTests : CompilationTestBase
+{
+    [Fact]
+    public void GlobalStatements_CanReferenceTopLevelTypes()
+    {
+        const string source = """
+interface IGreeter {
+    public Greet() -> unit;
+};
+
+class Greeter : IGreeter {
+    public Greet() -> unit => ();
+};
+
+enum Shade {
+    Red,
+    Green,
+};
+
+let greeter: IGreeter = Greeter();
+greeter.Greet();
+let shade = Shade.Green;
+""";
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree, assemblyName: "app");
+
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+        var interfaceDeclaration = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>().Single();
+        var enumDeclaration = root.DescendantNodes().OfType<EnumDeclarationSyntax>().Single();
+
+        var classSymbol = Assert.IsAssignableFrom<INamedTypeSymbol>(model.GetDeclaredSymbol(classDeclaration));
+        var interfaceSymbol = Assert.IsAssignableFrom<INamedTypeSymbol>(model.GetDeclaredSymbol(interfaceDeclaration));
+        var enumSymbol = Assert.IsAssignableFrom<INamedTypeSymbol>(model.GetDeclaredSymbol(enumDeclaration));
+
+        var greeterCreation = root
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single(invocation => invocation.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == "Greeter");
+        var creationType = model.GetTypeInfo(greeterCreation);
+        Assert.Same(classSymbol, creationType.Type);
+
+        var annotationType = root
+            .DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .First(id => id.Identifier.ValueText == "IGreeter");
+        var annotatedInfo = model.GetTypeInfo(annotationType);
+        Assert.Same(interfaceSymbol, annotatedInfo.Type);
+
+        var enumAccess = root
+            .DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Single(access => access.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == "Shade");
+        var enumMember = Assert.IsAssignableFrom<IFieldSymbol>(model.GetSymbolInfo(enumAccess).Symbol);
+        Assert.Same(enumSymbol, enumMember.ContainingType);
+    }
+}


### PR DESCRIPTION
## Summary
- cache the compilation unit binder before binding global statements so re-entrant lookups reuse it
- document the reasoning for the eager cache priming to prevent GetBinder recursion

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e6221e0660832f96858d8216296003