### PR TITLE
Handle static metadata generic method constraint substitution

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -1236,7 +1236,12 @@ internal abstract class Binder
 
             if ((constraintKind & TypeParameterConstraintKind.TypeConstraint) != 0)
             {
-                foreach (var constraintType in typeParameter.ConstraintTypes)
+                var constraintTypes = method is SubstitutedMethodSymbol substituted &&
+                    substituted.TryGetSubstitutedConstraintTypes(typeParameter, out var substitutedConstraints)
+                        ? substitutedConstraints
+                        : typeParameter.ConstraintTypes;
+
+                foreach (var constraintType in constraintTypes)
                 {
                     if (constraintType is IErrorTypeSymbol)
                         continue;

--- a/test/MetadataFixtures/ExtensionMethodsFixture/GenericContainer.cs
+++ b/test/MetadataFixtures/ExtensionMethodsFixture/GenericContainer.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Raven.MetadataFixtures.Generics;
+
+public class GenericContainer<TBase>
+{
+    public static TBase Coerce<TDerived>(TDerived value)
+        where TDerived : TBase
+    {
+        return value;
+    }
+}

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MetadataGenericMethodTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MetadataGenericMethodTests.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+using Raven.CodeAnalysis.Tests;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public sealed class MetadataGenericMethodTests : CompilationTestBase
+{
+    protected override MetadataReference[] GetMetadataReferences()
+        => TestMetadataReferences.DefaultWithExtensionMethods;
+
+    [Fact]
+    public void StaticGenericMethod_OnConstructedMetadataType_SubstitutesConstraint()
+    {
+        const string source = """
+            class Program
+            {
+                static coerce() -> System.Exception
+                {
+                    let value: System.ArgumentException = null;
+                    return Raven.MetadataFixtures.Generics.GenericContainer<System.Exception>.Coerce<System.ArgumentException>(value);
+                }
+            }
+            """;
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(System.Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var method = Assert.IsAssignableFrom<IMethodSymbol>(model.GetSymbolInfo(invocation).Symbol);
+
+        var exceptionType = compilation.GetTypeByMetadataName("System.Exception");
+        var argumentExceptionType = compilation.GetTypeByMetadataName("System.ArgumentException");
+
+        Assert.NotNull(exceptionType);
+        Assert.NotNull(argumentExceptionType);
+
+        Assert.Equal("Coerce", method.Name);
+        Assert.True(method.IsGenericMethod);
+        Assert.True(SymbolEqualityComparer.Default.Equals(method.ReturnType, exceptionType));
+        Assert.Single(method.TypeArguments);
+        Assert.True(SymbolEqualityComparer.Default.Equals(method.TypeArguments[0], argumentExceptionType));
+    }
+
+    [Fact]
+    public void StaticGenericMethod_OnConstructedMetadataType_InvalidConstraint_ReportsDiagnostic()
+    {
+        const string source = """
+            class Program
+            {
+                static invalid() -> unit
+                {
+                    let value: System.ArgumentException = null;
+                    Raven.MetadataFixtures.Generics.GenericContainer<System.ValueType>.Coerce<System.ArgumentException>(value);
+                }
+            }
+            """;
+
+        var (compilation, _) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "RAV0320");
+    }
+}


### PR DESCRIPTION
## Summary
- substitute constraint types for metadata methods coming from constructed generic types so static methods honor the instantiated container
- teach binder constraint validation to use the substituted constraints
- add a metadata fixture container and semantic tests covering successful and failing static generic invocations

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests *(fails: MemberBinding_StaticField_FromReferenceAssembly_ResolvesRuntimeField currently fails on main)*

------
https://chatgpt.com/codex/tasks/task_e_68ef8a1ce184832f8a72ed783de74916