### PR TITLE
Fix PE parameter default value retrieval for metadata load context

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/PE/PEParameterSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/PE/PEParameterSymbol.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 
 namespace Raven.CodeAnalysis.Symbols;
@@ -41,7 +42,24 @@ internal partial class PEParameterSymbol : PESymbol, IParameterSymbol
 
     public ParameterInfo GetParameterInfo() => _parameterInfo;
 
-    public bool HasExplicitDefaultValue => _parameterInfo.HasDefaultValue;
+    public bool HasExplicitDefaultValue
+    {
+        get
+        {
+            var rawDefaultValue = _parameterInfo.RawDefaultValue;
+            return rawDefaultValue != DBNull.Value && rawDefaultValue != System.Type.Missing;
+        }
+    }
 
-    public object? ExplicitDefaultValue => _parameterInfo.HasDefaultValue ? _parameterInfo.DefaultValue : null;
+    public object? ExplicitDefaultValue
+    {
+        get
+        {
+            var rawDefaultValue = _parameterInfo.RawDefaultValue;
+            if (rawDefaultValue == DBNull.Value || rawDefaultValue == System.Type.Missing)
+                return null;
+
+            return rawDefaultValue;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- avoid MetadataLoadContext exceptions when reading metadata parameter defaults by switching to RawDefaultValue
- interpret DBNull.Value and Type.Missing as absent defaults when exposing parameter information

## Testing
- dotnet build --property WarningLevel=0

------
https://chatgpt.com/codex/tasks/task_e_68ea851fdd88832f889db4e0b8a62345