### PR TITLE
Update try-match-async sample for await in try expressions

### DIFF
--- a/src/Raven.Compiler/samples/try-match-async.rav
+++ b/src/Raven.Compiler/samples/try-match-async.rav
@@ -1,10 +1,10 @@
-import System.*
+import System.Console.*
 import System.IO.*
+import System.Threading.Tasks.*
 
-let result = try await File.ReadAllLinesAsync("samples/tuples.rav") match {
-        //string[] no => "Test"
-        Exception ex => "Format invalid: ${ex.Message}"
-        _ => "unknown"
-    }
+let message = try await File.ReadAllLinesAsync("samples/tuples.rav") match {
+    string[] lines => "Read ${lines.Length} lines"
+    Exception ex => "Format invalid: ${ex.Message}"
+}
 
-Console.WriteLine(result)
+WriteLine(message)


### PR DESCRIPTION
## Summary
- update the try-match-async sample to demonstrate awaiting inside a try expression
- add explicit console and threading imports and print the formatted result

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: existing ParserNewlineTests assertions and terminal logger exception)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf4259584832fa83a51bc519d221d