### PR TITLE
Handle lambda argument error classification

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -4704,7 +4704,15 @@ partial class BlockBinder : Binder
         => expression is BoundErrorExpression;
 
     private static bool HasExpressionErrors(BoundExpression expression)
-        => IsErrorExpression(expression) || expression.Type?.ContainsErrorType() == true;
+    {
+        if (IsErrorExpression(expression))
+            return true;
+
+        if (expression is BoundLambdaExpression)
+            return false;
+
+        return expression.Type?.ContainsErrorType() == true;
+    }
 
     private BoundErrorExpression AsErrorExpression(BoundExpression expression)
     {


### PR DESCRIPTION
## Summary
- avoid treating lambda arguments as immediate errors so overload resolution can run

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 (fails: MoveNext_DoesNotEmitStackClearingPops and TerminalLogger exception)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933702d7524832f962578d8328377f2)