### PR TITLE
Document match expression grammar

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -178,7 +178,13 @@ FinallyClause            ::= 'finally' Block ;
 
 (* ---------- Expressions & precedence (lowest → highest) ---------- *)
 
-Expression               ::= AssignmentExpression ;
+Expression               ::= AssignmentExpression {MatchExpressionSuffix} ;
+
+MatchExpressionSuffix    ::= 'match' '{' MatchArmList '}' ;
+MatchArmList             ::= MatchArm {MatchArm} ;
+MatchArm                 ::= Pattern MatchGuardClause? '=>' Expression MatchArmTerminator? ;
+MatchGuardClause         ::= 'when' Expression ;
+MatchArmTerminator       ::= NewLineToken | ';' ;
 
 AssignmentExpression     ::= AssignmentTarget AssignmentOperator AssignmentExpression
                            | ConditionalNullCoalesceExpression ;


### PR DESCRIPTION
## Summary
- extend the expression production to include trailing `match` suffixes
- document match arm structure, guards, and terminators in the EBNF grammar

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df9795614832fa22024fc39c112c7)