### PR TITLE
Improve bound tree symbol display formatting

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/BoundTreePrinter.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundTreePrinter.cs
@@ -11,6 +11,11 @@ namespace Raven.CodeAnalysis;
 
 public static class BoundTreePrinter
 {
+    private static readonly SymbolDisplayFormat BoundTreeDisplayFormat = SymbolDisplayFormat.MinimallyQualifiedFormat
+        .WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)
+        .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType | SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeParameters)
+        .WithParameterOptions(SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName);
+
     public static void PrintBoundTree(this SemanticModel model)
     {
         if (model is null)
@@ -374,11 +379,11 @@ public static class BoundTreePrinter
 
     private static string FormatType(ITypeSymbol type)
     {
-        return type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        return type.ToDisplayString(BoundTreeDisplayFormat);
     }
 
     private static string FormatSymbol(ISymbol symbol)
     {
-        return symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        return symbol.ToDisplayString(BoundTreeDisplayFormat);
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated symbol display format for bound tree output that includes generic arguments and parameter details
- update bound tree printer to use the richer formatting for both types and symbols

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b389bb84832f9b345a738caecac0)