### PR TITLE
Fix union case pattern TryGet resolution and add tests

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
@@ -552,11 +552,11 @@ internal partial class BlockBinder
         var tryGetMethod = unionType
             .GetMembers(tryGetMethodName)
             .OfType<IMethodSymbol>()
-            .FirstOrDefault(m =>
-                !m.IsStatic &&
-                m.Parameters.Length == 1 &&
-                m.Parameters[0].RefKind == RefKind.Ref &&
-                SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, caseSymbol));
+            .FirstOrDefault(m => !m.IsStatic)
+            ?? caseSymbol
+                .GetMembers(tryGetMethodName)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(m => !m.IsStatic);
 
         if (tryGetMethod is null)
         {


### PR DESCRIPTION
## Summary
- broaden the TryGet helper lookup when binding discriminated union case patterns
- add match expression coverage for implicit payload locals and exhaustiveness on Result.Ok/Error cases

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 --filter "DiscriminatedUnionSemanticTests.CasePattern_ImplicitPayloadDesignations_BindLocals" *(fails: RAV0103 reported during binding)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4ba27884832fa49e72e6fa15f947)