### PR TITLE
Update samples status after rerun

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -28,20 +28,20 @@ Re-running every sample from `samples/` with `dotnet run --project ../src/Raven.
 | Sample | Status | Notes |
 | --- | --- | --- |
 | `arrays.rav` | ✅ Emitted / ✅ Ran | Running the DLL prints `3`, `1`, `42`, `3`. |
-| `async/async-await.rav` | ✅ Emitted / ✅ Ran | The async sample finishes with `first:1`, `sum:6`, and `done`. |
+| `async/async-await.rav` | ✅ Emitted / ✅ Ran | Finishes with `first:1`, `sum:6`, and `done`. |
 | `async/async-file-io.rav` | ✅ Emitted / ✅ Ran | Runtime output lists the staged writes `alpha`, `beta`, `gamma`. |
 | `async/async-generic-compute.rav` | ✅ Emitted / ✅ Ran | Shows the "Before/After" delay log before printing `42`. |
 | `async/async-inference-regression.rav` | ❌ Fails | Binder errors persist (`int` can't satisfy the `unit` return type and `WriteLine` overloads stay ambiguous). |
 | `async/async-task-return.rav` | ✅ Emitted / ✅ Ran | Prints the awaited task result `43`. |
 | `async/async-try-catch.rav` | ✅ Emitted / ✅ Ran | Logs `value:42`, `caught:boom`, and `completed`. |
 | `async/http-client.rav` | ✅ Emitted / ⚠️ HTTP dependency | Execution attempts an external request and exits with a 403 in the sandbox. |
-| `async/try-match-async.rav` | ❌ Fails | Still reports `Cannot convert from '0' to 'Task'` for the awaited `try match`. |
+| `async/try-match-async.rav` | ❌ Fails | Reports `Cannot convert from '0' to 'Task'` when binding the awaited `try match`. |
 | `catch.rav` | ✅ Emitted / ✅ Ran | Prints `Foo`. |
 | `classes.rav` | ✅ Emitted / ✅ Ran | Prints `Hello`, `John`, the projected record, and the trailing unit value. |
 | `collections.rav` | ✅ Emitted / ✅ Ran | Produces the expected hero roster. |
 | `discard.rav` | ✅ Emitted / ✅ Ran | Prints `Test` twice to demonstrate discards. |
-| `discriminated-unions.rav` | ❌ Fails | `.Ok(...)`/`.Error(...)` now resolve to the generated case constructors, and each case type exposes an implicit conversion back to the containing union so target-typed initializers and arguments share the same lowering path. The conversion emitter now instantiates the union and case definitions with the enclosing type arguments, so generic `.Ok(99)` initializers no longer emit invalid IL before `Console.WriteLine` runs.【F:src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs†L598-L676】【F:test/Raven.CodeAnalysis.Tests/CodeGen/DiscriminatedUnionCodeGenTests.cs†L236-L295】 The match arms still use the leading-dot syntax that the current pattern binder does not recognize, so they report `RAV1001`/`RAV0103` before exhaustiveness analysis. The file keeps its union declarations after the global statements so it satisfies the ordering rule while we focus on pattern binding, lowering, and code generation. |
-| `discriminated-unions2.rav` | ❌ Fails | The match arms still use the leading-dot case syntax, so binding reports missing names and exhaustiveness gaps. |
+| `discriminated-unions-generics.rav` | ✅ Emitted / ❌ Ran | Runtime aborts with `System.BadImageFormatException` while formatting the generic result. |
+| `discriminated-unions.rav` | ✅ Emitted / ✅ Ran | Prints the token classifications: `identifier 'alpha'`, `number 42`, `unknown token`. |
 | `enums.rav` | ✅ Emitted / ✅ Ran | Outputs `C`, `Grades`, `B`, `Grades`. |
 | `extensions.rav` | ✅ Emitted / ✅ Ran | Outputs `Count: 2`, `Sum: 3`, `Value: 4`. |
 | `foo.rav` | ✅ Emitted / ✅ Ran | Invocation prints `1`. |
@@ -56,7 +56,7 @@ Re-running every sample from `samples/` with `dotnet run --project ../src/Raven.
 | `goto.rav` | ✅ Emitted / ⚠️ Not run | Build succeeds but the program would loop forever, so execution is skipped. |
 | `interfaces.rav` | ✅ Emitted / ✅ Ran | Runtime output remains `Init`, `Do`, `Dispose 1`. |
 | `introduction.rav` | ✅ Emitted / ✅ Ran | Prints `Empty input.` followed by the summary lines. |
