### PR TITLE
Fix metadata type parameter display filtering

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
@@ -636,8 +636,10 @@ public static partial class SymbolExtensions
             else
             {
                 // Unconstructed type: fall back to parameter names declared on this type
+                var declaringType = typeSymbol.OriginalDefinition;
+
                 arguments = typeSymbol.TypeParameters
-                    .Where(p => SymbolEqualityComparer.Default.Equals(p.ContainingSymbol, typeSymbol))
+                    .Where(p => SymbolEqualityComparer.Default.Equals(p.ContainingSymbol, declaringType))
                     .Select(p => EscapeIdentifierIfNeeded(p.Name, format));
             }
 

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SymbolDisplayOptionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SymbolDisplayOptionTests.cs
@@ -158,4 +158,16 @@ class Sample {
             "Task.Run<TResult>(function: Func<Task<TResult>>) -> Task<TResult>",
             run.ToDisplayString(format));
     }
+
+    [Fact]
+    public void TypeDisplay_UsesDeclaringTypeParametersFromMetadata()
+    {
+        var compilation = CreateCompilation();
+        var taskType = Assert.IsAssignableFrom<INamedTypeSymbol>(
+            compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1"));
+
+        var display = taskType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+
+        Assert.Equal("Task<TResult>", display);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure symbol display uses the declaring type definition when choosing fallback type parameters for unconstructed generic types
- add a regression test covering metadata generic types such as Task<TResult>

## Testing
- dotnet build --property WarningLevel=0
- dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal *(fails: SyntaxNodeTest.ReplaceNodeWithMultipleNodes Shouldly assertion and terminal logger error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942f6c2befc832f90def79586d5758b)