### PR TITLE
Validate default parameter usage

### DIFF
--- a/docs/lang/spec/classes-and-members.md
+++ b/docs/lang/spec/classes-and-members.md
@@ -276,6 +276,18 @@ Print(42)
 Print("hi")
 ```
 
+### Default parameter values
+
+Methods, constructors, and other function-like members may specify default
+values for trailing parameters using `= expression`. Optional parameters follow
+the same rules as top-level functions: once a parameter provides a default, all
+subsequent parameters in the list must also supply defaults. The expression is
+restricted to compile-time constants—literals (including `null`), parenthesized
+literals, or unary `+`/`-` applied to numeric literals—and the resulting value
+must convert to the parameter type using an implicit conversion. When the
+expression fails these checks, the compiler reports an error and treats the
+parameter as required.
+
 ### Invocation operator
 
 Declaring a method named `self` makes instances of the type invocable with the

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -158,6 +158,18 @@
     Title="Explicit interface specifier must name an interface"
     Message="Explicit interface specifier must name an interface type" Category="compiler"
     Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV0317" Identifier="OptionalParameterMustBeTrailing"
+    Title="Optional parameters must be trailing"
+    Message="Optional parameter '{parameterName}' must be the last parameter in the list" Category="compiler"
+    Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV0318" Identifier="ParameterDefaultValueMustBeConstant"
+    Title="Default value must be a compile-time constant"
+    Message="Default value for parameter '{parameterName}' must be a compile-time constant" Category="compiler"
+    Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV0319" Identifier="ParameterDefaultValueCannotConvert"
+    Title="Default value cannot convert to parameter type"
+    Message="Default value for parameter '{parameterName}' cannot be converted to '{parameterType}'" Category="compiler"
+    Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0314" Identifier="ContainingTypeDoesNotImplementInterface"
     Title="Type does not implement interface"
     Message="Type '{typeName}' does not implement interface '{interfaceName}'" Category="compiler"

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -1336,6 +1336,7 @@ public partial class SemanticModel
 
         var parameters = new List<SourceParameterSymbol>();
 
+        var seenOptionalParameter = false;
         foreach (var parameterSyntax in classDecl.ParameterList!.Parameters)
         {
             var refKind = RefKind.None;
@@ -1354,7 +1355,12 @@ public partial class SemanticModel
                     ? classBinder.ResolveType(typeSyntax, refKindForType)
                     : classBinder.ResolveType(typeSyntax);
 
-            var hasDefaultValue = TypeMemberBinder.TryEvaluateParameterDefaultValue(parameterSyntax, parameterType, out var defaultValue);
+            var defaultResult = TypeMemberBinder.ProcessParameterDefault(
+                parameterSyntax,
+                parameterType,
+                parameterSyntax.Identifier.ValueText,
+                classBinder.Diagnostics,
+                ref seenOptionalParameter);
             var parameterSymbol = new SourceParameterSymbol(
                 parameterSyntax.Identifier.ValueText,
                 parameterType,
@@ -1364,8 +1370,8 @@ public partial class SemanticModel
                 [parameterSyntax.GetLocation()],
                 [parameterSyntax.GetReference()],
                 refKind,
-                hasDefaultValue,
-                defaultValue);
+                defaultResult.HasExplicitDefaultValue,
+                defaultResult.ExplicitDefaultValue);
 
             parameters.Add(parameterSymbol);
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/DefaultParameterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/DefaultParameterTests.cs
@@ -1,0 +1,61 @@
+using Raven.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class DefaultParameterTests : DiagnosticTestBase
+{
+    [Fact]
+    public void RequiredParameterAfterOptional_ReportsDiagnostic()
+    {
+        const string code = """
+class C {
+    public M(x: int = 1, y: int) {}
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV0317").WithSpan(2, 26, 2, 27).WithArguments("y")
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void DefaultValueMustBeConstant_ReportsDiagnostic()
+    {
+        const string code = """
+class C {
+    public M(x: int = 1 + 2) {}
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV0318").WithSpan(2, 23, 2, 28).WithArguments("x")
+            ]);
+
+        verifier.Verify();
+    }
+
+    [Fact]
+    public void DefaultValueMustConvertToParameterType_ReportsDiagnostic()
+    {
+        const string code = """
+class C {
+    public M(x: int = 3.14) {}
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            expectedDiagnostics: [
+                new DiagnosticResult("RAV0319").WithSpan(2, 23, 2, 27).WithArguments("x", "int")
+            ]);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- enforce default-value analysis when binding parameters so optional arguments must trail and use constant expressions
- add diagnostics for invalid default values, wire them through semantic model, and document the rules for members
- cover the new diagnostics with targeted unit tests

## Testing
- dotnet build -nologo
- dotnet test test/Raven.CodeAnalysis.Tests -nologo --filter DefaultParameterTests


------
https://chatgpt.com/codex/tasks/task_e_68ed46690160832fb78890d4354cb613