### PR TITLE
Update pattern matching and union documentation

### DIFF
--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -198,10 +198,15 @@ Assignable               ::= Identifier
                            | MemberBindingExpression
                            | ElementAccessExpression ;
 
-Pattern                  ::= VariablePattern | DeclarationPattern | TuplePattern | DiscardPattern | CasePattern ;
+Pattern                  ::= OrPattern ;
+OrPattern                ::= AndPattern {'or' AndPattern} ;
+AndPattern               ::= UnaryPattern {'and' UnaryPattern} ;
+UnaryPattern             ::= 'not' UnaryPattern | PrimaryPattern ;
+PrimaryPattern           ::= ConstantPattern | VariablePattern | DeclarationPattern | TuplePattern | DiscardPattern | CasePattern ;
 
+ConstantPattern          ::= Literal ;
 VariablePattern          ::= ('let' | 'var') VariableDesignation ;
-DeclarationPattern       ::= Type VariableDesignation ;
+DeclarationPattern       ::= Type [VariableDesignation] ;
 TuplePattern             ::= '(' PatternElement {',' PatternElement} ')' ;
 PatternElement           ::= [Identifier ':'] Pattern ;
 


### PR DESCRIPTION
## Summary
- document supported pattern forms, including variable bindings, constant patterns, and conjunction precedence
- add example demonstrating conjunction with union case patterns
- align grammar production rules with pattern matching syntax and precedence

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4dcdeb44832f8518de325a8300b8)