### PR TITLE
Support expression-bodied extension properties

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/MethodBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBinder.cs
@@ -48,7 +48,8 @@ class MethodBinder : TypeMemberBinder
         if (node is MethodDeclarationSyntax
             or ConstructorDeclarationSyntax
             or NamedConstructorDeclarationSyntax
-            or AccessorDeclarationSyntax)
+            or AccessorDeclarationSyntax
+            or PropertyDeclarationSyntax)
             return _methodSymbol;
 
         if (node is ParameterSyntax parameter)

--- a/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodBodyGenerator.cs
@@ -208,6 +208,8 @@ internal class MethodBodyGenerator
                 => semanticModel.GetBoundNode(c.ExpressionBody.Expression) as BoundExpression,
             AccessorDeclarationSyntax a when a.ExpressionBody is not null
                 => semanticModel.GetBoundNode(a.ExpressionBody.Expression) as BoundExpression,
+            PropertyDeclarationSyntax p when p.ExpressionBody is not null
+                => semanticModel.GetBoundNode(p.ExpressionBody.Expression) as BoundExpression,
             FunctionStatementSyntax l when l.ExpressionBody is not null
                 => semanticModel.GetBoundNode(l.ExpressionBody.Expression) as BoundExpression,
             _ => null
@@ -356,6 +358,18 @@ internal class MethodBodyGenerator
                          propertySymbol.BackingField is SourceFieldSymbol backingField)
                 {
                     EmitAutoPropertyAccessor(accessorDeclaration, propertySymbol, backingField);
+                }
+                else
+                {
+                    ILGenerator.Emit(OpCodes.Ret);
+                }
+                break;
+
+            case PropertyDeclarationSyntax propertyDeclaration:
+                if (expressionBody is not null)
+                {
+                    new ExpressionGenerator(baseGenerator, expressionBody).Emit();
+                    ILGenerator.Emit(OpCodes.Ret);
                 }
                 else
                 {

--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -509,6 +509,9 @@ internal class TypeGenerator
                     }
                 case IPropertySymbol propertySymbol:
                     {
+                        if (propertySymbol is SourcePropertySymbol sourceProperty && sourceProperty.IsDeclaredInExtension)
+                            break;
+
                         var getterSymbol = propertySymbol.GetMethod as IMethodSymbol;
                         var setterSymbol = propertySymbol.SetMethod as IMethodSymbol;
 

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExtensionDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExtensionDeclarationParser.cs
@@ -148,6 +148,10 @@ internal sealed class ExtensionDeclarationParser : SyntaxParser
         if (PeekToken().IsKind(SyntaxKind.OpenBraceToken))
             accessorList = ParseAccessorList();
 
+        ArrowExpressionClauseSyntax? expressionBody = null;
+        if (PeekToken().IsKind(SyntaxKind.FatArrowToken))
+            expressionBody = new ExpressionSyntaxParser(this).ParseArrowExpressionClause();
+
         EqualsValueClauseSyntax? initializer = null;
         if (IsNextToken(SyntaxKind.EqualsToken, out _))
             initializer = new EqualsValueClauseSyntaxParser(this).Parse();
@@ -161,6 +165,7 @@ internal sealed class ExtensionDeclarationParser : SyntaxParser
             identifier,
             typeAnnotation,
             accessorList,
+            expressionBody,
             initializer,
             terminatorToken);
     }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/TypeDeclarationParser.cs
@@ -580,6 +580,10 @@ internal class TypeDeclarationParser : SyntaxParser
             //typeAnnotation = (ArrowTypeClauseSyntax)typeAnnotation.ReplaceNode(lastToken, newToken);
         }
 
+        ArrowExpressionClauseSyntax? expressionBody = null;
+        if (PeekToken().IsKind(SyntaxKind.FatArrowToken))
+            expressionBody = new ExpressionSyntaxParser(this).ParseArrowExpressionClause();
+
         EqualsValueClauseSyntax? initializer = null;
         if (IsNextToken(SyntaxKind.EqualsToken, out _))
         {
@@ -588,7 +592,7 @@ internal class TypeDeclarationParser : SyntaxParser
 
         TryConsumeTerminator(out var terminatorToken);
 
-        return PropertyDeclaration(attributeLists, modifiers, explicitInterfaceSpecifier, identifier, typeAnnotation, accessorList, initializer, terminatorToken);
+        return PropertyDeclaration(attributeLists, modifiers, explicitInterfaceSpecifier, identifier, typeAnnotation, accessorList, expressionBody, initializer, terminatorToken);
     }
 
     private TypeAnnotationClauseSyntax CreateMissingTypeAnnotationClause()

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -702,6 +702,7 @@
     <Slot Name="Identifier" Type="Token" IsInherited="true" />
     <Slot Name="Type" Type="TypeAnnotationClause" IsInherited="true" />
     <Slot Name="AccessorList" Type="AccessorList" IsNullable="true" IsInherited="true" />
+    <Slot Name="ExpressionBody" Type="ArrowExpressionClause" IsNullable="true" />
     <Slot Name="Initializer" Type="EqualsValueClause" IsNullable="true" />
     <Slot Name="TerminatorToken" Type="Token" IsOptionalToken="true"/>
   </Node>


### PR DESCRIPTION
## Summary
- allow property declarations to use fat-arrow expression bodies in type and extension members
- bind expression-bodied properties as getter accessors and emit their IL bodies correctly
- avoid emitting property metadata for extension properties to prevent invalid IL

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: existing ThrowStatementInExpressionContext_ReportsDiagnostic expectation)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920505a8c94832fa9111c6d4f36b483)