### PR TITLE
Update sample references after moving directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Alternative names considered: Old Norse **"Hrafn"** or Danish **"Ravn."**
 
 See the pseudo-specification [here](/docs/lang/spec/language-specification.md).
 
-More [samples](src/Raven.Compiler/samples/).
+More [samples](samples/).
 
 ---
  
@@ -171,12 +171,13 @@ When a file path is supplied, the editor opens the file and displays its name in
 ```
 src/
   Raven.CodeAnalysis/         # Compiler core: syntax, binder, semantic model, code gen
-  Raven.Compiler/             # Command-line compiler & samples
+  Raven.Compiler/             # Command-line compiler
   Raven.CodeAnalysis.Testing/ # Diagnostic test helpers
   TypeUnionAnalyzer/          # Analyzer for C# type unions
   TestDep/                    # Auxiliary test project
 
 test/                         # Unit tests
+samples/                      # Example Raven programs and CLI demos
 tools/
   NodeGenerator/              # Generates syntax node code from Model.xml
   Generator/                  # Shared Roslyn generator framework

--- a/samples/run.sh
+++ b/samples/run.sh
@@ -5,7 +5,13 @@
 set -Euo pipefail
 shopt -s nullglob
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 OUTPUT_DIR="${OUTPUT_DIR:-output}"
+if [[ "$OUTPUT_DIR" != /* ]]; then
+  OUTPUT_DIR="$SCRIPT_DIR/$OUTPUT_DIR"
+fi
 
 # List of dlls to exclude (filenames only)
 EXCLUDE=(


### PR DESCRIPTION
## Summary
- point the README sample link and repository structure table at the new top-level `samples/` folder
- make `samples/build.sh` resolve the compiler and output directories relative to the repository root so it works from anywhere
- make `samples/run.sh` resolve its output directory relative to the script location and ensure the file terminates with a newline

## Testing
- `dotnet build --property WarningLevel=0`
- `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0` *(fails: Lambda_WithoutParameterTypes_UsesTargetDelegateSignature is red in main, which also crashes the terminal logger)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691baf52a610832fb272319ac13a86e5)