### PR TITLE
Document case patterns and union symbol APIs

### DIFF
--- a/docs/lang/proposals/discriminated-unions.md
+++ b/docs/lang/proposals/discriminated-unions.md
@@ -59,7 +59,10 @@ func describe(token: Token) -> string {
 }
 ```
 
-**Note:** The arms (for example, `.Identifier(text)`) is a `CasePattern` (mentioned in _grammar.ebnf_).
+**Note:** The arms (for example, `.Identifier(text)`) use the `CasePattern`
+syntax from _grammar.ebnf_: a leading `.` resolves the case against the current
+scrutinee, and an optional qualifier (such as `Token.Identifier`) forces lookup
+against a specific union type.
 
 ```csharp
 union Result<T> {
@@ -84,6 +87,23 @@ else if (token.TryGetUnknown(ref Token.Unknown? _)) { ... }
 ```
 
 The leading `.` in the pattern is the target-member pattern syntax. When used inside a `match` expression or `is` pattern it tells the compiler to resolve the case against the current scrutinee.
+
+## Compiler API integration
+
+Surface discriminated unions through the symbol model so semantic consumers can
+reason about unions declared in source or supplied via metadata:
+
+* `IsDiscriminatedUnion` returns `true` for the union struct itself and for any
+  constructed versions of it. When importing existing metadata, recognise the
+  synthesized `[DiscriminatedUnion]` attribute as the signal.
+* `IsDiscriminatedUnionCase` returns `true` for nested case structs and their
+  constructed forms. Metadata cases can be detected via the
+  `[DiscriminatedUnionCase]` attribute.
+* `UnderlyingDiscriminatedUnionType` (renamed from
+  `UnderlyingDiscriminatedUnion`) should report the outer union type. For
+  case structs it returns the containing union, and for the union type itself
+  it simply returns `this`. Attribute arguments on metadata-backed cases expose
+  the same relationship.
 
 ## Runtime representation
 

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -1003,6 +1003,13 @@ Patterns compose from the following primitives:
   test or bind each element independently. Each element may introduce a name
   before the colon (for example `(first: int, second: string)`) to bind the
   matched value while applying the nested subpattern.
+- `.Case` / `Type.Case` — case pattern; matches a discriminated union case by
+  name. The leading `.` resolves against the current scrutinee in a `match` arm
+  or `is` expression. A qualifying type name forces lookup against that union
+  regardless of the scrutinee's static type. Case patterns may supply nested
+  subpatterns in parentheses to bind or validate payload fields, mirroring the
+  parameter list declared on the case: `.Identifier(text)` or
+  `Result<int>.Error(let message)`.
 - `pattern1 or pattern2` — alternative; matches when either operand matches.
   Parentheses may be used to group alternatives.
 - `not pattern` — complement; succeeds when the operand fails. `not` does not
@@ -1030,6 +1037,10 @@ if value is "ok" or "pending" {
 
 if mode is not ("on" or "off") {
     Console.WriteLine("unexpected mode")
+}
+
+if token is .Identifier(text) {
+    Console.WriteLine($"identifier {text}")
 }
 ```
 


### PR DESCRIPTION
## Summary
- add case pattern syntax description to the language specification with example
- clarify discriminated union proposal note about case patterns and outline symbol API flags including UnderlyingDiscriminatedUnionType

## Testing
- not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e33dad094832f8cb7c3f72258e10c)