### PR TITLE
Bind property expression bodies with method body binder

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -889,7 +889,7 @@ internal class TypeMemberBinder : Binder
         return type;
     }
 
-    public Dictionary<SyntaxNode, MethodBinder> BindPropertyDeclaration(PropertyDeclarationSyntax propertyDecl)
+    public Dictionary<SyntaxNode, Binder> BindPropertyDeclaration(PropertyDeclarationSyntax propertyDecl)
     {
         var propertyType = ResolveType(propertyDecl.Type.Type);
         var modifiers = propertyDecl.Modifiers;
@@ -1119,7 +1119,7 @@ internal class TypeMemberBinder : Binder
             }
         }
 
-        var binders = new Dictionary<SyntaxNode, MethodBinder>();
+        var binders = new Dictionary<SyntaxNode, Binder>();
 
         SourceMethodSymbol? getMethod = null;
         SourceMethodSymbol? setMethod = null;
@@ -1296,7 +1296,9 @@ internal class TypeMemberBinder : Binder
                 methodSymbol.SetOverriddenMethod(overriddenGetter);
 
             var binder = new MethodBinder(methodSymbol, this);
-            binders[propertyDecl.ExpressionBody!] = binder;
+            var expressionBodyBinder = new MethodBodyBinder(methodSymbol, binder);
+
+            binders[propertyDecl.ExpressionBody!] = expressionBodyBinder;
 
             getMethod = methodSymbol;
         }


### PR DESCRIPTION
## Summary
- ensure property expression-bodied accessors are bound using a method body binder
- widen property accessor binder cache to store the appropriate binder type

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 *(fails: TerminalLogger ArgumentOutOfRangeException after existing RAV1014 errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334a1dec64832f856abdd166e509b6)