### PR TITLE
Handle boxing for value-type invocation arguments symmetrically

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -30,7 +30,7 @@ Re-running every sample from `samples/` with `dotnet run --project ../src/Raven.
 | `arrays.rav` | ✅ Emitted / ✅ Ran | Running the DLL prints `3`, `1`, `42`, `3`. |
 | `async/async-await.rav` | ✅ Emitted / ✅ Ran | Finishes with `first:1`, `sum:6`, and `done`. |
 | `async/async-file-io.rav` | ✅ Emitted / ✅ Ran | Runtime output lists the staged writes `alpha`, `beta`, `gamma`. |
-| `async/async-generic-compute.rav` | ✅ Emitted / ❌ Ran | Crashes with an `InvalidProgramException` while unwrapping the async generic result; the async state machine regressed after previously working. |
+| `async/async-generic-compute.rav` | ✅ Emitted / ✅ Ran | Prints `Before delay`, `After delay`, `After Compute`, and `42`. |
 | `async/async-inference-regression.rav` | ❌ Fails | Binder errors persist (`Run` overload count, `int` vs `unit`, ambiguous `WriteLine`); still never worked. |
 | `async/async-task-return.rav` | ✅ Emitted / ✅ Ran | Prints the awaited task result `43`. |
 | `async/async-try-catch.rav` | ✅ Emitted / ✅ Ran | Logs `value:42`, `caught:boom`, and `completed`. |

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -3035,7 +3035,7 @@ internal class ExpressionGenerator : Generator
 
                 if (argument?.Type is { } argumentType &&
                     RequiresValueTypeHandling(argumentType) &&
-                    !paramSymbol.Type.IsValueType)
+                    !RequiresValueTypeHandling(paramSymbol.Type))
                 {
                     ILGenerator.Emit(OpCodes.Box, ResolveClrType(argumentType));
                 }


### PR DESCRIPTION
## Summary
- use the shared value-type handling helper when deciding whether to box invocation arguments, preventing unnecessary boxing for generic parameters
- update the samples status table now that `async/async-generic-compute.rav` emits and runs successfully

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: existing semantic/codegen assertions and diagnostics mismatches)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692745a927a8832f9093954d66298811)