### PR TITLE
Fix async state machine self reference

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -919,7 +919,7 @@ internal class ExpressionGenerator : Generator
                         if (MethodSymbol.IsStatic)
                             throw new NotSupportedException($"Cannot take address of instance field '{field.Name}' in a static context.");
 
-                        ILGenerator.Emit(OpCodes.Ldarga, 0);
+                        ILGenerator.Emit(OpCodes.Ldarg_0);
                     }
                     else if (!TryEmitValueTypeReceiverAddress(addressOf.Receiver, addressOf.Receiver.Type, field.ContainingType))
                     {
@@ -934,10 +934,7 @@ internal class ExpressionGenerator : Generator
                     if (MethodSymbol.IsStatic)
                         throw new NotSupportedException($"Cannot take address of instance field '{field.Name}' in a static context.");
 
-                    if (MethodSymbol.ContainingType?.IsValueType == true)
-                        ILGenerator.Emit(OpCodes.Ldarga, 0);
-                    else
-                        ILGenerator.Emit(OpCodes.Ldarg_0);
+                    ILGenerator.Emit(OpCodes.Ldarg_0);
                 }
 
                 ILGenerator.Emit(OpCodes.Ldflda, GetField(field));
@@ -947,10 +944,7 @@ internal class ExpressionGenerator : Generator
                 if (MethodSymbol.IsStatic)
                     throw new NotSupportedException("Cannot take the address of 'self' in a static context.");
 
-                if (MethodSymbol.ContainingType?.IsValueType == true)
-                    ILGenerator.Emit(OpCodes.Ldarga, 0);
-                else
-                    ILGenerator.Emit(OpCodes.Ldarg_0);
+                ILGenerator.Emit(OpCodes.Ldarg_0);
                 break;
 
             case null when addressOf.Storage is BoundArrayAccessExpression arrayAccess:
@@ -2541,21 +2535,14 @@ internal class ExpressionGenerator : Generator
                 if (MethodSymbol.IsStatic)
                     return false;
 
-                if (requiresAddress)
-                    ILGenerator.Emit(OpCodes.Ldarga, 0);
-                else
-                    ILGenerator.Emit(OpCodes.Ldarg_0);
-
+                ILGenerator.Emit(OpCodes.Ldarg_0);
                 return true;
 
             case BoundSelfExpression selfExpression:
                 if (MethodSymbol.IsStatic)
                     return false;
 
-                if (requiresAddress)
-                    ILGenerator.Emit(OpCodes.Ldarga, 0);
-                else
-                    ILGenerator.Emit(OpCodes.Ldarg_0);
+                ILGenerator.Emit(OpCodes.Ldarg_0);
                 return true;
 
             case BoundAddressOfExpression addressOf:


### PR DESCRIPTION
## Summary
- ensure async state machine codegen loads the `this` pointer with `ldarg.0` instead of `ldarga` when passing the state machine to builder APIs
- update value-type receiver handling so calls like `AwaitUnsafeOnCompleted` receive a correct managed pointer

## Testing
- `dotnet run -- samples/async-await.rav -o test.dll -d pretty && dotnet test.dll`
- `dotnet build`
- `dotnet test test/Raven.CodeAnalysis.Tests` *(fails: missing existing import diagnostics)*

------
https://chatgpt.com/codex/tasks/task_e_68f54e9003c8832f8c5730e9440fdccb