### PR TITLE
Document runtime behavior of emitted samples

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -5,39 +5,41 @@ Re-running every sample with `dotnet run -- samples/<file>.rav -o output/<file>.
 
 | Sample | Status | Notes |
 | --- | --- | --- |
-| `arrays.rav` | ✅ Emitted | |
-| `async-await.rav` | ✅ Emitted | |
-| `catch.rav` | ✅ Emitted | |
-| `classes.rav` | ✅ Emitted | |
-| `collections.rav` | ✅ Emitted | |
-| `enums.rav` | ✅ Emitted | |
-| `foo.rav` | ✅ Emitted | |
-| `function-types.rav` | ✅ Emitted | |
-| `general.rav` | ✅ Emitted | |
-| `generator.rav` | ✅ Emitted | |
-| `generics.rav` | ✅ Emitted | |
-| `generics2.rav` | ✅ Emitted | |
-| `goto.rav` | ✅ Emitted | |
-| `interfaces.rav` | ❌ Fails | Binder crashes while resolving interpolated string concatenation during diagnostic gathering.【bc7ee1†L1-L26】
-| `introduction.rav` | ✅ Emitted | |
-| `io.rav` | ✅ Emitted | |
-| `lambda.rav` | ✅ Emitted | |
-| `linq.rav` | ✅ Emitted | |
-| `main.rav` | ✅ Emitted | |
-| `match.rav` | ✅ Emitted | |
-| `parse-number.rav` | ✅ Emitted | |
-| `pattern-matching.rav` | ✅ Emitted | |
-| `reflection.rav` | ✅ Emitted | |
-| `string-interpolation.rav` | ✅ Emitted | |
-| `test.rav` | ✅ Emitted | |
-| `test2.rav` | ✅ Emitted | |
-| `test3.rav` | ❌ Fails | Top-level program synthesis still recurses inside `SynthesizedMainMethodSymbol.ResolveReturnType`.【58d0b2†L1-L120】
-| `tokenizer.rav` | ⚠️ Hangs | Trivia lexing never terminates; the build must be canceled manually.【55f5d9†L1-L4】
-| `try-match.rav` | ✅ Emitted | |
-| `tuples.rav` | ⚠️ Emitted with warning | Compilation reports the redundant-pattern diagnostic but still emits IL.【79f2e5†L1-L3】
-| `tuples2.rav` | ✅ Emitted | |
-| `type-unions.rav` | ❌ Fails | Emission aborts when `ResolveRuntimeMethodInfo` cannot locate the target CLR method.【73dafa†L1-L18】
-| `unit.rav` | ✅ Emitted | |
+| `arrays.rav` | ✅ Emitted / ✅ Ran | Re-verified via `dotnet run --no-build --no-restore -- samples/arrays.rav -o output/arrays.dll`; `dotnet output/arrays.dll` prints the expected 3, 1, 42, 3 sequence.【6eb898†L1-L1】【639047†L1-L1】【0d40e5†L1-L5】 |
+| `async-await.rav` | ✅ Emitted / ❌ Runtime failure | Emitted with `dotnet run --no-build --no-restore -- samples/async-await.rav -o output/async-await.dll`, but running the DLL throws `System.InvalidProgramException` from the async state machine.【119a61†L1-L1】【a11630†L1-L2】【f135b0†L1-L7】 |
+| `catch.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/catch.rav -o output/catch.dll`; `dotnet output/catch.dll` prints `Foo`.【e84da2†L1-L1】【cf1cdf†L1-L2】【dea803†L1-L3】 |
+| `classes.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/classes.rav -o output/classes.dll`; running the DLL prints the sample greetings and record projection results.【e789cb†L1-L1】【a65916†L1-L2】【5e03a0†L1-L5】 |
+| `collections.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/collections.rav -o output/collections.dll`; executing the DLL yields the expected hero roster sequence.【36ed9b†L1-L1】【3f85f3†L1-L2】【9640dc†L1-L8】 |
+| `enums.rav` | ✅ Emitted / ❌ Runtime failure | Emitted via `dotnet run --no-build --no-restore -- samples/enums.rav -o output/enums.dll`, but `dotnet output/enums.dll` crashes with a `TypeLoadException` because the enum contains an illegal field type.【ec5f92†L1-L1】【d78b09†L1-L2】【840f61†L1-L5】 |
+| `foo.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/foo.rav -o output/foo.dll`; running the DLL prints `1`.【f9bf71†L1-L1】【6e8354†L1-L2】【9a42fe†L1-L3】 |
+| `function-types.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/function-types.rav -o output/function-types.dll`; the DLL reports the composed delegate results (10, 20, 20).【b2312d†L1-L1】【f03fee†L1-L2】【03898f†L1-L4】 |
+| `general.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/general.rav -o output/general.dll`; running prints `Hello, World!` and the sample values 1, 42, 3.【ca59b4†L1-L1】【ecd6d3†L1-L2】【ba615f†L1-L6】 |
+| `generator.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/generator.rav -o output/generator.dll`; the DLL prints 42 followed by the expected odd sequence.【d80754†L1-L1】【bbc94c†L1-L2】【6ff9bd†L1-L6】 |
+| `generics.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/generics.rav -o output/generics.dll`; running returns 2, 2, 3 as expected.【6e0ffc†L1-L1】【63c119†L1-L2】【7206be†L1-L4】 |
+| `generics2.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/generics2.rav -o output/generics2.dll`; `dotnet output/generics2.dll` prints `ok`.【759051†L1-L1】【a1f5b8†L1-L2】【f6b5e1†L1-L3】 |
+| `goto.rav` | ✅ Emitted / ⚠️ Not run | Emitted via `dotnet run --no-build --no-restore -- samples/goto.rav -o output/goto.dll`; runtime execution was skipped because the sample’s `goto` loop never terminates.【f4fcb7†L1-L1】【f304da†L1-L1】【F:src/Raven.Compiler/samples/goto.rav†L1-L5】 |
+| `interfaces.rav` | ❌ Fails | Binder crashes while resolving interpolated string concatenation during diagnostic gathering.【bc7ee1†L1-L26】 |
+| `introduction.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/introduction.rav -o output/introduction.dll`; running the DLL prints the expected summary of argument handling.【229406†L1-L1】【c23ee0†L1-L2】【35473e†L1-L4】 |
+| `io.rav` | ✅ Emitted / ⚠️ Requires args | Emitted via `dotnet run --no-build --no-restore -- samples/io.rav -o output/io.dll`; running without an argument reports “Expected 1 argument” and exits after counting zero files.【dd98d4†L1-L1】【da1908†L1-L2】【b18cce†L1-L4】 |
+| `lambda.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/lambda.rav -o output/lambda.dll`; executing the DLL prints the captured lambda results.【1f02b5†L1-L1】【f39f82†L1-L2】【eb68d9†L1-L6】 |
+| `linq.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/linq.rav -o output/linq.dll`; the DLL enumerates 3, 2, 1 as expected.【9b4c4a†L1-L1】【b2c784†L1-L2】【0c8340†L1-L5】 |
+| `main.rav` | ✅ Emitted / ❌ Runtime failure | Emitted via `dotnet run --no-build --no-restore -- samples/main.rav -o output/main.dll`, but running the DLL throws a `TypeLoadException` for the `Status` enum’s illegal field type.【4f8e24†L1-L1】【e288e2†L1-L2】【1d2f9f†L1-L5】 |
+| `match.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/match.rav -o output/match.dll`; runtime output shows the expected pattern discriminations (`Int32`, `String`, `foo`).【fb8e0f†L1-L1】【cceef1†L1-L2】【10a7fc†L1-L5】 |
+| `parse-number.rav` | ✅ Emitted / ⚠️ Interactive loop | Emitted via `dotnet run --no-build --no-restore -- samples/parse-number.rav -o output/parse-number.dll`; running the DLL enters an endless prompt loop that accumulates totals until manually interrupted.【45afc8†L1-L1】【d8d5dd†L1-L2】【afe580†L1-L2】【8fdea1†L1-L4】【1b35d3†L1-L1】 |
+| `pattern-matching.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/pattern-matching.rav -o output/pattern-matching.dll`; running prints `else`.【363dbf†L1-L1】【85e426†L1-L2】【a069c2†L1-L3】 |
+| `reflection.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/reflection.rav -o output/reflection.dll`; runtime output lists reflection metadata such as `System.Object` members.【bda6ec†L1-L1】【eac729†L1-L2】【6963f7†L1-L6】 |
+| `string-interpolation.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/string-interpolation.rav -o output/string-interpolation.dll`; the DLL prints the Hebrew greeting as expected.【5b1970†L1-L1】【a31c11†L1-L2】【a2351b†L1-L3】 |
+| `test.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/test.rav -o output/test.dll`; running prints `8`.【e23c86†L1-L1】【56d464†L1-L2】【253cff†L1-L3】 |
+| `test2.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/test2.rav -o output/test2.dll`; running prints `42`, `Hello, World!`, and `Hello, 2`.【f242cf†L1-L1】【573417†L1-L2】【368ad8†L1-L5】 |
+| `test3.rav` | ❌ Fails | Top-level program synthesis still recurses inside `SynthesizedMainMethodSymbol.ResolveReturnType`.【58d0b2†L1-L120】 |
+| `tokenizer.rav` | ⚠️ Hangs | Trivia lexing never terminates; the build must be canceled manually.【55f5d9†L1-L4】 |
+| `try-match.rav` | ✅ Emitted / ⚠️ Input mismatch | Emitted via `dotnet run --no-build --no-restore -- samples/try-match.rav -o output/try-match.dll`; running reports “Format invalid: The input string 'foo' was not in a correct format.” before exiting.【833303†L1-L1】【c66dbd†L1-L2】【222a54†L1-L3】 |
+| `tuples.rav` | ⚠️ Emitted with warning / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/tuples.rav -o output/tuples.dll`, which reiterates the redundant catch-all warning; runtime output prints tuple projections without error.【e87a06†L1-L1】【c0f43e†L1-L4】【e72be4†L1-L6】 |
+| `tuples2.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/tuples2.rav -o output/tuples2.dll`; running prints `tuple False foo`.【4870d9†L1-L1】【2eb57d†L1-L2】【b0b6a1†L1-L3】 |
+| `type-unions.rav` | ❌ Fails | Emission aborts when `ResolveRuntimeMethodInfo` cannot locate the target CLR method.【73dafa†L1-L18】 |
+| `unit.rav` | ✅ Emitted / ✅ Ran | Emitted via `dotnet run --no-build --no-restore -- samples/unit.rav -o output/unit.dll`; running prints `Hello` followed by unit literals.【df4e31†L1-L1】【8c34bb†L1-L1】【714a4c†L1-L6】 |
+
+**Runtime observations.** `async-await.rav` currently emits invalid IL that the CLR rejects, while `enums.rav` and `main.rav` crash with `TypeLoadException` because their generated enums declare illegal fields.【119a61†L1-L1】【a11630†L1-L2】【f135b0†L1-L7】【ec5f92†L1-L1】【d78b09†L1-L2】【840f61†L1-L5】【4f8e24†L1-L1】【e288e2†L1-L2】【1d2f9f†L1-L5】 The interactive samples are not turnkey: `io.rav` expects a directory argument, `parse-number.rav` loops forever waiting for input, `goto.rav` is an intentional infinite loop, and `try-match.rav` reports a format error for its default `'foo'` argument.【dd98d4†L1-L1】【da1908†L1-L2】【b18cce†L1-L4】【45afc8†L1-L1】【d8d5dd†L1-L2】【afe580†L1-L2】【8fdea1†L1-L4】【1b35d3†L1-L1】【f4fcb7†L1-L1】【f304da†L1-L1】【F:src/Raven.Compiler/samples/goto.rav†L1-L5】【833303†L1-L1】【c66dbd†L1-L2】【222a54†L1-L3】
 
 ## Common problem patterns
 - **Symbol binding recursion (resolved):** `SymbolEqualityComparer` now tracks visited symbol pairs to break cycles when inspecting extension methods, interface defaults, and interpolated strings. The affected samples (`samples/main.rav`, `samples/generator.rav`, `samples/interfaces.rav`, `samples/linq.rav`, and `samples/reflection.rav`) compile successfully again.【F:src/Raven.CodeAnalysis/SymbolEqualityComparer.cs†L1-L215】【4528a4†L1-L4】【2941cf†L1-L3】【152141†L1-L2】【d2560e†L1-L3】【2a10c8†L1-L2】【a8337e†L1-L3】【14c359†L1-L2】【4013ab†L1-L3】【9f9ee0†L1-L2】【6a0816†L1-L3】


### PR DESCRIPTION
## Summary
- update the sample status table to record runtime outcomes for every previously emitting program
- note the outstanding runtime failures and interactive requirements for async-await, enums/main, io, parse-number, goto, and try-match

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e6606cf1c8832fad5f4bb9c2e509a0