### PR TITLE
Format function delegate diagnostics with arrow notation

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/FunctionTypeDiagnosticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/FunctionTypeDiagnosticTests.cs
@@ -1,0 +1,26 @@
+using Raven.CodeAnalysis;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class FunctionTypeDiagnosticTests : CompilationTestBase
+{
+    [Fact]
+    public void LambdaArgument_TypeMismatch_UsesFunctionNotation()
+    {
+        var source = """
+        func test(x: int -> int) {}
+
+        func main() {
+            test(() => 1)
+        }
+        """;
+
+        var (compilation, _) = CreateCompilation(source);
+
+        var diagnostic = Assert.Single(compilation.GetDiagnostics());
+        Assert.Equal(CompilerDiagnostics.CannotConvertFromTypeToType, diagnostic.Descriptor);
+        Assert.Equal("Cannot convert from '() -> int' to 'int -> int'", diagnostic.GetMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- render Action/Func-based delegate types as Raven arrow function signatures when formatting diagnostics
- cover the new formatting with a semantic regression test that exercises a lambda argument mismatch

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing lambda/metadata fixture diagnostics and parser regression expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e695779444832f8e3c95bb44a963af