### PR TITLE
Improve operator diagnostic formatting

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.Lambda.cs
@@ -517,6 +517,16 @@ partial class BlockBinder
                 returnType
             );
 
+        if (targetDelegate is not null &&
+            targetSignature is not null &&
+            targetSignature.Parameters.Length != parameterSymbols.Count)
+        {
+            _diagnostics.ReportCannotConvertFromTypeToType(
+                delegateType.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                targetDelegate.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                syntax.GetLocation());
+        }
+
         if (lambdaSymbol is SourceLambdaSymbol mutable)
         {
             mutable.SetReturnType(returnType);

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -3728,8 +3728,9 @@ partial class BlockBinder : Binder
         }
 
         // 4. Fel
+        var operatorText = SyntaxFacts.GetSyntaxTokenText(opKind) ?? opKind.ToString();
         _diagnostics.ReportOperatorCannotBeAppliedToOperandsOfTypes(
-            opKind.ToString(),
+            operatorText,
             left.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
             right.Type.ToDisplayStringKeywordAware(SymbolDisplayFormat.MinimallyQualifiedFormat),
             diagnosticLocation ?? Location.None);

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/ExpressionSyntaxParser.cs
@@ -1145,7 +1145,10 @@ internal class ExpressionSyntaxParser : SyntaxParser
             return DefaultExpression(defaultKeyword, openParenToken, type, closeParenToken);
         }
 
-        return DefaultExpression(defaultKeyword, null, null, null);
+        var missingOpenParen = MissingToken(SyntaxKind.OpenParenToken);
+        var missingCloseParen = MissingToken(SyntaxKind.CloseParenToken);
+
+        return DefaultExpression(defaultKeyword, missingOpenParen, null, missingCloseParen);
     }
 
     private ExpressionSyntax ParseTypeOfExpression()

--- a/test/Raven.CodeAnalysis.Tests/Semantics/BoundBinaryOperatorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/BoundBinaryOperatorTests.cs
@@ -28,4 +28,15 @@ public class BoundBinaryOperatorTests : CompilationTestBase
         var diagnostic = Assert.Single(compilation.GetDiagnostics());
         Assert.Equal(CompilerDiagnostics.OperatorCannotBeAppliedToOperandsOfTypes, diagnostic.Descriptor);
     }
+
+    [Fact]
+    public void Bind_InvalidOperator_UsesOperatorText()
+    {
+        var source = "let x = true < 1";
+        var (compilation, _) = CreateCompilation(source);
+
+        var diagnostic = Assert.Single(compilation.GetDiagnostics());
+
+        Assert.Equal("Operator '<' cannot be applied to operands of type 'bool' and 'int'", diagnostic.GetMessage());
+    }
 }


### PR DESCRIPTION
## Summary
- use the operator token text when reporting invalid binary operator diagnostics
- treat paren-less default expressions as using missing parentheses tokens
- surface lambda-to-function-type parameter count mismatches and add a regression test for operator diagnostic text

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: `IteratorILGenerationTests.MoveNext_DoesNotEmitStackClearingPops` expected IL differs)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330829b968832fa343a3c059082a11)