### PR TITLE
Add diagnostics for incomplete syntax tokens

### DIFF
--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -479,6 +479,10 @@
     Message="Continue statements are only valid inside loops" Category="compiler" Severity="Error"
     EnabledByDefault="true"
     Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV3600" Identifier="UnexpectedTokenInIncompleteSyntax"
+    Title="Unexpected token"
+    Message="Unexpected token '{token}'" Category="compiler" Severity="Error"
+    EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV3601" Identifier="UnmatchedCharacter"
     Title="Unmatched character"
     Message="Unmatched '{character}'" Category="compiler" Severity="Error"

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
@@ -272,15 +272,7 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
             IsPossibleCompilationUnitMemberStart(token) ||
             StatementSyntaxParser.IsTokenPotentialStatementStart(token));
 
-        // TEMP
-        if (skippedTokens.Any(x => x.IsKind(SyntaxKind.CloseBraceToken)))
-        {
-            AddDiagnostic(DiagnosticInfo.Create(
-                CompilerDiagnostics.UnmatchedCharacter,
-                span, '}'));
-        }
-
-        return CreateSkippedToken(skippedTokens);
+        return CreateSkippedToken(skippedTokens, span);
     }
 
     private SyntaxList ParseModifiers()

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/StatementSyntaxParser.cs
@@ -171,15 +171,7 @@ internal class StatementSyntaxParser : SyntaxParser
             SyntaxKind.LineFeedToken or SyntaxKind.CarriageReturnToken or SyntaxKind.CarriageReturnLineFeedToken ||
             IsTokenPotentialStatementStart(token));
 
-        var skippedToken = CreateSkippedToken(skippedTokens);
-
-        // TEMP
-        if (skippedTokens.Any(x => x.IsKind(SyntaxKind.CloseBraceToken)))
-        {
-            AddDiagnostic(DiagnosticInfo.Create(
-                CompilerDiagnostics.UnmatchedCharacter,
-                span, '}'));
-        }
+        var skippedToken = CreateSkippedToken(skippedTokens, span);
 
         return IncompleteStatement(skippedToken, Diagnostics);
     }

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -372,8 +372,28 @@ internal class SyntaxParser : ParseContext
         return skippedTokens;
     }
 
-    protected SyntaxToken CreateSkippedToken(List<SyntaxToken> skippedTokens)
+    protected SyntaxToken CreateSkippedToken(List<SyntaxToken> skippedTokens, TextSpan diagnosticSpan)
     {
+        if (skippedTokens.Count > 0)
+        {
+            var unexpectedToken = skippedTokens[0];
+            var unexpectedTokenDisplay = string.IsNullOrEmpty(unexpectedToken.Text)
+                ? unexpectedToken.Kind.ToString()
+                : unexpectedToken.Text;
+
+            if (unexpectedToken.IsKind(SyntaxKind.CloseBraceToken))
+            {
+                AddDiagnostic(DiagnosticInfo.Create(CompilerDiagnostics.UnmatchedCharacter, diagnosticSpan, '}'));
+            }
+            else
+            {
+                AddDiagnostic(DiagnosticInfo.Create(
+                    CompilerDiagnostics.UnexpectedTokenInIncompleteSyntax,
+                    diagnosticSpan,
+                    unexpectedTokenDisplay));
+            }
+        }
+
         var trivia = new SyntaxTrivia(new SkippedTokensTrivia(new SyntaxList(skippedTokens.ToArray())));
 
         return new SyntaxToken(

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/Test.cs
@@ -650,6 +650,26 @@ public class ParserNewlineTests
     }
 
     [Fact]
+    public void IncompleteStatement_UnexpectedToken_ReportsDiagnostic()
+    {
+        var syntaxTree = SyntaxTree.ParseText(")");
+
+        var diagnostic = syntaxTree.GetDiagnostics().Single();
+
+        diagnostic.Descriptor.ShouldBe(CompilerDiagnostics.UnexpectedTokenInIncompleteSyntax);
+    }
+
+    [Fact]
+    public void IncompleteStatement_UnmatchedBrace_ReportsDiagnostic()
+    {
+        var syntaxTree = SyntaxTree.ParseText("}");
+
+        var diagnostic = syntaxTree.GetDiagnostics().Single();
+
+        diagnostic.Descriptor.ShouldBe(CompilerDiagnostics.UnmatchedCharacter);
+    }
+
+    [Fact]
     public void Statement_InvalidTokenInBlock_SkipsUntilNextStatement()
     {
         var syntaxTree = SyntaxTree.ParseText("if (true) { ) if (true) return; }");


### PR DESCRIPTION
## Summary
- add a dedicated unexpected-token diagnostic when parsing incomplete syntax
- route unmatched '}' reporting through the shared skipped-token helper
- cover the new diagnostics with parser tests

## Testing
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal *(fails: diagnostic verification differences and TerminalLogger argument range error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427335cef8832f85ad99afd29a13f0)