### PR TITLE
Fix tuple runtime type resolution

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -454,7 +454,11 @@ internal sealed class ConstructedMethodSymbol : IMethodSymbol
 
         if (symbol is ITupleTypeSymbol tuple)
         {
-            return GetProjectedRuntimeType(tuple.UnderlyingTupleType, codeGen, treatUnitAsVoid, isTopLevel: false);
+            var elementClrTypes = tuple.TupleElements
+                .Select(element => GetProjectedRuntimeType(element.Type, codeGen, treatUnitAsVoid, isTopLevel: false))
+                .ToArray();
+
+            return TypeSymbolExtensionsForCodeGen.GetValueTupleClrType(elementClrTypes, codeGen.Compilation);
         }
 
         if (symbol is INamedTypeSymbol named && named.IsGenericType && !named.IsUnboundGenericType)


### PR DESCRIPTION
## Summary
- construct runtime ValueTuple types directly when lowering tuple expressions
- update constructed method projection to reuse the tuple runtime construction helper
- compare runtime and symbol tuple signatures structurally to handle generic ValueTuple methods

## Testing
- dotnet run --project src/Raven.Compiler -- /tmp/test_tuple.rav -o /tmp/test_tuple.dll -d pretty -bt
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests -property:WarningLevel=0 *(fails: existing NullReferenceException in Binder/BlockBinder.cs)*

------
https://chatgpt.com/codex/tasks/task_e_68f5f71b892c832f8703af86e0ca5ace