### PR TITLE
Capitalize union case properties

### DIFF
--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -997,6 +997,9 @@ public partial class SemanticModel
 
                     if (refKind == RefKind.None)
                     {
+                        var parameterName = parameterSyntax.Identifier.ValueText;
+                        var propertyName = GetUnionCasePropertyName(parameterName);
+
                         var backingField = new SourceFieldSymbol(
                             $"<{parameterSyntax.Identifier.ValueText}>k__BackingField",
                             parameterType,
@@ -1012,7 +1015,7 @@ public partial class SemanticModel
                             declaredAccessibility: Accessibility.Private);
 
                         var propertySymbol = new SourcePropertySymbol(
-                            parameterSyntax.Identifier.ValueText,
+                            propertyName,
                             parameterType,
                             caseSymbol,
                             caseSymbol,
@@ -1022,7 +1025,7 @@ public partial class SemanticModel
                             declaredAccessibility: Accessibility.Public);
 
                         var getterSymbol = new SourceMethodSymbol(
-                            $"get_{parameterSyntax.Identifier.ValueText}",
+                            $"get_{propertyName}",
                             parameterType,
                             ImmutableArray<SourceParameterSymbol>.Empty,
                             propertySymbol,
@@ -1096,6 +1099,20 @@ public partial class SemanticModel
         }
 
         unionSymbol.SetCases(caseSymbols);
+    }
+
+    private static string GetUnionCasePropertyName(string parameterName)
+    {
+        if (string.IsNullOrEmpty(parameterName))
+            return parameterName;
+
+        if (char.IsUpper(parameterName[0]))
+            return parameterName;
+
+        Span<char> buffer = stackalloc char[parameterName.Length];
+        parameterName.AsSpan().CopyTo(buffer);
+        buffer[0] = char.ToUpperInvariant(buffer[0]);
+        return new string(buffer);
     }
 
     private void RegisterUnionDeclaration(

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/DiscriminatedUnionCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/DiscriminatedUnionCodeGenTests.cs
@@ -61,8 +61,8 @@ class Container {
         Assert.Equal(42, (int)valueField.GetValue(caseValue)!);
         Assert.Equal("ok", (string)labelField.GetValue(caseValue)!);
 
-        var valueProperty = caseType.GetProperty("value", BindingFlags.Public | BindingFlags.Instance)!;
-        var labelProperty = caseType.GetProperty("label", BindingFlags.Public | BindingFlags.Instance)!;
+        var valueProperty = caseType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!;
+        var labelProperty = caseType.GetProperty("Label", BindingFlags.Public | BindingFlags.Instance)!;
 
         Assert.False(valueProperty.CanWrite);
         Assert.False(labelProperty.CanWrite);
@@ -123,7 +123,7 @@ class Container {
         var caseType = unionType.GetNestedType("Some", BindingFlags.Public | BindingFlags.NonPublic)!;
         Assert.Equal(caseType, payload!.GetType());
 
-        var valueProperty = caseType.GetProperty("value", BindingFlags.Public | BindingFlags.Instance)!;
+        var valueProperty = caseType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!;
         Assert.Equal(42, (int)valueProperty.GetValue(payload)!);
     }
 
@@ -244,14 +244,14 @@ class Container {
         var okArgs = new object?[] { Activator.CreateInstance(okCaseType)! };
         var okResult = (bool)okTryGetMethod.Invoke(okUnionValue, okArgs)!;
         Assert.True(okResult);
-        var okValueProperty = okCaseType.GetProperty("value", BindingFlags.Public | BindingFlags.Instance)!;
+        var okValueProperty = okCaseType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!;
         Assert.Equal(7, (int)okValueProperty.GetValue(okArgs[0])!);
 
         var errorUnionValue = getErrorMethod.Invoke(container, Array.Empty<object?>());
         var errorArgs = new object?[] { Activator.CreateInstance(errorCaseType)! };
         var errorResult = (bool)errorTryGetMethod.Invoke(errorUnionValue, errorArgs)!;
         Assert.True(errorResult);
-        var errorMessageProperty = errorCaseType.GetProperty("message", BindingFlags.Public | BindingFlags.Instance)!;
+        var errorMessageProperty = errorCaseType.GetProperty("Message", BindingFlags.Public | BindingFlags.Instance)!;
         Assert.Equal("boom", (string)errorMessageProperty.GetValue(errorArgs[0])!);
 
         var mismatchArgs = new object?[] { Activator.CreateInstance(errorCaseType)! };


### PR DESCRIPTION
## Summary
- normalize discriminated union case property names so they are always capitalized and expose a helper that keeps the backing field untouched
- update the generated getter method names to match the capitalized properties
- adjust the discriminated union code generation tests to assert the new property casing

## Testing
- `dotnet build --property WarningLevel=0`
- `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0` *(fails in TopLevelGlobalStatementTests.GlobalStatements_CanReferenceTopLevelTypes because the compiled sample now reports RAV1011 diagnostics)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de43761e8832fabb9dd2becb211b0)