### PR TITLE
Ensure async entry point bridge is generated before emission

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -723,14 +723,20 @@ internal class CodeGenerator
 
             EmitMemberILBodies();
 
-            CreateTypes();
-
             if (entryPointGenerator is null)
             {
                 entryPointGenerator = _typeGenerators.Values
-                    .SelectMany(x => x.MethodGenerators)
-                    .FirstOrDefault(x => x.IsEntryPointCandidate);
+                    .SelectMany(generator => generator.MethodGenerators)
+                    .FirstOrDefault(generator => generator.IsEntryPointCandidate);
             }
+
+            if (entryPointGenerator is not null && !entryPointGenerator.HasEmittedBody)
+            {
+                CurrentEmittingMethod = entryPointGenerator.MethodSymbol;
+                entryPointGenerator.EmitBody();
+            }
+
+            CreateTypes();
 
             EntryPoint = entryPointGenerator?.MethodBase;
 

--- a/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/CodeGeneratorTests.cs
@@ -26,12 +26,7 @@ class Foo {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -77,12 +72,7 @@ class Helper {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -121,12 +111,7 @@ class Helper {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -168,12 +153,7 @@ async func Main() -> Task<int> {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -216,12 +196,7 @@ async func Main() -> Task {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -283,12 +258,7 @@ class Helper {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -315,12 +285,7 @@ let x = if true {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -348,12 +313,7 @@ class Foo : IFoo {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)
@@ -397,12 +357,7 @@ class Foo : IDisposable {
 
         var syntaxTree = SyntaxTree.ParseText(code);
 
-        var version = TargetFrameworkResolver.ResolveVersion(TestTargetFramework.Default);
-
-        var runtimePath = TargetFrameworkResolver.GetRuntimeDll(version);
-
-        MetadataReference[] references = [
-                MetadataReference.CreateFromFile(runtimePath)];
+        var references = TestMetadataReferences.Default;
 
         var compilation = Compilation.Create("test", new CompilationOptions(OutputKind.ConsoleApplication))
             .AddSyntaxTrees(syntaxTree)


### PR DESCRIPTION
## Summary
- compute the compilation entry point before building members so async bridge methods are available

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal *(fails: existing LambdaInferenceTests and logger crash)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942cf6336ac832fbb6d03e5380590e9)