### PR TITLE
Add TryGet helpers for discriminated unions

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -920,6 +920,7 @@ public partial class SemanticModel
         var caseSymbols = new List<IDiscriminatedUnionCaseSymbol>();
         var unitType = Compilation.GetSpecialType(SpecialType.System_Unit);
         var valueType = Compilation.GetSpecialType(SpecialType.System_ValueType);
+        var boolType = Compilation.GetSpecialType(SpecialType.System_Boolean);
         int ordinal = 0;
 
         foreach (var caseClause in unionDecl.Cases)
@@ -1067,6 +1068,31 @@ public partial class SemanticModel
                 Array.Empty<SyntaxReference>());
 
             conversionMethod.SetParameters(new[] { conversionParameter });
+
+            var tryGetMethod = new SourceMethodSymbol(
+                $"TryGet{caseClause.Identifier.ValueText}",
+                boolType!,
+                ImmutableArray<SourceParameterSymbol>.Empty,
+                unionSymbol,
+                unionSymbol,
+                namespaceSymbol,
+                new[] { caseClause.GetLocation() },
+                Array.Empty<SyntaxReference>(),
+                isStatic: false,
+                methodKind: MethodKind.Ordinary,
+                declaredAccessibility: Accessibility.Public);
+
+            var tryGetParameter = new SourceParameterSymbol(
+                "value",
+                caseSymbol,
+                tryGetMethod,
+                unionSymbol,
+                namespaceSymbol,
+                new[] { caseClause.GetLocation() },
+                Array.Empty<SyntaxReference>(),
+                RefKind.Ref);
+
+            tryGetMethod.SetParameters(new[] { tryGetParameter });
         }
 
         unionSymbol.SetCases(caseSymbols);


### PR DESCRIPTION
## Summary
- synthesize `TryGet<Case>` instance helpers for discriminated union structs and emit the supporting IL
- exercise the new helpers from a reflection-based code generation test to verify that they expose the active case payload

## Testing
- `dotnet build --property WarningLevel=0`
- `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0` *(fails: Raven.CodeAnalysis.Tests.ThrowStatementCodeGenTests.ThrowStatement_PropagatesException due to missing System.Exception symbol in test input)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de0362f28832f87927c746b22f113)