### PR TITLE
Add distinct highlighting for string interpolation delimiters

### DIFF
--- a/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
+++ b/src/Raven.CodeAnalysis.Console/Text/ConsoleSyntaxHighlighter.cs
@@ -19,6 +19,7 @@ public class ColorScheme
     public AnsiColor Type { get; internal set; }
     public AnsiColor Keyword { get; internal set; }
     public AnsiColor StringLiteral { get; internal set; }
+    public AnsiColor Interpolation { get; internal set; }
     public AnsiColor NumericLiteral { get; internal set; }
     public AnsiColor Comment { get; internal set; }
     public AnsiColor Field { get; internal set; }
@@ -38,6 +39,7 @@ public class ColorScheme
         Type = AnsiColor.Magenta,
         Keyword = AnsiColor.BrightBlue,
         StringLiteral = AnsiColor.BrightYellow,
+        Interpolation = AnsiColor.Cyan,
         NumericLiteral = AnsiColor.Yellow,
         Comment = AnsiColor.Green,
         Field = AnsiColor.Cyan,
@@ -58,6 +60,7 @@ public class ColorScheme
         Type = AnsiColor.BrightMagenta,
         Keyword = AnsiColor.BrightBlue,
         StringLiteral = AnsiColor.BrightRed,
+        Interpolation = AnsiColor.BrightCyan,
         NumericLiteral = AnsiColor.Red,
         Comment = AnsiColor.BrightGreen,
         Field = AnsiColor.Cyan,
@@ -365,6 +368,7 @@ public static class ConsoleSyntaxHighlighter
     {
         SemanticClassification.Keyword => ColorScheme.Keyword,
         SemanticClassification.StringLiteral => ColorScheme.StringLiteral,
+        SemanticClassification.Interpolation => ColorScheme.Interpolation,
         SemanticClassification.NumericLiteral => ColorScheme.NumericLiteral,
         SemanticClassification.Comment => ColorScheme.Comment,
         SemanticClassification.Method => ColorScheme.Method,

--- a/src/Raven.CodeAnalysis/SemanticClassifier.cs
+++ b/src/Raven.CodeAnalysis/SemanticClassifier.cs
@@ -21,12 +21,15 @@ public static class SemanticClassifier
             // Literals
             else if (kind == SyntaxKind.StringLiteralToken ||
                      kind == SyntaxKind.StringStartToken ||
-                     kind == SyntaxKind.StringEndToken ||
-                     kind == SyntaxKind.DollarToken ||
+                     kind == SyntaxKind.StringEndToken)
+            {
+                tokenMap[descendant] = SemanticClassification.StringLiteral;
+            }
+            else if (kind == SyntaxKind.DollarToken ||
                      (kind == SyntaxKind.OpenBraceToken && descendant.Parent is InterpolationSyntax) ||
                      (kind == SyntaxKind.CloseBraceToken && descendant.Parent is InterpolationSyntax))
             {
-                tokenMap[descendant] = SemanticClassification.StringLiteral;
+                tokenMap[descendant] = SemanticClassification.Interpolation;
             }
             else if (kind == SyntaxKind.NumericLiteralToken)
             {
@@ -128,6 +131,7 @@ public enum SemanticClassification
     Keyword,
     NumericLiteral,
     StringLiteral,
+    Interpolation,
     Comment,
     Namespace,
     Type,

--- a/src/Raven.Editor/CodeTextView.cs
+++ b/src/Raven.Editor/CodeTextView.cs
@@ -191,6 +191,7 @@ public class CodeTextView : TextView
         {
             SemanticClassification.Keyword => new(Color.BrightBlue, background),
             SemanticClassification.StringLiteral => new(Color.BrightGreen, background),
+            SemanticClassification.Interpolation => new(Color.Cyan, background),
             SemanticClassification.NumericLiteral => new(Color.BrightYellow, background),
             SemanticClassification.Comment => new(Color.Green, background),
             SemanticClassification.Method => new(Color.BrightYellow, background),

--- a/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/SemanticClassifierTests.cs
@@ -34,9 +34,9 @@ class C {
 
         result.Tokens[startQuote].ShouldBe(SemanticClassification.StringLiteral);
         result.Tokens[endQuote].ShouldBe(SemanticClassification.StringLiteral);
-        result.Tokens[dollar].ShouldBe(SemanticClassification.StringLiteral);
-        result.Tokens[openBrace].ShouldBe(SemanticClassification.StringLiteral);
-        result.Tokens[closeBrace].ShouldBe(SemanticClassification.StringLiteral);
+        result.Tokens[dollar].ShouldBe(SemanticClassification.Interpolation);
+        result.Tokens[openBrace].ShouldBe(SemanticClassification.Interpolation);
+        result.Tokens[closeBrace].ShouldBe(SemanticClassification.Interpolation);
     }
 
     [Fact]

--- a/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Text/ConsoleSyntaxHighlighterTests.cs
@@ -80,6 +80,41 @@ class Test {
     }
 
     [Fact]
+    public void InterpolatedString_UsesDistinctInterpolationColor()
+    {
+        var source = """
+class Test {
+    GetInfo(name: string) -> string {
+        return "Hello ${name}";
+    }
+}
+""";
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = Compilation.Create("test", [tree], TestMetadataReferences.Default, new CompilationOptions(OutputKind.ConsoleApplication));
+        var root = tree.GetRoot();
+
+        var originalScheme = ConsoleSyntaxHighlighter.ColorScheme;
+        try
+        {
+            ConsoleSyntaxHighlighter.ColorScheme = ColorScheme.Dark;
+
+            var text = root.WriteNodeToText(compilation);
+
+            var interpolationAnsi = $"\u001b[{(int)ConsoleSyntaxHighlighter.ColorScheme.Interpolation}m";
+            var stringAnsi = $"\u001b[{(int)ConsoleSyntaxHighlighter.ColorScheme.StringLiteral}m";
+
+            Assert.Contains(interpolationAnsi, text);
+            Assert.Contains(stringAnsi, text);
+            Assert.Contains($"{interpolationAnsi}$", text);
+            Assert.DoesNotContain($"{stringAnsi}$", text);
+        }
+        finally
+        {
+            ConsoleSyntaxHighlighter.ColorScheme = originalScheme;
+        }
+    }
+
+    [Fact]
     public void MethodInvocation_UsesMethodColor()
     {
         var source = """


### PR DESCRIPTION
## Summary
- add a dedicated interpolation color to the console/editor color schemes and map it in the syntax highlighter
- classify interpolation delimiters separately from string literals for semantic highlighting
- cover interpolation highlighting with an additional console syntax highlighter test

## Testing
- DOTNET_CLI_TERMINAL_WIDTH=120 dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 (fails: multiple existing test failures unrelated to interpolation highlighting; see logs for details)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933002fff6c832f93c3d660377ddefe)