### PR TITLE
Fix MoveToImmutable crash when filtering hoisted locals

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/AsyncLowerer.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/AsyncLowerer.cs
@@ -1595,15 +1595,24 @@ internal static class AsyncLowerer
             if (_hoistableLocals.Count == 0 || locals.IsDefaultOrEmpty)
                 return locals;
 
-            var builder = ImmutableArray.CreateBuilder<ILocalSymbol>();
+            var builder = ImmutableArray.CreateBuilder<ILocalSymbol>(locals.Length);
+            var removedHoistedLocal = false;
 
             foreach (var local in locals)
             {
-                if (!_hoistableLocals.ContainsKey(local))
-                    builder.Add(local);
+                if (_hoistableLocals.ContainsKey(local))
+                {
+                    removedHoistedLocal = true;
+                    continue;
+                }
+
+                builder.Add(local);
             }
 
-            return builder.MoveToImmutable();
+            if (!removedHoistedLocal)
+                return locals;
+
+            return builder.ToImmutable();
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid using MoveToImmutable when filtering locals in the async lowerer
- track whether any hoisted locals were removed and fall back to the original local list when possible

## Testing
- dotnet run --project src/Raven.Compiler -- samples/http-client.rav -o test.dll -d pretty


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a2cfc05c832fa174438506080a93)