### PR TITLE
Update discriminated union grammar

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -31,6 +31,7 @@ Declaration              ::= NamespaceDeclaration
                            | FunctionDeclaration
                            | ExtensionDeclaration
                            | EnumDeclaration
+                           | UnionDeclaration
                            | ClassDeclaration
                            | StructDeclaration
                            | InterfaceDeclaration ;
@@ -71,8 +72,15 @@ ClassDeclaration         ::= TypeModifiers? 'class' Identifier PrimaryConstructo
 PrimaryConstructor       ::= '(' ParameterList? ')' ;
 StructDeclaration        ::= TypeModifiers? 'struct' Identifier ClassBody ;
 InterfaceDeclaration     ::= TypeModifiers? 'interface' Identifier BaseList? ClassBody ;
+UnionDeclaration         ::= TypeModifiers? 'union' Identifier TypeParameterList?
+                             '{' UnionCaseList '}' TypeTerminator? ;
+UnionCaseList            ::= UnionCaseClause {UnionCaseClause} ;
+UnionCaseClause          ::= Identifier ParameterList? ;
 BaseList                 ::= ':' Type {',' Type} ;
 ClassBody                ::= '{' {ClassMember} '}' ;
+
+TypeTerminator           ::= NewLineToken | ';' ;
+NewLineToken             ::= /* newline trivia promoted to a token after type declarations */ ;
 
 ClassMember              ::= FieldDeclaration
                            | MethodDeclaration


### PR DESCRIPTION
## Summary
- add `union` declarations to the EBNF grammar so discriminated unions appear alongside other type declarations
- describe the case list structure and optional terminator to document how the parser accepts case clauses

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bae779504832fbaea753d0f4b4b53)