### PR TITLE
Allow empty top-level console programs

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/TopLevelGlobalStatementTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/TopLevelGlobalStatementTests.cs
@@ -73,4 +73,22 @@ enum Shade {
         var enumMember = Assert.IsAssignableFrom<IFieldSymbol>(model.GetSymbolInfo(enumAccess).Symbol);
         Assert.Same(enumSymbol, enumMember.ContainingType);
     }
+
+    [Fact]
+    public void EmptyTopLevelProgram_EmitsEmptyMain()
+    {
+        var tree = SyntaxTree.ParseText(string.Empty);
+        var compilation = CreateCompilation(tree, assemblyName: "app");
+
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString())));
+
+        var entryPoint = compilation.GetEntryPoint();
+        Assert.NotNull(entryPoint);
+        Assert.Equal("Main", entryPoint!.Name);
+        Assert.Equal("Program", entryPoint.ContainingType?.Name);
+        Assert.Equal(SpecialType.System_Unit, entryPoint.ReturnType.SpecialType);
+    }
 }


### PR DESCRIPTION
## Summary
- generate synthesized top-level Program.Main even when a console compilation unit contains no global statements or declarations
- adjust binder setup to always create and cache a top-level binder for eligible console units
- add a regression test confirming an empty source file still emits a valid entry point

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: existing diagnostics/logging failures in the suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e3a11bf4832f9c7892fd0f39be0b)