### PR TITLE
Preserve declared union host types for metadata

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/AliasSymbol.cs
@@ -189,6 +189,8 @@ internal sealed class AliasUnionTypeSymbol : AliasSymbol, IUnionTypeSymbol
 
     public IEnumerable<ITypeSymbol> Types => _type.Types;
 
+    public ITypeSymbol? DeclaredUnderlyingType => _type.DeclaredUnderlyingType;
+
     public ImmutableArray<INamedTypeSymbol> Interfaces => _type.Interfaces;
 
     public ImmutableArray<INamedTypeSymbol> AllInterfaces => _type.AllInterfaces;

--- a/src/Raven.CodeAnalysis/Symbols/Constructed/UnionTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/UnionTypeSymbol.cs
@@ -8,12 +8,20 @@ internal partial class UnionTypeSymbol : SourceSymbol, IUnionTypeSymbol
 {
     private readonly ImmutableArray<ITypeSymbol> _types;
 
-    public UnionTypeSymbol(IEnumerable<ITypeSymbol> types, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations)
+    public UnionTypeSymbol(
+        IEnumerable<ITypeSymbol> types,
+        ISymbol containingSymbol,
+        INamedTypeSymbol? containingType,
+        INamespaceSymbol? containingNamespace,
+        Location[] locations,
+        ITypeSymbol? declaredUnderlyingType = null)
         : base(SymbolKind.Type, string.Empty, containingSymbol, containingType, containingNamespace, locations, [])
     {
         _types = types is ImmutableArray<ITypeSymbol> array ? array : ImmutableArray.CreateRange(types);
 
-        BaseType = ComputeBaseType(_types);
+        DeclaredUnderlyingType = declaredUnderlyingType;
+
+        BaseType = declaredUnderlyingType as INamedTypeSymbol ?? ComputeBaseType(_types);
 
         TypeKind = TypeKind.Union;
     }
@@ -21,6 +29,8 @@ internal partial class UnionTypeSymbol : SourceSymbol, IUnionTypeSymbol
     public override string Name => string.Join(" | ", Types.Select(x => x.ToDisplayStringKeywordAware(SymbolDisplayFormat.FullyQualifiedFormat)));
 
     public IEnumerable<ITypeSymbol> Types => _types;
+
+    public ITypeSymbol? DeclaredUnderlyingType { get; }
 
     public SpecialType SpecialType => SpecialType.None;
 

--- a/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/ISymbol.cs
@@ -478,6 +478,14 @@ public interface ITupleTypeSymbol : INamedTypeSymbol
 public interface IUnionTypeSymbol : ITypeSymbol
 {
     IEnumerable<ITypeSymbol> Types { get; }
+
+    /// <summary>
+    /// Gets the CLR type that originally declared the union, if any.
+    /// This is used when reading metadata from external assemblies so that
+    /// the runtime representation can remain compatible with the original
+    /// signature (e.g. object vs ValueType).
+    /// </summary>
+    ITypeSymbol? DeclaredUnderlyingType { get; }
 }
 
 public interface ITypeParameterSymbol : ITypeSymbol


### PR DESCRIPTION
## Summary
- extend `IUnionTypeSymbol` to expose the CLR type that originally declared a union
- capture declared runtime types when resolving metadata unions so the code generator matches external signatures
- prefer the declared type during union emission and alias forwarding to keep external metadata compatible

## Testing
- dotnet build -v minimal
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: Assignment_NullLiteral_To_NullableReference_PreservesConvertedType still expects a bound assignment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6bdc2989c832fae419fbf75eaef5c