### PR TITLE
Suppress conversion diagnostics for error-typed expressions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -4091,7 +4091,7 @@ partial class BlockBinder : Binder
 
     protected bool IsAssignable(ITypeSymbol targetType, ITypeSymbol sourceType, out Conversion conversion)
     {
-        if (targetType.TypeKind == TypeKind.Error || sourceType.TypeKind == TypeKind.Error)
+        if (targetType.ContainsErrorType() || sourceType.ContainsErrorType())
         {
             conversion = new Conversion(isImplicit: true, isIdentity: true);
             return true;
@@ -4103,7 +4103,8 @@ partial class BlockBinder : Binder
 
     private static bool ShouldAttemptConversion(BoundExpression expression)
     {
-        return expression is BoundMethodGroupExpression || expression.Type is { TypeKind: not TypeKind.Error };
+        return expression is BoundMethodGroupExpression ||
+            expression.Type is { } type && !type.ContainsErrorType();
     }
 
     private BoundExpression ApplyConversion(BoundExpression expression, ITypeSymbol targetType, Conversion conversion, SyntaxNode? syntax = null)

--- a/src/Raven.CodeAnalysis/Compilation.Conversions.cs
+++ b/src/Raven.CodeAnalysis/Compilation.Conversions.cs
@@ -49,6 +49,9 @@ public partial class Compilation
             return conversion.WithAlias(aliasInvolved);
         }
 
+        if (source.ContainsErrorType() || destination.ContainsErrorType())
+            return Finalize(new Conversion(isImplicit: true, isIdentity: true));
+
         if (source is LiteralTypeSymbol litSrc && destination is LiteralTypeSymbol litDest)
             return Equals(litSrc.ConstantValue, litDest.ConstantValue)
                 ? Finalize(new Conversion(isImplicit: true, isIdentity: true))

--- a/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/LambdaInferenceTests.cs
@@ -312,4 +312,26 @@ class Container {
 
         verifier.Verify();
     }
+
+    [Fact]
+    public void Lambda_WithErrorTypeArgument_DoesNotReportConversionError()
+    {
+        const string code = """
+func apply(value: int, transform: int -> int) -> int {
+    transform(value)
+}
+
+let doubled = x => x * 2
+
+let result = apply(5, doubled)
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            [
+                new DiagnosticResult("RAV2200").WithSpan(5, 15, 5, 16).WithArguments("x"),
+            ]);
+
+        verifier.Verify();
+    }
 }


### PR DESCRIPTION
## Summary
- add an `ITypeSymbol.ContainsErrorType` helper and use it to short-circuit conversion attempts on error symbols
- treat conversions involving error types as implicit so cascading RAV1503 diagnostics are suppressed
- add a regression test covering lambdas whose parameter types fail to infer

## Testing
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: known issues in PatternAssignmentSemanticTests.TuplePatternAssignment_WithExistingLocals_ReusesBindings and AsyncILGenerationTests.AsyncLambda_EmitsStateMachineMetadata)*


------
https://chatgpt.com/codex/tasks/task_e_68e6ab37f624832f82592606d4c07244