### PR TITLE
Resolve runtime fields for metadata members

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/PE/PEFieldSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEFieldSymbol.cs
@@ -8,6 +8,7 @@ internal partial class PEFieldSymbol : PESymbol, IFieldSymbol
     private readonly FieldInfo _fieldInfo;
     private ITypeSymbol? _type;
     private Accessibility? _accessibility;
+    private FieldInfo? _runtimeFieldInfo;
 
     public PEFieldSymbol(TypeResolver typeResolver, FieldInfo fieldInfo, INamedTypeSymbol? containingType, Location[] locations)
         : base(containingType, containingType, containingType.ContainingNamespace, locations)
@@ -34,5 +35,18 @@ internal partial class PEFieldSymbol : PESymbol, IFieldSymbol
 
     public object? GetConstantValue() => _fieldInfo.GetRawConstantValue();
 
-    public virtual FieldInfo GetFieldInfo() => _fieldInfo;
+    public virtual FieldInfo GetFieldInfo()
+    {
+        if (_runtimeFieldInfo is not null)
+            return _runtimeFieldInfo;
+
+        var runtimeField = _typeResolver.ResolveRuntimeField(_fieldInfo);
+        if (runtimeField is not null)
+        {
+            _runtimeFieldInfo = runtimeField;
+            return runtimeField;
+        }
+
+        return _fieldInfo;
+    }
 }

--- a/src/Raven.CodeAnalysis/TypeSymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/TypeSymbolExtensions.cs
@@ -93,31 +93,38 @@ public static class TypeSymbolExtensions
     private static Type GetFrameworkType(SpecialType specialType, Compilation compilation)
     {
         // Helper to fetch type from the MetadataLoadContext CoreAssembly
-        static Type FromCoreAssembly(Compilation c, string fullName) =>
-            c.CoreAssembly.GetType(fullName) ?? throw new InvalidOperationException($"Type '{fullName}' not found in CoreAssembly");
+        static Type Resolve(Compilation c, string fullName)
+        {
+            var runtimeType = c.ResolveRuntimeType(fullName);
+            if (runtimeType is not null)
+                return runtimeType;
+
+            return c.CoreAssembly.GetType(fullName)
+                ?? throw new InvalidOperationException($"Type '{fullName}' not found in referenced assemblies.");
+        }
 
         return specialType switch
         {
-            SpecialType.System_Int32 => FromCoreAssembly(compilation, "System.Int32"),
-            SpecialType.System_String => FromCoreAssembly(compilation, "System.String"),
-            SpecialType.System_Boolean => FromCoreAssembly(compilation, "System.Boolean"),
-            SpecialType.System_Object => FromCoreAssembly(compilation, "System.Object"),
-            SpecialType.System_Void => FromCoreAssembly(compilation, "System.Void"),
-            SpecialType.System_Unit => FromCoreAssembly(compilation, "System.Void"),
-            SpecialType.System_Double => FromCoreAssembly(compilation, "System.Double"),
-            SpecialType.System_Char => FromCoreAssembly(compilation, "System.Char"),
-            SpecialType.System_Int64 => FromCoreAssembly(compilation, "System.Int64"),
-            SpecialType.System_Single => FromCoreAssembly(compilation, "System.Single"),
-            SpecialType.System_Byte => FromCoreAssembly(compilation, "System.Byte"),
-            SpecialType.System_Decimal => FromCoreAssembly(compilation, "System.Decimal"),
-            SpecialType.System_Int16 => FromCoreAssembly(compilation, "System.Int16"),
-            SpecialType.System_UInt32 => FromCoreAssembly(compilation, "System.UInt32"),
-            SpecialType.System_UInt64 => FromCoreAssembly(compilation, "System.UInt64"),
-            SpecialType.System_UInt16 => FromCoreAssembly(compilation, "System.UInt16"),
-            SpecialType.System_SByte => FromCoreAssembly(compilation, "System.SByte"),
-            SpecialType.System_DateTime => FromCoreAssembly(compilation, "System.DateTime"),
-            SpecialType.System_Array => FromCoreAssembly(compilation, "System.Array"),
-            SpecialType.System_Type => FromCoreAssembly(compilation, "System.Type"),
+            SpecialType.System_Int32 => Resolve(compilation, "System.Int32"),
+            SpecialType.System_String => Resolve(compilation, "System.String"),
+            SpecialType.System_Boolean => Resolve(compilation, "System.Boolean"),
+            SpecialType.System_Object => Resolve(compilation, "System.Object"),
+            SpecialType.System_Void => Resolve(compilation, "System.Void"),
+            SpecialType.System_Unit => Resolve(compilation, "System.Void"),
+            SpecialType.System_Double => Resolve(compilation, "System.Double"),
+            SpecialType.System_Char => Resolve(compilation, "System.Char"),
+            SpecialType.System_Int64 => Resolve(compilation, "System.Int64"),
+            SpecialType.System_Single => Resolve(compilation, "System.Single"),
+            SpecialType.System_Byte => Resolve(compilation, "System.Byte"),
+            SpecialType.System_Decimal => Resolve(compilation, "System.Decimal"),
+            SpecialType.System_Int16 => Resolve(compilation, "System.Int16"),
+            SpecialType.System_UInt32 => Resolve(compilation, "System.UInt32"),
+            SpecialType.System_UInt64 => Resolve(compilation, "System.UInt64"),
+            SpecialType.System_UInt16 => Resolve(compilation, "System.UInt16"),
+            SpecialType.System_SByte => Resolve(compilation, "System.SByte"),
+            SpecialType.System_DateTime => Resolve(compilation, "System.DateTime"),
+            SpecialType.System_Array => Resolve(compilation, "System.Array"),
+            SpecialType.System_Type => Resolve(compilation, "System.Type"),
             _ => throw new NotSupportedException($"Unsupported special type: {specialType}")
         };
     }

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/MemberBindingCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/MemberBindingCodeGenTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class MemberBindingCodeGenTests
+{
+    [Fact]
+    public void MemberBinding_StaticField_FromReferenceAssembly_ResolvesRuntimeField()
+    {
+        const string code = """
+class Program {
+    static Get() -> string {
+        .Empty
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var type = assembly.GetType("Program", throwOnError: true)!;
+        var get = type.GetMethod("Get")!;
+
+        var value = (string)get.Invoke(null, Array.Empty<object>())!;
+        Assert.Equal(string.Empty, value);
+    }
+}


### PR DESCRIPTION
## Summary
- cache runtime field info for PEFieldSymbol instances using TypeResolver to resolve metadata fields to runtime assemblies
- add a TypeResolver helper for fetching runtime FieldInfo and fall back to runtime types for special framework type lookups
- add a regression test ensuring member binding to string.Empty succeeds when inferred from type context

## Testing
- `(cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f)`
- `(cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/BoundNodeGenerator -- -f)`
- `(cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/DiagnosticsGenerator -- -f)`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests --no-restore` *(fails: MethodReference diagnostics tests report unexpected System.Action<T> resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e687af6cac832fb260e03999dea53b