### PR TITLE
Ensure lambda inference prefers BCL Func delegates

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -593,10 +593,15 @@ public partial class Compilation
             allTypes.Add(returnType);
 
         string delegateName = isAction ? "Action" : "Func";
-
-        var delegateType = systemNamespace?.GetMembers(delegateName)
+        INamedTypeSymbol? delegateType = systemNamespace?.GetMembers(delegateName)
             .OfType<INamedTypeSymbol>()
             .FirstOrDefault(t => t.Arity == allTypes.Count);
+
+        if (delegateType is null)
+        {
+            var metadataName = $"System.{delegateName}`{allTypes.Count}";
+            delegateType = GetTypeByMetadataName(metadataName);
+        }
 
         if (delegateType is not null)
             return delegateType.Construct(allTypes.ToArray());


### PR DESCRIPTION
## Summary
- fall back to GetTypeByMetadataName when resolving System.Func/System.Action in CreateFunctionTypeSymbol so we always choose the BCL delegate when available
- add semantic tests covering local and global lambda declarations to assert their inferred delegate type is System.Func<int,int>

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests --filter "Lambda_LocalDeclaration_InfersFuncDelegate|Lambda_GlobalDeclaration_UsesFuncDelegate"

------
https://chatgpt.com/codex/tasks/task_e_68e7dfc4b668832f9cbc7b45b14c801a