### PR TITLE
Ensure enums use runtime underlying type during emission

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -76,9 +76,15 @@ internal class TypeGenerator
             );
 
             // Lägg till value__ direkt här
+            // Raven enums currently default to an Int32 underlying type. If the language adds support
+            // for explicit enum bases we should thread that information through the symbol model and
+            // resolve it here instead of hard-coding Int32.
+            var enumUnderlyingType = Compilation.GetSpecialType(SpecialType.System_Int32);
+            var runtimeUnderlyingType = ResolveClrType(enumUnderlyingType);
+
             TypeBuilder.DefineField(
                 "value__",
-                Compilation.GetTypeByMetadataName("System.Int32").GetClrType(Compilation),
+                runtimeUnderlyingType,
                 FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName
             );
 


### PR DESCRIPTION
## Summary
- resolve the runtime CLR type for the synthesized enum `value__` field using the codegen type resolver instead of metadata-only types
- document the current assumption that enums default to `Int32` until the symbol model exposes explicit enum bases

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build`
- `MSBUILDTERMINALLOGGER=false dotnet test test/Raven.CodeAnalysis.Tests` *(fails: existing semantic and metadata extension method diagnostics assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68e6728f0764832fad89db6e9b9a4444