### PR TITLE
Fix Raven.LanguageServer compilation issues

### DIFF
--- a/src/Raven.LanguageServer/CompletionHandler.cs
+++ b/src/Raven.LanguageServer/CompletionHandler.cs
@@ -6,6 +6,8 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Text;
 using RavenCompletionItem = Raven.CodeAnalysis.CompletionItem;
+using LspCompletionItem = OmniSharp.Extensions.LanguageServer.Protocol.Models.CompletionItem;
+using TextDocumentSelector = OmniSharp.Extensions.LanguageServer.Protocol.Models.TextDocumentSelector;
 
 namespace Raven.LanguageServer;
 
@@ -22,7 +24,7 @@ internal sealed class CompletionHandler : ICompletionHandler
     public CompletionRegistrationOptions GetRegistrationOptions(CompletionCapability capability, ClientCapabilities clientCapabilities)
         => new()
         {
-            DocumentSelector = DocumentSelector.ForLanguage("raven"),
+            DocumentSelector = TextDocumentSelector.ForLanguage("raven"),
             TriggerCharacters = new Container<string>(".", ":", "(")
         };
 
@@ -50,10 +52,10 @@ internal sealed class CompletionHandler : ICompletionHandler
     {
     }
 
-    private static CompletionItem ToLspCompletion(RavenCompletionItem item, SourceText text)
+    private static LspCompletionItem ToLspCompletion(RavenCompletionItem item, SourceText text)
     {
         var range = PositionHelper.ToRange(text, item.ReplacementSpan);
-        return new CompletionItem
+        return new LspCompletionItem
         {
             Label = item.DisplayText,
             Detail = item.Description,

--- a/src/Raven.LanguageServer/DocumentStore.cs
+++ b/src/Raven.LanguageServer/DocumentStore.cs
@@ -5,10 +5,14 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
-using DiagnosticSeverity = Raven.CodeAnalysis.DiagnosticSeverity;
+using CodeDiagnostic = Raven.CodeAnalysis.Diagnostic;
+using CodeDiagnosticSeverity = Raven.CodeAnalysis.DiagnosticSeverity;
 using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
 using LspDiagnosticSeverity = OmniSharp.Extensions.LanguageServer.Protocol.Models.DiagnosticSeverity;
+using LspRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+using SyntaxTree = Raven.CodeAnalysis.Syntax.SyntaxTree;
 
 namespace Raven.LanguageServer;
 
@@ -106,7 +110,7 @@ internal sealed class DocumentStore
         }
     }
 
-    private static bool ShouldReport(Diagnostic diagnostic, SyntaxTree syntaxTree)
+    private static bool ShouldReport(CodeDiagnostic diagnostic, SyntaxTree syntaxTree)
     {
         if (diagnostic.Location.SourceTree is null)
             return false;
@@ -114,10 +118,10 @@ internal sealed class DocumentStore
         return diagnostic.Location.SourceTree == syntaxTree;
     }
 
-    private static LspDiagnostic MapDiagnostic(Diagnostic diagnostic)
+    private static LspDiagnostic MapDiagnostic(CodeDiagnostic diagnostic)
     {
         var lineSpan = diagnostic.Location.GetLineSpan();
-        var range = new Range(
+        var range = new LspRange(
             new Position(lineSpan.StartLinePosition.Line, lineSpan.StartLinePosition.Character),
             new Position(lineSpan.EndLinePosition.Line, lineSpan.EndLinePosition.Character));
 
@@ -130,13 +134,13 @@ internal sealed class DocumentStore
         };
     }
 
-    private static LspDiagnosticSeverity? MapSeverity(DiagnosticSeverity severity)
+    private static LspDiagnosticSeverity? MapSeverity(CodeDiagnosticSeverity severity)
         => severity switch
         {
-            DiagnosticSeverity.Error => LspDiagnosticSeverity.Error,
-            DiagnosticSeverity.Warning => LspDiagnosticSeverity.Warning,
-            DiagnosticSeverity.Info => LspDiagnosticSeverity.Information,
-            DiagnosticSeverity.Hidden => LspDiagnosticSeverity.Hint,
+            CodeDiagnosticSeverity.Error => LspDiagnosticSeverity.Error,
+            CodeDiagnosticSeverity.Warning => LspDiagnosticSeverity.Warning,
+            CodeDiagnosticSeverity.Info => LspDiagnosticSeverity.Information,
+            CodeDiagnosticSeverity.Hidden => LspDiagnosticSeverity.Hint,
             _ => null
         };
 }

--- a/src/Raven.LanguageServer/PositionHelper.cs
+++ b/src/Raven.LanguageServer/PositionHelper.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Text;
+using LspRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Raven.LanguageServer;
 
