### PR TITLE
Skip emitting synthesized Main without executable code

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/TypeGenerator.cs
@@ -484,6 +484,9 @@ internal class TypeGenerator
             {
                 case IMethodSymbol methodSymbol when methodSymbol.MethodKind is not (MethodKind.PropertyGet or MethodKind.PropertySet):
                     {
+                        if (methodSymbol is SynthesizedMainMethodSymbol { ContainsExecutableCode: false })
+                            break;
+
                         if (methodSymbol.MethodKind == MethodKind.LambdaMethod)
                             break;
 


### PR DESCRIPTION
## Summary
- avoid emitting synthesized Program.Main when there are no executable top-level statements
- keep user-defined Main methods from being duplicated alongside a generated entry point

## Testing
- dotnet build --property WarningLevel=0 *(fails: Raven.LanguageServer missing/ambiguous types during build)*
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal *(fails: conversion test failure and logger exception)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942baeefd68832fbc67c39b5784ba3e)