### PR TITLE
Refresh samples README status table

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -41,6 +41,7 @@ Re-running every sample from `samples/` with `dotnet run --project ../src/Raven.
 | `collections.rav` | ✅ Emitted / ✅ Ran | Produces the expected hero roster. |
 | `discard.rav` | ✅ Emitted / ✅ Ran | Prints `Test` twice to demonstrate discards. |
 | `discriminated-unions.rav` | ❌ Fails | `.Ok(...)`/`.Error(...)` now resolve to the generated case constructors, and each case type exposes an implicit conversion back to the containing union so target-typed initializers and arguments share the same lowering path. The conversion emitter now instantiates the union and case definitions with the enclosing type arguments, so generic `.Ok(99)` initializers no longer emit invalid IL before `Console.WriteLine` runs.【F:src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs†L598-L676】【F:test/Raven.CodeAnalysis.Tests/CodeGen/DiscriminatedUnionCodeGenTests.cs†L236-L295】 The match arms still use the leading-dot syntax that the current pattern binder does not recognize, so they report `RAV1001`/`RAV0103` before exhaustiveness analysis. The file keeps its union declarations after the global statements so it satisfies the ordering rule while we focus on pattern binding, lowering, and code generation. |
+| `discriminated-unions2.rav` | ❌ Fails | The match arms still use the leading-dot case syntax, so binding reports missing names and exhaustiveness gaps. |
 | `enums.rav` | ✅ Emitted / ✅ Ran | Outputs `C`, `Grades`, `B`, `Grades`. |
 | `extensions.rav` | ✅ Emitted / ✅ Ran | Outputs `Count: 2`, `Sum: 3`, `Value: 4`. |
 | `foo.rav` | ✅ Emitted / ✅ Ran | Invocation prints `1`. |
@@ -55,7 +56,7 @@ Re-running every sample from `samples/` with `dotnet run --project ../src/Raven.
 | `goto.rav` | ✅ Emitted / ⚠️ Not run | Build succeeds but the program would loop forever, so execution is skipped. |
 | `interfaces.rav` | ✅ Emitted / ✅ Ran | Runtime output remains `Init`, `Do`, `Dispose 1`. |
 | `introduction.rav` | ✅ Emitted / ✅ Ran | Prints `Empty input.` followed by the summary lines. |
-| `io.rav` | ✅ Emitted / ⚠️ Requires args | Pass a directory argument (for example `.`) so the program can enumerate files and report the count. |
+| `io.rav` | ✅ Emitted / ✅ Ran | Running with a directory argument such as `.` enumerates the entries and reports the count. |
 | `lambda.rav` | ✅ Emitted / ✅ Ran | Shows the captured lambda results and closure state transitions. |
 | `linq.rav` | ✅ Emitted / ✅ Ran | Outputs the reversed list `3`, `2`, `1`. |
 | `main.rav` | ✅ Emitted / ✅ Ran | Prints the critical value banner and tuple projection. |
@@ -70,19 +71,19 @@ Re-running every sample from `samples/` with `dotnet run --project ../src/Raven.
 | `string-interpolation.rav` | ✅ Emitted / ✅ Ran | Outputs the Hebrew greeting from `Console.WriteLine`. |
 | `test.rav` | ✅ Emitted / ✅ Ran | Prints the lambda totals `7`, `5`, and `5`. |
 | `test2.rav` | ✅ Emitted / ✅ Ran | Produces `42`, `Hello, World!`, and `Hello, 2`. |
-| `test3.rav` | ❌ Fails | Top-level program synthesis still recurses in `SynthesizedMainMethodSymbol.ResolveReturnType`. |
+| `test3.rav` | ✅ Emitted / ✅ Ran | The synthesized entry point now completes without console output. |
 | `test4.rav` | ✅ Emitted / ✅ Ran | Completes silently after exercising property override compatibility. |
 | `test5.rav` | ✅ Emitted / ✅ Ran | Prints `Foo: Hejtest 2 3`. |
 | `test9.rav` | ✅ Emitted / ✅ Ran | Produces the unit literal `()`. |
 | `test10.rav` | ✅ Emitted / ✅ Ran | Prints `(2, test)`. |
-| `tokenizer.rav` | ⚠️ Hangs | `timeout 3` aborts compilation, indicating the tokenizer still fails to terminate. |
+| `tokenizer.rav` | ⚠️ Compile timeout | `timeout 10` aborts compilation before a DLL is emitted, so the tokenizer still fails to finish binding/emission. |
 | `try-match.rav` | ✅ Emitted / ⚠️ Input mismatch | Running with the default `'foo'` argument reports the format error and exits. |
 | `tuples.rav` | ⚠️ Emitted with warning / ✅ Ran | Compilation warns about the redundant catch-all, and the program prints the tuple projections. |
 | `tuples2.rav` | ✅ Emitted / ✅ Ran | Runtime output remains `tuple False foo`. |
 | `type-unions.rav` | ✅ Emitted / ⚠️ External dependency | Copy `src/TestDep/bin/Debug/net9.0/TestDep.dll` beside the emitted DLL before running so the union projections print. |
 | `unit.rav` | ✅ Emitted / ✅ Ran | Outputs `Hello` and the unit literals. |
 
-**Runtime observations.** The async sample completes, `reflection.rav` now runs to completion, and `type-unions.rav` still requires copying `TestDep.dll` next to the emitted assembly. The interactive samples remain non-turnkey: `io.rav` expects a directory argument, `parse-number.rav` loops waiting for input, `goto.rav` is an intentional infinite loop, and `try-match.rav` reports a format error for its default `'foo'` argument. `tokenizer.rav` still fails to terminate, and `test3.rav` continues to hit the entry-point synthesis recursion. Additional regressions remain: the HTTP client sample needs external network access (and currently exits with 403), `async/async-inference-regression.rav` and `async/try-match-async.rav` still fail to bind, and `discriminated-unions.rav` is blocked on the issues called out above.
+**Runtime observations.** The async suite completes, `reflection.rav` runs to completion, and `type-unions.rav` still requires copying `TestDep.dll` next to the emitted assembly. The interactive samples remain non-turnkey: `io.rav` expects a directory argument (running with `.` lists 50 entries), `parse-number.rav` loops waiting for input, `goto.rav` is an intentional infinite loop, and `try-match.rav` reports a format error for its default `'foo'` argument. `tokenizer.rav` still times out during compilation, while `test3.rav` now emits and runs quietly. Additional regressions remain: the HTTP client sample needs external network access (and currently exits with 403), `async/async-inference-regression.rav` and `async/try-match-async.rav` still fail to bind, and both discriminated union samples are blocked on the issues called out above.
 
 ### Discriminated union gaps
 


### PR DESCRIPTION
## Summary
- Reran the samples and refreshed the compilation/runtime status table
- Added the missing `discriminated-unions2.rav` entry to the table
- Updated the runtime observations to reflect the current IO, tokenizer, and test3 behavior

## Testing
- dotnet build --property WarningLevel=0
- while read -r f; do run_sample "$f"; echo; done < <(find . -name '*.rav' | sort)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e5647b524832f90ec2d5ae662560c)