### PR TITLE
Support expression-bodied local functions

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -712,7 +712,11 @@ internal class CodeGenerator
                 if (semanticModel.GetDeclaredSymbol(functionStatement) is not SourceMethodSymbol functionSymbol)
                     continue;
 
-                TryRewriteAsyncMethod(semanticModel, functionSymbol, functionStatement.Body, expressionBody: null);
+                TryRewriteAsyncMethod(
+                    semanticModel,
+                    functionSymbol,
+                    functionStatement.Body,
+                    functionStatement.ExpressionBody);
             }
 
             foreach (var accessor in root.DescendantNodes().OfType<AccessorDeclarationSyntax>())

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -132,6 +132,8 @@ internal class MethodBodyGenerator
                 => semanticModel.GetBoundNode(c.ExpressionBody.Expression) as BoundExpression,
             AccessorDeclarationSyntax a when a.ExpressionBody is not null
                 => semanticModel.GetBoundNode(a.ExpressionBody.Expression) as BoundExpression,
+            FunctionStatementSyntax l when l.ExpressionBody is not null
+                => semanticModel.GetBoundNode(l.ExpressionBody.Expression) as BoundExpression,
             _ => null
         };
 
@@ -204,9 +206,17 @@ internal class MethodBodyGenerator
 
             case FunctionStatementSyntax functionStatement:
                 if (boundBody != null)
+                {
                     EmitMethodBlock(boundBody);
+                }
+                else if (expressionBody is not null)
+                {
+                    EmitExpressionBody(expressionBody);
+                }
                 else
+                {
                     ILGenerator.Emit(OpCodes.Ret);
+                }
                 break;
 
             case MethodDeclarationSyntax methodDeclaration:

--- a/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
+++ b/src/Raven.CodeAnalysis/Diagnostics/MissingReturnTypeAnnotationAnalyzer.cs
@@ -71,10 +71,10 @@ public sealed class MissingReturnTypeAnnotationAnalyzer : DiagnosticAnalyzer
         }
 
         foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
-            AnalyzeNode(method, method.Identifier, method.ReturnType, method.Body);
+            AnalyzeNode(method, method.Identifier, method.ReturnType, method.Body ?? (SyntaxNode?)method.ExpressionBody);
 
         foreach (var function in root.DescendantNodes().OfType<FunctionStatementSyntax>())
-            AnalyzeNode(function, function.Identifier, function.ReturnType, function.Body);
+            AnalyzeNode(function, function.Identifier, function.ReturnType, function.Body ?? (SyntaxNode?)function.ExpressionBody);
     }
 
     private static string FormatType(ITypeSymbol type)

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -416,11 +416,33 @@ internal class StatementSyntaxParser : SyntaxParser
 
         var returnParameterAnnotation = new TypeAnnotationClauseSyntaxParser(this).ParseReturnTypeAnnotation();
 
-        var block = ParseBlockStatementSyntax();
+        BlockStatementSyntax? block = null;
+        ArrowExpressionClauseSyntax? expressionBody = null;
+
+        if (IsNextToken(SyntaxKind.OpenBraceToken, out _))
+        {
+            block = ParseBlockStatementSyntax();
+        }
+        else if (IsNextToken(SyntaxKind.FatArrowToken, out _))
+        {
+            expressionBody = new ExpressionSyntaxParser(this).ParseArrowExpressionClause();
+        }
+        else
+        {
+            block = ParseBlockStatementSyntax();
+        }
 
         TryConsumeTerminator(out var terminatorToken);
 
-        return FunctionStatement(modifiers, funcKeyword, identifier, parameterList, returnParameterAnnotation, block, terminatorToken);
+        return FunctionStatement(
+            modifiers,
+            funcKeyword,
+            identifier,
+            parameterList,
+            returnParameterAnnotation,
+            block,
+            expressionBody,
+            terminatorToken);
     }
 
     private SyntaxList ParseFunctionModifiers()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -695,6 +695,7 @@
     <Slot Name="ParameterList" Type="ParameterList" />
     <Slot Name="ReturnType" Type="ArrowTypeClause" IsNullable="true" />
     <Slot Name="Body" Type="BlockStatement" IsNullable="true" />
+    <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" />
     <Slot Name="TerminatorToken" Type="Token" IsOptionalToken="true"/>
   </Node>
   <Node Name="ObjectCreationExpression" Inherits="Expression">

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/ExpressionBodyCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/ExpressionBodyCodeGenTests.cs
@@ -63,4 +63,58 @@ class Foo : IDisposable {
 
         Assert.Equal(new[] { "Init", "Dispose" }, output);
     }
+
+    [Fact]
+    public void FunctionExpressionBody_EmitsAndExecutes()
+    {
+        const string code = """
+import System.*
+
+func Foo(x: int) -> int => x + 1
+
+func main() {
+    Console.WriteLine(Foo(41))
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+
+        var compilation = Compilation.Create(
+                "function_expression_body",
+                new CompilationOptions(OutputKind.ConsoleApplication))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        peStream.Position = 0;
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var assembly = loaded.Assembly;
+        var entryPoint = assembly.EntryPoint;
+        Assert.NotNull(entryPoint);
+
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            var parameters = entryPoint!.GetParameters().Length == 0
+                ? Array.Empty<object?>()
+                : new object?[] { Array.Empty<string>() };
+            _ = entryPoint.Invoke(null, parameters);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        var output = writer.ToString()
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(new[] { "42" }, output);
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
@@ -366,6 +366,22 @@ public class ParserNewlineTests
     }
 
     [Fact]
+    public void Function_WithExpressionBody_ParsesArrowExpression()
+    {
+        var source = "func foo() -> int => 42";
+        var lexer = new Lexer(new StringReader(source));
+        var context = new BaseParseContext(lexer);
+        var parser = new StatementSyntaxParser(context);
+
+        var statement = (FunctionStatementSyntax)parser.ParseStatement().CreateRed();
+
+        Assert.Null(statement.Body);
+        var expressionBody = Assert.IsType<ArrowExpressionClauseSyntax>(statement.ExpressionBody);
+        Assert.Equal(SyntaxKind.FatArrowToken, expressionBody.ArrowToken.Kind);
+        Assert.Equal("42", expressionBody.Expression.ToString());
+    }
+
+    [Fact]
     public void VariableDeclaration_MissingIdentifier_ProducesMissingToken()
     {
         var source = "let = 1";


### PR DESCRIPTION
## Summary
- allow local functions to use expression bodies (`=>`) by extending the syntax model and parser
- bind and emit expression-bodied functions so async lowering and code generation work with them
- add parser and code generation tests that cover the new expression-body form for local functions

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: reference assemblies unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e81266ab78832f945791aa48bee72f