### PR TITLE
Add syntax support for case patterns

### DIFF
--- a/docs/lang/proposals/discriminated-unions.md
+++ b/docs/lang/proposals/discriminated-unions.md
@@ -64,6 +64,24 @@ syntax from _grammar.ebnf_: a leading `.` resolves the case against the current
 scrutinee, and an optional qualifier (such as `Token.Identifier`) forces lookup
 against a specific union type.
 
+Case patterns accept the same payload shape declared on the case. A
+parameterless case may be matched with either `.Unknown` or `.Unknown()`, while
+payload-bearing cases unpack each element positionally:
+
+```csharp
+let token = Token.Identifier("foo")
+
+let description = token match {
+    .Identifier(let text) => text,
+    Token.Unknown() => "missing",
+}
+```
+
+Adding an explicit qualifier bypasses the scrutinee's static type and is useful
+when the union flows in as an interface or object. The parser treats the
+qualifier as part of the case path; binding will validate that the qualifier and
+case belong to the same union when semantic analysis is implemented.
+
 ```csharp
 union Result<T> {
     Ok(value: T)

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -1009,7 +1009,8 @@ Patterns compose from the following primitives:
   regardless of the scrutinee's static type. Case patterns may supply nested
   subpatterns in parentheses to bind or validate payload fields, mirroring the
   parameter list declared on the case: `.Identifier(text)` or
-  `Result<int>.Error(let message)`.
+  `Result<int>.Error(let message)`. Parentheses are optional for parameterless
+  cases, so `.Unknown` and `.Unknown()` are equivalent.
 - `pattern1 or pattern2` — alternative; matches when either operand matches.
   Parentheses may be used to group alternatives.
 - `not pattern` — complement; succeeds when the operand fails. `not` does not

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -592,6 +592,10 @@
     <Slot Name="OperatorToken" Type="Token" />
     <Slot Name="Right" Type="Pattern" />
   </Node>
+  <Node Name="CasePattern" Inherits="Pattern">
+    <Slot Name="Path" Type="CasePatternPath" />
+    <Slot Name="ArgumentList" Type="CasePatternArgumentList" IsNullable="true" />
+  </Node>
   <Node Name="VariablePattern" Inherits="Pattern">
     <Slot Name="BindingKeyword" Type="Token" />
     <Slot Name="Designation" Type="VariableDesignation" />
@@ -611,6 +615,16 @@
   <Node Name="TuplePatternElement" Inherits="Node">
     <Slot Name="NameColon" Type="NameColon" IsNullable="true" />
     <Slot Name="Pattern" Type="Pattern" />
+  </Node>
+  <Node Name="CasePatternPath" Inherits="Node">
+    <Slot Name="Qualifier" Type="Type" IsNullable="true" />
+    <Slot Name="DotToken" Type="Token" DefaultToken="DotToken"/>
+    <Slot Name="Identifier" Type="Token" />
+  </Node>
+  <Node Name="CasePatternArgumentList" Inherits="Node">
+    <Slot Name="OpenParenToken" Type="Token" DefaultToken="OpenParenToken"/>
+    <Slot Name="Arguments" Type="SeparatedList" ElementType="Pattern" />
+    <Slot Name="CloseParenToken" Type="Token" DefaultToken="CloseParenToken"/>
   </Node>
   <Node Name="EnumDeclaration" Inherits="BaseTypeDeclaration">
     <Slot Name="AttributeLists" Type="List" ElementType="AttributeList" IsInherited="true" />


### PR DESCRIPTION
## Summary
- add syntax nodes for case patterns and parse both shorthand and qualified case paths with optional payloads
- document case pattern behavior in the language specification and discriminated union proposal
- add parser coverage for case patterns in match arms

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: existing AsyncFunction_WithoutReturnType_WithReturnExpression_InfersTaskOfResult expectation and ThrowStatementCodeGenTests missing System.Exception context)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e351e4318832fb12dc17a9460d235)