### PR TITLE
Add discriminated union syntax parsing

### DIFF
--- a/docs/lang/proposals/discriminated-unions.md
+++ b/docs/lang/proposals/discriminated-unions.md
@@ -1,6 +1,6 @@
 # Proposal: Discriminated unions
 
-> ⚠️ This proposal has **NOT** been implemented
+> ✅ The syntax described here is implemented in the parser. Emission and semantic analysis remain future work.
 
 Discriminated unions are value types that represent a fixed set of alternative shapes. Each alternative is modeled as a distinct nested struct type whose constructor is declared inline with the union definition. The compiler emits `TryGet*` helpers for each case and pattern matching is expressed in terms of these helpers, ensuring exhaustiveness.
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -2069,6 +2069,33 @@ import Grades.*
 let best = A
 ```
 
+### Discriminated unions
+
+A discriminated union declaration defines a value type composed of a fixed set
+of **cases**. Each case acts like an inline constructor with an optional payload
+described by a parameter list. Unions use the `union` keyword:
+
+```raven
+union Token {
+    Identifier(text: string)
+    Number(value: int)
+    Unknown
+}
+```
+
+Unions may declare type parameters (`union Result<T> { ... }`). Each case shares
+the union's type parameters, and can be referenced either via the type name or
+with the leading-dot shorthand:
+
+```raven
+let token = Token.Identifier("foo")
+let other: Token = .Unknown
+```
+
+Each case becomes a nested struct that can be constructed directly. Pattern
+matching exhaustively checks every case; see [Pattern matching](#pattern-matching)
+for examples of the leading-dot syntax inside `match` expressions.
+
 ## Object-oriented types
 
 For guidance on declaring classes, structs, members, and interfaces, see

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
@@ -125,6 +125,7 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
             order = MemberOrder.Members;
         }
         else if (nextToken.IsKind(SyntaxKind.EnumKeyword) ||
+                 nextToken.IsKind(SyntaxKind.UnionKeyword) ||
                  nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword) || nextToken.IsKind(SyntaxKind.InterfaceKeyword) || nextToken.IsKind(SyntaxKind.ExtensionKeyword) ||
                  nextToken.IsKind(SyntaxKind.PublicKeyword) || nextToken.IsKind(SyntaxKind.PrivateKeyword) ||
                  nextToken.IsKind(SyntaxKind.InternalKeyword) || nextToken.IsKind(SyntaxKind.ProtectedKeyword) ||
@@ -160,6 +161,17 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
                 var enumDeclaration = new EnumDeclarationParser(this).Parse();
 
                 memberDeclarations.Add(enumDeclaration);
+                order = MemberOrder.Members;
+                return;
+            }
+
+            if (typeKeywordKind == SyntaxKind.UnionKeyword)
+            {
+                checkpoint.Dispose();
+
+                var unionDeclaration = new UnionDeclarationParser(this).Parse();
+
+                memberDeclarations.Add(unionDeclaration);
                 order = MemberOrder.Members;
                 return;
             }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
@@ -133,6 +133,7 @@ internal class NamespaceDeclarationParser : SyntaxParser
             order = MemberOrder.Members;
         }
         else if (nextToken.IsKind(SyntaxKind.EnumKeyword) ||
+                 nextToken.IsKind(SyntaxKind.UnionKeyword) ||
                  nextToken.IsKind(SyntaxKind.StructKeyword) || nextToken.IsKind(SyntaxKind.ClassKeyword) || nextToken.IsKind(SyntaxKind.InterfaceKeyword) || nextToken.IsKind(SyntaxKind.ExtensionKeyword) ||
                  nextToken.IsKind(SyntaxKind.PublicKeyword) || nextToken.IsKind(SyntaxKind.PrivateKeyword) ||
                  nextToken.IsKind(SyntaxKind.InternalKeyword) || nextToken.IsKind(SyntaxKind.ProtectedKeyword) ||
@@ -167,6 +168,17 @@ internal class NamespaceDeclarationParser : SyntaxParser
                 var enumDeclaration = new EnumDeclarationParser(this).Parse();
 
                 memberDeclarations.Add(enumDeclaration);
+                order = MemberOrder.Members;
+                return;
+            }
+
+            if (typeKeywordKind == SyntaxKind.UnionKeyword)
+            {
+                checkpoint.Dispose();
+
+                var unionDeclaration = new UnionDeclarationParser(this).Parse();
+
+                memberDeclarations.Add(unionDeclaration);
                 order = MemberOrder.Members;
                 return;
             }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -273,6 +273,12 @@ internal class TypeDeclarationParser : SyntaxParser
                 memberDeclarationCheckpoint.Dispose();
                 return new EnumDeclarationParser(this).Parse();
             }
+
+            if (typeKeywordKind == SyntaxKind.UnionKeyword)
+            {
+                memberDeclarationCheckpoint.Dispose();
+                return new UnionDeclarationParser(this).Parse();
+            }
         }
 
         if (keywordOrIdentifier.IsKind(SyntaxKind.ClassKeyword) || keywordOrIdentifier.IsKind(SyntaxKind.InterfaceKeyword))
@@ -285,6 +291,12 @@ internal class TypeDeclarationParser : SyntaxParser
         {
             memberDeclarationCheckpoint.Dispose();
             return new EnumDeclarationParser(this).Parse();
+        }
+
+        if (keywordOrIdentifier.IsKind(SyntaxKind.UnionKeyword))
+        {
+            memberDeclarationCheckpoint.Dispose();
+            return new UnionDeclarationParser(this).Parse();
         }
 
         if (keywordOrIdentifier.IsKind(SyntaxKind.LetKeyword) || keywordOrIdentifier.IsKind(SyntaxKind.VarKeyword))

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/UnionDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/UnionDeclarationParser.cs
@@ -1,0 +1,158 @@
+namespace Raven.CodeAnalysis.Syntax.InternalSyntax.Parser;
+
+using System.Collections.Generic;
+
+using Raven.CodeAnalysis.Syntax.InternalSyntax;
+
+using static SyntaxFactory;
+
+internal class UnionDeclarationParser : SyntaxParser
+{
+    public UnionDeclarationParser(ParseContext context) : base(context)
+    {
+    }
+
+    internal UnionDeclarationSyntax Parse()
+    {
+        var attributeLists = AttributeDeclarationParser.ParseAttributeLists(this);
+        var modifiers = ParseModifiers();
+
+        var unionKeyword = ExpectToken(SyntaxKind.UnionKeyword);
+
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
+
+        TypeParameterListSyntax? typeParameterList = null;
+        if (PeekToken().IsKind(SyntaxKind.LessThanToken))
+        {
+            typeParameterList = new TypeDeclarationParser(this).ParseTypeParameterList();
+        }
+
+        ConsumeTokenOrMissing(SyntaxKind.OpenBraceToken, out var openBraceToken);
+
+        List<GreenNode> cases = new();
+
+        while (true)
+        {
+            var next = PeekToken();
+
+            if (next.IsKind(SyntaxKind.CloseBraceToken))
+            {
+                break;
+            }
+
+            var unionCase = ParseCase();
+            cases.Add(unionCase);
+        }
+
+        ConsumeTokenOrMissing(SyntaxKind.CloseBraceToken, out var closeBraceToken);
+
+        var terminatorToken = ConsumeOptionalTypeTerminator();
+
+        return UnionDeclaration(
+            attributeLists,
+            modifiers,
+            unionKeyword,
+            identifier,
+            typeParameterList,
+            openBraceToken,
+            List(cases),
+            closeBraceToken,
+            terminatorToken);
+    }
+
+    private UnionCaseClauseSyntax ParseCase()
+    {
+        SyntaxToken identifier;
+        if (CanTokenBeIdentifier(PeekToken()))
+        {
+            identifier = ReadIdentifierToken();
+        }
+        else
+        {
+            identifier = ExpectToken(SyntaxKind.IdentifierToken);
+        }
+
+        ParameterListSyntax? parameterList = null;
+        if (PeekToken().IsKind(SyntaxKind.OpenParenToken))
+        {
+            parameterList = new TypeDeclarationParser(this).ParseParameterList();
+        }
+
+        return UnionCaseClause(identifier, parameterList);
+    }
+
+    private SyntaxList ParseModifiers()
+    {
+        SyntaxList modifiers = SyntaxList.Empty;
+
+        while (true)
+        {
+            var kind = PeekToken().Kind;
+
+            if (kind is SyntaxKind.PublicKeyword or
+                    SyntaxKind.PrivateKeyword or
+                    SyntaxKind.InternalKeyword or
+                    SyntaxKind.ProtectedKeyword or
+                    SyntaxKind.StaticKeyword or
+                    SyntaxKind.AbstractKeyword or
+                    SyntaxKind.SealedKeyword or
+                    SyntaxKind.PartialKeyword or
+                    SyntaxKind.VirtualKeyword or
+                    SyntaxKind.AsyncKeyword or
+                    SyntaxKind.OpenKeyword or
+                    SyntaxKind.OverrideKeyword)
+            {
+                modifiers = modifiers.Add(ReadToken());
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return modifiers;
+    }
+
+    private SyntaxToken ConsumeOptionalTypeTerminator()
+    {
+        var previous = TreatNewlinesAsTokens;
+        SetTreatNewlinesAsTokens(true);
+
+        try
+        {
+            var current = PeekToken();
+
+            if (IsNewLineLike(current) || current.Kind == SyntaxKind.SemicolonToken)
+            {
+                return ReadToken();
+            }
+
+            if (current.Kind is SyntaxKind.EndOfFileToken or SyntaxKind.CloseBraceToken)
+            {
+                return Token(SyntaxKind.None);
+            }
+
+            return Token(SyntaxKind.None);
+        }
+        finally
+        {
+            SetTreatNewlinesAsTokens(previous);
+        }
+    }
+
+    private static bool IsNewLineLike(SyntaxToken token)
+    {
+        return token.Kind is SyntaxKind.NewLineToken or
+            SyntaxKind.LineFeedToken or
+            SyntaxKind.CarriageReturnToken or
+            SyntaxKind.CarriageReturnLineFeedToken;
+    }
+}

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -622,6 +622,21 @@
     <Slot Name="CloseBraceToken" Type="Token" IsInherited="true"  DefaultToken="CloseBraceToken"/>
     <Slot Name="TerminatorToken" Type="Token" IsInherited="true"  IsOptionalToken="true"/>
   </Node>
+  <Node Name="UnionDeclaration" Inherits="BaseTypeDeclaration">
+    <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
+    <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />
+    <Slot Name="UnionKeyword" Type="Token" DefaultToken="UnionKeyword"/>
+    <Slot Name="Identifier" Type="Token" IsInherited="true" />
+    <Slot Name="TypeParameterList" Type="TypeParameterList" IsNullable="true" />
+    <Slot Name="OpenBraceToken" Type="Token" IsInherited="true"  DefaultToken="OpenBraceToken"/>
+    <Slot Name="Cases" Type="List" ElementType="UnionCaseClause" />
+    <Slot Name="CloseBraceToken" Type="Token" IsInherited="true"  DefaultToken="CloseBraceToken"/>
+    <Slot Name="TerminatorToken" Type="Token" IsInherited="true"  IsOptionalToken="true"/>
+  </Node>
+  <Node Name="UnionCaseClause" Inherits="Node">
+    <Slot Name="Identifier" Type="Token" />
+    <Slot Name="ParameterList" Type="ParameterList" IsNullable="true" />
+  </Node>
   <Node Name="IndexerDeclaration" Inherits="BasePropertyDeclaration">
     <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />
     <Slot Name="Modifiers" Type="TokenList" IsInherited="true" />

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -18,6 +18,7 @@
   <TokenKind Name="ConstKeyword" Text="const" IsReservedWord="true" />
   <TokenKind Name="FuncKeyword" Text="func" IsReservedWord="true" />
   <TokenKind Name="EnumKeyword" Text="enum" IsReservedWord="true" />
+  <TokenKind Name="UnionKeyword" Text="union" IsReservedWord="true" />
   <TokenKind Name="StructKeyword" Text="struct" IsReservedWord="true" />
   <TokenKind Name="ClassKeyword" Text="class" IsReservedWord="true" />
   <TokenKind Name="InterfaceKeyword" Text="interface" IsReservedWord="true" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/UnionDeclarationParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/UnionDeclarationParserTests.cs
@@ -1,0 +1,46 @@
+using Raven.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class UnionDeclarationParserTests
+{
+    [Fact]
+    public void UnionDeclaration_WithCases_ParsesCaseList()
+    {
+        var source = "union Token { Identifier(text: string) Unknown }";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var declaration = Assert.IsType<UnionDeclarationSyntax>(Assert.Single(root.Members));
+
+        Assert.Equal("Token", declaration.Identifier.Text);
+        Assert.Collection(
+            declaration.Cases,
+            first =>
+            {
+                Assert.Equal("Identifier", first.Identifier.Text);
+                Assert.NotNull(first.ParameterList);
+            },
+            second =>
+            {
+                Assert.Equal("Unknown", second.Identifier.Text);
+                Assert.Null(second.ParameterList);
+            });
+    }
+
+    [Fact]
+    public void UnionDeclaration_WithTypeParameters_ParsesGenerics()
+    {
+        var source = "union Result<T> { Ok(value: T) }";
+        var tree = SyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var declaration = Assert.IsType<UnionDeclarationSyntax>(Assert.Single(root.Members));
+
+        Assert.NotNull(declaration.TypeParameterList);
+        var okCase = Assert.Single(declaration.Cases);
+        Assert.Equal("Ok", okCase.Identifier.Text);
+        Assert.NotNull(okCase.ParameterList);
+    }
+}


### PR DESCRIPTION
## Summary
- add the `union` keyword, syntax nodes, and parser support for discriminated union declarations and cases
- teach the compilation- and namespace-level parsers (plus nested member parser) to dispatch to the union parser
- document the new declaration form and add parser tests that cover basic and generic unions

## Testing
- `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0` *(fails: GlobalStatements_CanReferenceTopLevelTypes in Raven.CodeAnalysis.Semantics.Tests.TopLevelGlobalStatementTests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b781e83dc832f9915ce3a88514d8c)