### PR TITLE
Fix caching for constructed member builders

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -65,10 +65,13 @@ internal class CodeGenerator
 
     internal bool TryGetMemberBuilder(SourceSymbol symbol, ImmutableArray<ITypeSymbol> substitution, out MemberInfo memberInfo)
     {
-        if (!substitution.IsDefaultOrEmpty &&
-            _constructedMappings.TryGetValue(new MemberBuilderCacheKey(symbol, substitution), out memberInfo!))
+        if (!substitution.IsDefaultOrEmpty)
         {
-            return true;
+            if (_constructedMappings.TryGetValue(new MemberBuilderCacheKey(symbol, substitution), out memberInfo!))
+                return true;
+
+            memberInfo = null!;
+            return false;
         }
 
         return _mappings.TryGetValue(symbol, out memberInfo!);


### PR DESCRIPTION
## Summary
- prevent CodeGenerator from returning definition builders when a constructed member cache lookup misses
- ensure IL emission resolves and caches constructed methods/constructors for generic instantiations
- unblock samples such as generics2.rav and extensions.rav from producing invalid assemblies

## Testing
- dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/generics2.rav
- dotnet run --project src/Raven.Compiler -- src/Raven.Compiler/samples/extensions.rav
- dotnet test test/Raven.CodeAnalysis.Tests --property:WarningLevel=0 *(fails: ParserNewlineTests assertions; pre-existing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125acdd468832fa47e6247b55ab67f)