### PR TITLE
Document extension properties

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -44,13 +44,18 @@ FunctionDeclaration      ::= FunctionModifiers?
 
 ExtensionDeclaration     ::= 'extension' Identifier 'for' Type ExtensionBody ;
 ExtensionBody            ::= '{' {ExtensionMember} '}' ;
-ExtensionMember          ::= ExtensionMethodDeclaration ;
+ExtensionMember          ::= ExtensionMethodDeclaration
+                           | ExtensionPropertyDeclaration ;
 ExtensionMethodDeclaration
                            ::= ExtensionMethodModifiers?
                                Identifier '(' ParameterList? ')'
                                ReturnTypeClause?
                                ( Block | '=>' Expression ) ;
 ExtensionMethodModifiers ::= AccessModifier ;
+ExtensionPropertyDeclaration
+                           ::= ExtensionPropertyModifiers?
+                               Identifier ':' Type AccessorList ;
+ExtensionPropertyModifiers ::= AccessModifier ;
 
 ReturnTypeClause         ::= '->' Type ;
 


### PR DESCRIPTION
## Summary
- update the language specification to describe extension properties and their semantics
- extend the grammar to allow extension property declarations
- expand the .NET implementation notes to explain how extension property accessors are emitted

## Testing
- not run (documentation only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e8183daf9c832f802a83067172a591