### PR TITLE
Bundle Raven.Core.dll by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Options:
 
 - `--framework <tfm>` &ndash; target framework
 - `--refs <path>` &ndash; additional metadata reference (repeatable)
+- `--raven-core <path>` &ndash; reference a specific `Raven.Core.dll`
+- `--emit-core-types-only` &ndash; embed Raven core shims instead of using `Raven.Core.dll`
 - `-o <path>` &ndash; output assembly path
 - `-s` &ndash; display the syntax tree (single file only)
 - `-d [plain|pretty[:no-diagnostics]]` &ndash; dump syntax (`plain` for raw text, `pretty` for highlighted syntax; append `:no-diagnostics` to skip underlines, single file only)
@@ -157,6 +159,8 @@ Options:
 - `-bt` &ndash; print the binder and bound tree (single file only)
 - `--symbols [list|hierarchy]` &ndash; inspect source symbols (`list` dumps properties, `hierarchy` prints the tree)
 - `-h`, `--help` &ndash; show help
+
+`ravc` now ships with and references `Raven.Core.dll` by default. The library is copied next to `ravc` during build, and any compilation also copies it to the output directory of the produced assembly. Use `--raven-core` to point to a different build of Raven.Core, or `--emit-core-types-only` to embed the shimmed core types instead of referencing the DLL.
 
 Creating a `.debug/` directory in the current or parent folder causes the
 compiler to emit per-file dumps (syntax tree, highlighted syntax, raw source,

--- a/src/Raven.Compiler/Raven.Compiler.csproj
+++ b/src/Raven.Compiler/Raven.Compiler.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <AssemblyName>ravc</AssemblyName>
+    <UseRavenCoreReference Condition="'$(UseRavenCoreReference)' == ''">true</UseRavenCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Raven.Core\Raven.Core.csproj" Condition="'$(UseRavenCoreReference)' == 'true'" />
     <ProjectReference Include="..\Raven.CodeAnalysis\Raven.CodeAnalysis.csproj" />
     <ProjectReference Include="..\Raven.CodeAnalysis.Console\Raven.CodeAnalysis.Console.csproj" />
   </ItemGroup>

--- a/src/Raven.Core/Raven.Core.csproj
+++ b/src/Raven.Core/Raven.Core.csproj
@@ -3,8 +3,11 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>false</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <OutputPath>$(MSBuildThisFileDirectory)bin/$(Configuration)/$(TargetFramework)/</OutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)bin/$(Configuration)/</OutputPath>
     <AssemblyName>None</AssemblyName>
+    <RavenCoreOutputDirectory>$(OutputPath)$(TargetFramework)/</RavenCoreOutputDirectory>
+    <TargetPath>$(RavenCoreOutputDirectory)Raven.Core.dll</TargetPath>
+    <BuiltProjectOutputGroupDependsOn>$(BuiltProjectOutputGroupDependsOn);CollectRavenCoreOutput</BuiltProjectOutputGroupDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,21 +15,30 @@
     <RavenSource Include="Result.rav" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Raven.Compiler\Raven.Compiler.csproj" />
-  </ItemGroup>
-
   <Target Name="CompileRavenCore"
     BeforeTargets="Build"
     Inputs="@(RavenSource)"
-    Outputs="$(OutputPath)Raven.Core.dll">
-    <MakeDir Directories="$(OutputPath)" />
+    Outputs="$(RavenCoreOutputDirectory)Raven.Core.dll">
+    <MakeDir Directories="$(RavenCoreOutputDirectory)" />
     <Exec
-      Command="dotnet run --project ../Raven.Compiler/Raven.Compiler.csproj -- --framework $(TargetFramework) --embed-core-types --output-type classlib -o &quot;$(OutputPath)Raven.Core.dll&quot; @(RavenSource->'&quot;%(FullPath)&quot;', ' ')" />
+      Command="dotnet run --project ../Raven.Compiler/Raven.Compiler.csproj -p:UseRavenCoreReference=false -- --emit-core-types-only --framework $(TargetFramework) --output-type classlib -o &quot;$(RavenCoreOutputDirectory)Raven.Core.dll&quot; @(RavenSource->'&quot;%(FullPath)&quot;', ' ')" />
   </Target>
 
   <Target Name="CleanRavenCore"
     BeforeTargets="Clean">
-    <RemoveDir Directories="$(OutputPath)" />
+    <RemoveDir Directories="$(RavenCoreOutputDirectory)" />
+  </Target>
+
+  <Target Name="CollectRavenCoreOutput">
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Include="$(RavenCoreOutputDirectory)Raven.Core.dll">
+        <TargetPath>Raven.Core.dll</TargetPath>
+      </BuiltProjectOutputGroupOutput>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveNoneAssembly" AfterTargets="Build">
+    <Delete Files="$(RavenCoreOutputDirectory)None.dll" />
+    <Delete Files="$(OutputPath)None.dll" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- default the CLI to use a bundled Raven.Core.dll and copy default assemblies into compilation outputs
- add new --emit-core-types-only escape-hatch flag
- introduce a conditional Raven.Core project reference with an opt-out property to avoid build cycles while letting ravc consume the core library by default
- rework the Raven.Core build to emit the generated Raven.Core.dll into the TF-specific output directory, surface it to consumers, and remove the placeholder None.dll during core-only generation
- update documentation to describe the new default bundling behavior and the CLI switches for overriding or embedding the core types

## Testing
- dotnet build --property WarningLevel=0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693320490310832f934046c6ce86d358)