-| `io.rav` | ✅ Emitted / ✅ Ran | Running with a directory argument such as `.` enumerates the entries and reports the count. |
+| `io.rav` | ✅ Emitted / ✅ Ran | Running with `.` enumerates 49 entries in the directory. |
 | `lambda.rav` | ✅ Emitted / ✅ Ran | Shows the captured lambda results and closure state transitions. |
 | `linq.rav` | ✅ Emitted / ✅ Ran | Outputs the reversed list `3`, `2`, `1`. |
 | `main.rav` | ✅ Emitted / ✅ Ran | Prints the critical value banner and tuple projection. |
@@ -71,19 +71,19 @@ Re-running every sample from `samples/` with `dotnet run --project ../src/Raven.
 | `string-interpolation.rav` | ✅ Emitted / ✅ Ran | Outputs the Hebrew greeting from `Console.WriteLine`. |
 | `test.rav` | ✅ Emitted / ✅ Ran | Prints the lambda totals `7`, `5`, and `5`. |
 | `test2.rav` | ✅ Emitted / ✅ Ran | Produces `42`, `Hello, World!`, and `Hello, 2`. |
-| `test3.rav` | ✅ Emitted / ✅ Ran | The synthesized entry point now completes without console output. |
+| `test3.rav` | ✅ Emitted / ✅ Ran | Completes without console output. |
 | `test4.rav` | ✅ Emitted / ✅ Ran | Completes silently after exercising property override compatibility. |
 | `test5.rav` | ✅ Emitted / ✅ Ran | Prints `Foo: Hejtest 2 3`. |
 | `test9.rav` | ✅ Emitted / ✅ Ran | Produces the unit literal `()`. |
 | `test10.rav` | ✅ Emitted / ✅ Ran | Prints `(2, test)`. |
-| `tokenizer.rav` | ⚠️ Compile timeout | `timeout 10` aborts compilation before a DLL is emitted, so the tokenizer still fails to finish binding/emission. |
+| `tokenizer.rav` | ❌ Compile timeout | Compilation hung until the process was killed after 30 seconds, so no DLL was emitted. |
 | `try-match.rav` | ✅ Emitted / ⚠️ Input mismatch | Running with the default `'foo'` argument reports the format error and exits. |
 | `tuples.rav` | ⚠️ Emitted with warning / ✅ Ran | Compilation warns about the redundant catch-all, and the program prints the tuple projections. |
 | `tuples2.rav` | ✅ Emitted / ✅ Ran | Runtime output remains `tuple False foo`. |
-| `type-unions.rav` | ✅ Emitted / ⚠️ External dependency | Copy `src/TestDep/bin/Debug/net9.0/TestDep.dll` beside the emitted DLL before running so the union projections print. |
+| `type-unions.rav` | ✅ Emitted / ❌ Ran | Fails at runtime with `FileNotFoundException` for `TestDep.dll` unless the dependency is copied beside the emitted DLL. |
 | `unit.rav` | ✅ Emitted / ✅ Ran | Outputs `Hello` and the unit literals. |
 
-**Runtime observations.** The async suite completes, `reflection.rav` runs to completion, and `type-unions.rav` still requires copying `TestDep.dll` next to the emitted assembly. The interactive samples remain non-turnkey: `io.rav` expects a directory argument (running with `.` lists 50 entries), `parse-number.rav` loops waiting for input, `goto.rav` is an intentional infinite loop, and `try-match.rav` reports a format error for its default `'foo'` argument. `tokenizer.rav` still times out during compilation, while `test3.rav` now emits and runs quietly. Additional regressions remain: the HTTP client sample needs external network access (and currently exits with 403), `async/async-inference-regression.rav` and `async/try-match-async.rav` still fail to bind, and both discriminated union samples are blocked on the issues called out above.
+**Runtime observations.** The async suite completes aside from the two known binder regressions, and `reflection.rav` runs to completion. Interactive or non-terminating samples remain non-turnkey: `io.rav` expects a directory argument (running with `.` listed 49 entries), `parse-number.rav` loops waiting for input, and `goto.rav` intentionally never exits. `try-match.rav` reports a format error for its default `'foo'` argument, `tokenizer.rav` still times out during compilation, the HTTP client sample exits with a 403, and `type-unions.rav` needs `TestDep.dll` beside the emitted assembly. `discriminated-unions.rav` now runs to completion, while the generic variant aborts at runtime with a `BadImageFormatException`.
 
 ### Discriminated union gaps
 


### PR DESCRIPTION
## Summary
- refresh the samples README table after rerunning every sample, including new coverage for `discriminated-unions-generics.rav`
- document the latest compile/run outcomes such as the now-running `discriminated-unions.rav`, the `BadImageFormatException` in the generic union sample, and updated notes for interactive or dependency-heavy runs

## Testing
- `dotnet build --property WarningLevel=0`
- `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0` (fails: OptionalParameterSemanticTests triggers logger error)
- `bash /tmp/run_samples.sh`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0a8c8238832fbfd00ffd39de9e3b)