### PR TITLE
Fix async Task<T> return conversions

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/AsyncMethodTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/AsyncMethodTests.cs
@@ -75,6 +75,41 @@ class C {
     }
 
     [Fact]
+    public void AsyncTaskOfIntMethod_WithReturnExpression_IsAccepted()
+    {
+        const string source = """
+import System.Threading.Tasks.*
+
+class C {
+    async f() -> Task[Int32] {
+        return 1;
+    }
+}
+""";
+        var (compilation, _) = CreateCompilation(source);
+        Assert.Empty(compilation.GetDiagnostics());
+    }
+
+    [Fact]
+    public void AsyncTaskOfIntMethod_WithIncompatibleReturnExpression_ReportsDiagnostic()
+    {
+        const string source = """
+import System.Threading.Tasks.*
+
+class C {
+    async f() -> Task[Int32] {
+        return "oops";
+    }
+}
+""";
+        var (compilation, _) = CreateCompilation(source);
+        var diagnostic = Assert.Single(compilation.GetDiagnostics());
+        Assert.Equal(CompilerDiagnostics.CannotConvertFromTypeToType, diagnostic.Descriptor);
+        Assert.Contains("String", diagnostic.GetMessage(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Int32", diagnostic.GetMessage(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TopLevelAwait_PromotesSynthesizedMainToAsyncTask()
     {
         const string source = """


### PR DESCRIPTION
## Summary
- ensure async return binding converts expressions to the Task result type before lowering
- add regression tests covering async Task<int> methods with valid and invalid return expressions

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails due to pre-existing AccessibilityTests failure)*

------
https://chatgpt.com/codex/tasks/task_e_68eacbd2a8dc832fb6b44c62d0491e6b