@@ -21,14 +23,14 @@ internal static class PositionHelper
         return Math.Min(lineStart + character, content.Length);
     }
 
-    public static Range ToRange(SourceText text, TextSpan span)
+    public static LspRange ToRange(SourceText text, TextSpan span)
     {
         var content = text.ToString();
         var lineStarts = TextUtils.ComputeLineStarts(content);
         var (startLine, startChar) = GetLinePosition(lineStarts, span.Start);
         var (endLine, endChar) = GetLinePosition(lineStarts, span.End);
 
-        return new Range(new Position(startLine, startChar), new Position(endLine, endChar));
+        return new LspRange(new Position(startLine, startChar), new Position(endLine, endChar));
     }
 
     private static (int line, int character) GetLinePosition(List<int> lineStarts, int position)

--- a/src/Raven.LanguageServer/Program.cs
+++ b/src/Raven.LanguageServer/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Raven.CodeAnalysis;
+using OmniLanguageServer = OmniSharp.Extensions.LanguageServer.Server.LanguageServer;
 
 namespace Raven.LanguageServer;
 
@@ -11,13 +12,13 @@ internal static class Program
     {
         var workspace = RavenWorkspace.Create();
 
-        var server = await LanguageServer.From(options =>
+        var server = await OmniLanguageServer.From(options =>
         {
             options
                 .WithInput(Console.OpenStandardInput())
                 .WithOutput(Console.OpenStandardOutput())
                 .ConfigureLogging(b => b.AddConsole())
-                .ConfigureServices(services =>
+                .WithServices(services =>
                 {
                     services.AddSingleton(workspace);
                     services.AddSingleton<DocumentStore>();

--- a/src/Raven.LanguageServer/Raven.LanguageServer.csproj
+++ b/src/Raven.LanguageServer/Raven.LanguageServer.csproj
@@ -7,6 +7,7 @@
     <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="OmniSharp.Extensions.LanguageProtocol" Version="0.19.9" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
   </ItemGroup>

--- a/src/Raven.LanguageServer/RavenTextDocumentSyncHandler.cs
+++ b/src/Raven.LanguageServer/RavenTextDocumentSyncHandler.cs
@@ -5,6 +5,9 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using SaveOptions = OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities.SaveOptions;
+using TextDocumentSelector = OmniSharp.Extensions.LanguageServer.Protocol.Models.TextDocumentSelector;
+using TextDocumentSyncKind = OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities.TextDocumentSyncKind;
 
 namespace Raven.LanguageServer;
 
@@ -50,29 +53,15 @@ internal sealed class RavenTextDocumentSyncHandler : TextDocumentSyncHandlerBase
     public override Task<Unit> Handle(DidSaveTextDocumentParams notification, CancellationToken cancellationToken)
         => PublishDiagnosticsAsync(notification.TextDocument.Uri, cancellationToken);
 
-    public override TextDocumentSyncKind Change => TextDocumentSyncKind.Full;
-
-    public override TextDocumentAttributes GetTextDocumentAttributes(TextDocumentIdentifier identifier)
-        => new(identifier.Uri, "raven");
-
-    public override TextDocumentChangeRegistrationOptions GetRegistrationOptions(SynchronizationCapability capability, ClientCapabilities clientCapabilities)
+    protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(TextSynchronizationCapability capability, ClientCapabilities clientCapabilities)
         => new()
         {
-            DocumentSelector = DocumentSelector.ForLanguage("raven"),
-            SyncKind = Change
-        };
-
-    public override Task<Unit> Handle(WillSaveTextDocumentParams notification, CancellationToken cancellationToken)
-        => Task.FromResult(Unit.Value);
-
-    public override Task<Unit> Handle(WillSaveWaitUntilTextDocumentParams notification, CancellationToken cancellationToken)
-        => Task.FromResult(Unit.Value);
-
-    public override TextDocumentSaveRegistrationOptions CreateRegistrationOptions(TextDocumentSaveCapability capability, ClientCapabilities clientCapabilities)
-        => new()
-        {
-            IncludeText = true,
-            DocumentSelector = DocumentSelector.ForLanguage("raven"),
+            DocumentSelector = TextDocumentSelector.ForLanguage("raven"),
+            Change = TextDocumentSyncKind.Full,
+            Save = new SaveOptions
+            {
+                IncludeText = true
+            }
         };
 
     private async Task<Unit> PublishDiagnosticsAsync(DocumentUri uri, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- resolve namespace conflicts and update Language Server registration to the current OmniSharp API
- disambiguate Raven diagnostics and syntax types when mapping to LSP structures
- add logging dependency and align service registration to restore LanguageServer build

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal *(fails: existing IncrementDecrementTests expectation)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942be972ca8832fbcee9b865a7ba902)