### PR TITLE
Document async await try/catch investigation

### DIFF
--- a/docs/investigations/async-await.md
+++ b/docs/investigations/async-await.md
@@ -1,25 +1,17 @@
-# Async/await test8 investigation
+# Async/await feature investigation
 
 ## Objective
-Emit the async sample below through `ravc`, load the resulting `test.dll`, and match the IL that Roslyn produces for the equivalent C# code—particularly the constructed async state machine and its builder calls.
+Track the overall completeness of Raven's async/await implementation. The original work validated the `test8.rav` generic sample end-to-end; the investigation now stays open to capture regressions, gaps in test coverage, and the work required to reach feature parity with Roslyn. The immediate focus is understanding why awaits inside guarded regions fail to run and ensuring the existing pattern-matching sample behaves correctly when the awaited operation throws.
 
-```swift
-import System.Console.*
-import System.Threading.Tasks.*
+**Immediate targets**
 
-async func Test<T>(value: T) -> Task<T> {
-    await Task.Delay(10)
-    return value
-}
-
-let x = await Test(42)
-
-WriteLine(x)
-```
+1. Instrument `samples/async-try-catch.rav` so the resulting `async-try-catch.dll` pinpoints why the awaited block never reaches its handler even though the process exits cleanly (exit code `0`).【F:src/Raven.Compiler/samples/async-try-catch.rav†L1-L16】
+2. Apply the same diagnostics to `samples/http-client.rav` (`http-client.dll`) because it reproduces the identical failure pattern when awaiting inside a `try/catch`.【F:src/Raven.Compiler/samples/http-client.rav†L1-L33】
+3. Stress `samples/try-match-async.rav` by forcing the awaited target to throw so we understand how the `try ... match` construct behaves when the awaited Task faults, not just when it produces a value.【F:src/Raven.Compiler/samples/try-match-async.rav†L1-L9】
 
 ## Current findings
 * The constructed async state machine now reuses its own generic parameter when emitting builder completions. `ConstructedNamedTypeSymbol.ResolveRuntimeTypeArgument` first reuses any registered runtime type for the state-machine parameter before falling back to the async-method mapping, so the builder MemberRefs resolve to `AsyncTaskMethodBuilder<!T>` instead of leaking the async method’s `!!0`.【F:src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs†L268-L304】
-* The emitted IL for `Program/'<>c__AsyncStateMachine0`1'::MoveNext` now calls `AsyncTaskMethodBuilder<!T>.SetResult(!0)`, matching Roslyn’s baseline and eliminating the verifier mismatch that produced `AsyncTaskMethodBuilder<!!0>` earlier in the investigation.【F:docs/investigations/async-await.md†L30-L35】
+* The emitted IL for `Program/'<>c__AsyncStateMachine0`1'::MoveNext` now calls `AsyncTaskMethodBuilder<!T>.SetResult(!0)`, matching Roslyn’s baseline and eliminating the verifier mismatch that produced `AsyncTaskMethodBuilder<!!0>` earlier in the investigation.【F:docs/investigations/async-await.md†L33-L38】
 * The compiled `test8.rav` sample still executes successfully and prints `42`, confirming the earlier `BadImageFormatException` fix continues to hold end-to-end.【88982c†L1-L2】
 * Re-running `samples/async-await.rav` through the CLI emits `/tmp/async-await.dll` and the binary prints the expected `first:1`, `sum:6`, and `done` messages, so the `Task.FromResult` inference regression no longer reproduces.【413905†L1-L17】【27dee1†L1-L4】
 * Await expressions that live inside a `try` block currently generate invalid IL: both `samples/async-try-catch.rav` and `samples/http-client.rav` abort with `InvalidProgramException` before reaching their handlers, so `await` inside a guarded region is temporarily regressed until the async state machine wires its dispatch blocks without re-entering the method prologue.【4907a6†L1-L6】【52225f†L1-L6】
@@ -33,7 +25,7 @@ WriteLine(x)
 | `test6.rav` | ✅ runs | Continues to build/run after the await lowering updates.【d6680d†L1-L5】 |
 | `test7.rav` | ✅ runs | Exercises awaiting `Task.FromResult` in an async helper without issues.【7d6784†L1-L2】 |
 | `test8.rav` | ✅ runs | Emits the generic async state machine correctly and prints `42`.【88982c†L1-L2】 |
-| `try-match-async.rav` | ✅ runs | Still builds and executes its awaited pattern matching sample.【a00ac9†L1-L3】 |
+| `try-match-async.rav` | ⚠️ verify | Succeeds when the awaited operation completes successfully, but the sample still needs coverage for the faulted-await path described above.【F:src/Raven.Compiler/samples/try-match-async.rav†L1-L9】 |
 * Targeted regression tests covering await lowering, the builder `Start<TStateMachine>` MethodSpec, and the `SetResult` MemberRef all pass, guarding the substitution pipeline against regressions.【9329ec†L1-L11】【0f004d†L1-L6】【5e9a18†L1-L8】
 
 ### IL snapshot – builder completion uses the state-machine generic
@@ -50,6 +42,8 @@ IL_00c0: call instance void valuetype [System.Private.CoreLib]System.Runtime.Com
 * Add metadata regression coverage for `AsyncTaskMethodBuilder<T>.SetException` mirroring the `SetResult` test so the completion path remains pinned to the state-machine generic parameter.【F:test/Raven.CodeAnalysis.Tests/Semantics/AsyncLowererTests.cs†L1195-L1252】
 * Diff the MethodSpec table for `test8` against Roslyn to confirm awaiter helpers (`GetAwaiter`, `GetResult`, `get_IsCompleted`) also stay on the async-method generics now that the runtime substitution prefers the state-machine parameter.【F:src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs†L268-L304】
 * Re-run `async-await.rav` periodically to guard the `Task.FromResult` inference path, ensuring the await-heavy sample keeps compiling and running end-to-end.【413905†L1-L17】【27dee1†L1-L4】
+* Capture the invalid IL emitted for `async-try-catch.rav` and `http-client.rav` (e.g., via `ilverify` or `ilspycmd`) so the faulty state-machine blocks can be compared against Roslyn’s version and patched before enabling awaits inside guarded regions again.【F:src/Raven.Compiler/samples/async-try-catch.rav†L1-L16】【F:src/Raven.Compiler/samples/http-client.rav†L1-L33】
+* Extend `try-match-async.rav` with a deliberate faulting await (throwing inside the awaited Task) and assert the resulting pattern match routes to the `Exception` arm, proving the lowered state machine raises the exception before the pattern switch executes.【F:src/Raven.Compiler/samples/try-match-async.rav†L1-L9】
 * Keep `async-try-catch.rav` in the manual sample rotation so the async try/catch lowering (and `catch (Exception)` binding) stay covered whenever lowering changes land.【F:src/Raven.Compiler/samples/async-try-catch.rav†L1-L16】【39032d†L1-L17】【78df97†L1-L4】
 * Expand runtime coverage with additional generic async samples (e.g., nested awaits or multiple type parameters) to ensure the substitution logic scales beyond the `Test<T>` scenario.【9329ec†L1-L11】
 


### PR DESCRIPTION
## Summary
- reframe the async/await investigation doc around overall feature completeness instead of the single `test8` sample
- record the current focus on the `async-try-catch`, `http-client`, and `try-match-async` samples, update the sample status table, and capture new follow-up tasks for these scenarios

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919da5e0c08832fad48f196365acb11)