### PR TITLE
Fix method substitution comparer for constructed methods

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -25,7 +25,7 @@ internal sealed class ConstructedMethodSymbol : IMethodSymbol
         if (typeParameters.Length != typeArguments.Length)
             throw new ArgumentException($"Method '{definition.Name}' expects {typeParameters.Length} type arguments, but got {typeArguments.Length}.", nameof(typeArguments));
 
-        _substitutionMap = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(typeParameters.Length);
+        _substitutionMap = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(typeParameters.Length, SymbolEqualityComparer.Default);
         for (int i = 0; i < typeParameters.Length; i++)
             _substitutionMap[typeParameters[i]] = typeArguments[i];
     }


### PR DESCRIPTION
## Summary
- use `SymbolEqualityComparer.Default` when building substitution maps in constructed method symbols so metadata type parameters are substituted correctly
- allow awaitable try expressions such as `try await Task.FromResult(1)` to bind to the concrete result type instead of `Task.TResult`

## Testing
- `dotnet build` *(fails: test/Raven.CodeAnalysis.Tests/Semantics/ExceptionHandlingTests.cs(173,49): error CS8602: Dereference of a possibly null reference.)*

------
https://chatgpt.com/codex/tasks/task_e_68ed24a9f988832f80cff73321cc68d0