### PR TITLE
Fix binding for expression-bodied properties

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -1296,7 +1296,7 @@ internal class TypeMemberBinder : Binder
                 methodSymbol.SetOverriddenMethod(overriddenGetter);
 
             var binder = new MethodBinder(methodSymbol, this);
-            binders[propertyDecl] = binder;
+            binders[propertyDecl.ExpressionBody!] = binder;
 
             getMethod = methodSymbol;
         }

--- a/test/Raven.CodeAnalysis.Tests/Symbols/ExpressionBodiedPropertyBindingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/ExpressionBodiedPropertyBindingTests.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class ExpressionBodiedPropertyBindingTests
+{
+    [Fact]
+    public void ExpressionBodiedProperty_BindsToPropertySymbol()
+    {
+        var syntaxTree = SyntaxTree.ParseText(
+            """
+            class C {
+                public IsOk: int => 2
+            }
+            """);
+
+        var compilation = Compilation.Create(
+            "test",
+            [syntaxTree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var model = compilation.GetSemanticModel(syntaxTree);
+        var propertySyntax = syntaxTree.GetRoot().DescendantNodes().OfType<PropertyDeclarationSyntax>().Single();
+
+        var symbol = Assert.IsAssignableFrom<IPropertySymbol>(model.GetDeclaredSymbol(propertySyntax));
+        Assert.Equal("IsOk", symbol.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure expression-bodied properties cache binders on the expression body instead of the declaration
- add a regression test confirming the declared symbol for an expression-bodied property is the property symbol

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: AsyncFunction_WithoutReturnType_WithReturnExpression_InfersTaskOfResult expects `Task<System.Int32>` vs `Task<int>`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e2223084832f879338e72d10d590)