### PR TITLE
Handle metadata assembly fallbacks in TypeResolver

### DIFF
--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -966,6 +966,34 @@ public partial class Compilation
         return assemblySymbol;
     }
 
+    internal bool TryGetPEAssemblySymbol(Assembly assembly, out PEAssemblySymbol? symbol)
+    {
+        symbol = null;
+
+        if (assembly is null)
+            return false;
+
+        if (_assemblySymbols.TryGetValue(assembly, out var existing) && existing is PEAssemblySymbol peAssembly)
+        {
+            symbol = peAssembly;
+            return true;
+        }
+
+        try
+        {
+            if (GetAssembly(assembly) is PEAssemblySymbol resolved)
+            {
+                symbol = resolved;
+                return true;
+            }
+        }
+        catch
+        {
+        }
+
+        return false;
+    }
+
     private Assembly? RegisterRuntimeAssembly(Assembly metadataAssembly, string? explicitPath = null)
     {
         if (metadataAssembly is null)


### PR DESCRIPTION
## Summary
- expose Compilation.TryGetPEAssemblySymbol so metadata assemblies discovered at runtime can be reused
- update TypeResolver to resolve metadata types even when their assembly name is absent from the referenced symbol list

## Testing
- dotnet build
- dotnet test test/Raven.CodeAnalysis.Tests --logger "console;verbosity=minimal" *(fails: Invocation_WithLambdaArgument_ResolvesPredicateOverload expects 2 candidates but 9 reported; pre-existing failure)*
- dotnet run --project src/Raven.Compiler -- samples/async-await.rav -o test.dll -d pretty

------
https://chatgpt.com/codex/tasks/task_e_68f53abc5a24832f8510273eade62c80