### PR TITLE
Ensure async lowering maps builder members to method generics

### DIFF
--- a/docs/investigations/async-await.md
+++ b/docs/investigations/async-await.md
@@ -1,6 +1,6 @@
 # Async/await action plan – test8 reboot
 
-> Living action plan owner: **Compiler team** · Last updated: _2025-11-11_
+> Living action plan owner: **Compiler team** · Last updated: _2025-11-16_
 
 ## Objective
 
@@ -26,6 +26,7 @@ WriteLine(x)
 
 | Date | Status | Notes |
 | --- | --- | --- |
+| 2025-11-16 | 🟡 At risk | Constructed async state-machine members now expose builder lookups remapped to the async method's generics, and a new lowering regression proves the `Create` site instantiates `AsyncTaskMethodBuilder<!!T>` for the method body; runtime validation is still pending.【F:src/Raven.CodeAnalysis/Symbols/Synthesized/SynthesizedAsyncStateMachineTypeSymbol.cs†L132-L153】【F:test/Raven.CodeAnalysis.Tests/Semantics/AsyncLowererTests.cs†L1001-L1055】 |
 | 2025-11-15 | 🟡 At risk | Substituting the awaited `Task<T>` result before instantiating the builder now hands `AsyncTaskMethodBuilder<!0>` the struct parameter instead of the method generic; still need CLI/`ilverify` confirmation that the runtime loads the image.【F:src/Raven.CodeAnalysis/Symbols/Synthesized/SynthesizedAsyncStateMachineTypeSymbol.cs†L521-L563】 |
 | 2025-11-14 | 🟡 At risk | Substituting the builder type before field synthesis keeps `AsyncTaskMethodBuilder<!0>` anchored to the struct parameter so `SetException`/`SetResult` no longer encode `!!0`; need a fresh CLI+`ilverify` pass to confirm the runtime accepts the image.【F:src/Raven.CodeAnalysis/Symbols/Synthesized/SynthesizedAsyncStateMachineTypeSymbol.cs†L261-L286】 |
 | 2025-11-13 | 🟡 At risk | Exposed explicit async↔state-machine type-parameter mappings and taught the emitter to reuse them; new semantic coverage guards the round-trip ahead of runtime validation.【F:src/Raven.CodeAnalysis/Symbols/Synthesized/SynthesizedAsyncStateMachineTypeSymbol.cs†L79-L118】【F:src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs†L108-L140】【F:test/Raven.CodeAnalysis.Tests/Semantics/AsyncLowererTests.cs†L110-L165】 |
@@ -44,6 +45,10 @@ WriteLine(x)
   `Task<T>`, the awaited `T` is substituted with the state machine's `!0` before
   we instantiate `AsyncTaskMethodBuilder<T>`, preventing Reflection.Emit from caching
   the method-generic handle that previously surfaced as `AsyncTaskMethodBuilder<!!0>`.【F:src/Raven.CodeAnalysis/Symbols/Synthesized/SynthesizedAsyncStateMachineTypeSymbol.cs†L521-L563】
+* **Method body builder lookups reuse async generics.** `GetConstructedMembers` now
+  returns a method-context view of the builder helpers so lowering wires up
+  `AsyncTaskMethodBuilder<!!T>` for the local state-machine initialization; the
+  new regression covers the substitution even though CLI execution still fails.【F:src/Raven.CodeAnalysis/Symbols/Synthesized/SynthesizedAsyncStateMachineTypeSymbol.cs†L132-L153】【F:test/Raven.CodeAnalysis.Tests/Semantics/AsyncLowererTests.cs†L1001-L1055】
 * **Builder field construction pinned to struct generics.** The builder type is now
   substituted before `_builder` is synthesized, so every subsequent lookup observes
   `AsyncTaskMethodBuilder<!0>` and the `SetException`/`SetResult` MethodSpecs shed their

--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/AsyncLowerer.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/AsyncLowerer.cs
@@ -124,7 +124,7 @@ internal static class AsyncLowerer
         var constructor = constructed.Constructor;
         var moveNextMethod = constructed.MoveNext;
         var stateField = constructed.StateField;
-        var builderMembers = constructed.BuilderMembers;
+        var builderMembers = constructed.AsyncMethodBuilderMembers;
         var builderField = builderMembers.BuilderField;
         var thisField = constructed.ThisField;
         var parameterFieldMap = constructed.ParameterFields;

--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -268,7 +268,8 @@ internal class MethodGenerator
             var builderCtor = attributeType.GetConstructor(new[] { systemType });
             if (builderCtor is not null)
             {
-                var builderTypeName = GetAssemblyQualifiedMetadataName(stateMachine.BuilderField.Type);
+                var builderTypeSymbol = stateMachine.SubstituteStateMachineTypeParameters(stateMachine.BuilderField.Type);
+                var builderTypeName = GetAssemblyQualifiedMetadataName(builderTypeSymbol);
                 ApplyMethodCustomAttribute(builderCtor, builderTypeName);
             }
         }


### PR DESCRIPTION
## Summary
- expose method-context builder members on the synthesized async state machine and remap attribute emission to the async method generics
- teach the async lowerer to use the remapped builder helpers and add a regression test for the generic `Create` call
- document the new substitution step in the async-await investigation log

## Testing
- `dotnet build --property WarningLevel=0`
- `MSBUILDTERMINALLOGGER=false dotnet test test/Raven.CodeAnalysis.Tests --no-build --filter "FullyQualifiedName=Raven.CodeAnalysis.Semantics.Tests.AsyncLowererTests.Rewrite_AsyncGenericMethod_UsesAsyncMethodTypeParametersForBuilder" -property:WarningLevel=0`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130da3fe00832f891c636ed73af7e2)