### PR TITLE
Avoid duplicate local declarations in emitted IL

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -591,6 +591,17 @@ internal class MethodBodyGenerator
             if (localSymbol.Type is null)
                 continue;
 
+            // Locals are declared once at the method scope. When the block is emitted
+            // we may revisit the same locals to populate nested scopes with the
+            // existing builders. Ensure we reuse the builder instead of declaring a
+            // duplicate slot.
+            var existingBuilder = targetScope.GetLocal(localSymbol);
+            if (existingBuilder is not null)
+            {
+                targetScope.AddLocal(localSymbol, existingBuilder);
+                continue;
+            }
+
             var clrType = ResolveClrType(localSymbol.Type);
             var builder = ILGenerator.DeclareLocal(clrType);
             builder.SetLocalSymInfo(localSymbol.Name);


### PR DESCRIPTION
## Summary
- reuse existing local builders when re-registering locals for nested scopes
- prevent the IL emitter from declaring multiple slots for the same Raven local

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing MethodReference tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ccb56de4832f971c22131f9fd40a