### PR TITLE
Fix async await detection false positives

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
@@ -525,7 +525,8 @@ partial class BlockBinder
 
         if (isAsyncLambda && lambdaSymbol is SourceLambdaSymbol asyncLambda)
         {
-            var containsAwait = AsyncLowerer.ContainsAwait(bodyExpr);
+            var containsAwait = AsyncLowerer.ContainsAwait(bodyExpr) ||
+                Compilation.ContainsAwaitExpressionOutsideNestedFunctions(syntax.ExpressionBody);
             asyncLambda.SetContainsAwait(containsAwait);
 
             if (!containsAwait)

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -6508,7 +6508,8 @@ partial class BlockBinder : Binder
 
             if (symbol is SourceMethodSymbol { IsAsync: true } asyncMethod)
             {
-                var containsAwait = AsyncLowerer.ContainsAwait(boundBlock);
+                var containsAwait = AsyncLowerer.ContainsAwait(boundBlock) ||
+                    Compilation.ContainsAwaitExpressionOutsideNestedFunctions(function.ExpressionBody);
                 asyncMethod.SetContainsAwait(containsAwait);
 
                 if (!containsAwait)

--- a/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/MethodBodyBinder.cs
@@ -103,7 +103,8 @@ class MethodBodyBinder : BlockBinder
 
     private void AnalyzeAsyncBody(SyntaxNode bodySyntax, SourceMethodSymbol asyncMethod, BoundBlockStatement bound)
     {
-        var containsAwait = AsyncLowerer.ContainsAwait(bound);
+        var containsAwait = AsyncLowerer.ContainsAwait(bound) ||
+            Compilation.ContainsAwaitExpressionOutsideNestedFunctions(bodySyntax);
         asyncMethod.SetContainsAwait(containsAwait);
 
         if (containsAwait)

--- a/src/Raven.CodeAnalysis/Compilation.cs
+++ b/src/Raven.CodeAnalysis/Compilation.cs
@@ -279,21 +279,26 @@ public partial class Compilation
     internal static bool ContainsAwaitExpressionOutsideNestedFunctions(StatementSyntax statement)
     {
         return ContainsAwaitExpressionOutsideNestedFunctions((SyntaxNode)statement);
+    }
 
-        static bool ContainsAwaitExpressionOutsideNestedFunctions(SyntaxNode node)
+    internal static bool ContainsAwaitExpressionOutsideNestedFunctions(SyntaxNode node)
+    {
+        return ContainsAwaitExpressionOutsideNestedFunctionsCore(node);
+
+        static bool ContainsAwaitExpressionOutsideNestedFunctionsCore(SyntaxNode current)
         {
-            if (node is FunctionStatementSyntax or LambdaExpressionSyntax)
+            if (current is FunctionStatementSyntax or LambdaExpressionSyntax)
                 return false;
 
-            if (node.Kind == SyntaxKind.AwaitExpression)
+            if (current.Kind == SyntaxKind.AwaitExpression)
                 return true;
 
-            foreach (var child in node.ChildNodes())
+            foreach (var child in current.ChildNodes())
             {
                 if (child is FunctionStatementSyntax or LambdaExpressionSyntax)
                     continue;
 
-                if (ContainsAwaitExpressionOutsideNestedFunctions(child))
+                if (ContainsAwaitExpressionOutsideNestedFunctionsCore(child))
                     return true;
             }
 


### PR DESCRIPTION
## Summary
- add syntax-based fallback checks when computing async-await presence for methods, functions, and lambdas
- suppress AsyncLacksAwait diagnostics when the bound or syntax trees still contain awaits
- cover top-level async function scenarios with new tests mirroring the sample

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 --filter Analyze_TopLevelAsyncFunctionWithAwaitAndUnionMatch_FindsAwait
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: existing test Raven.CodeAnalysis.Semantics.Tests.LambdaInferenceTests.Lambda_WithoutParameterTypes_UsesTargetDelegateSignature due to missing Program.Main entry point)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e2ef0df8832f824addfa7c050863)