### PR TITLE
CLI: add --doc-tool to select RavenDoc and emit RavenDoc output

### DIFF
--- a/src/Raven.Compiler/Raven.Compiler.csproj
+++ b/src/Raven.Compiler/Raven.Compiler.csproj
@@ -19,5 +19,6 @@
     <ProjectReference Include="..\Raven.Core\Raven.Core.csproj" Condition="'$(UseRavenCoreReference)' == 'true'" />
     <ProjectReference Include="..\Raven.CodeAnalysis\Raven.CodeAnalysis.csproj" />
     <ProjectReference Include="..\Raven.CodeAnalysis.Console\Raven.CodeAnalysis.Console.csproj" />
+    <ProjectReference Include="..\RavenDoc\RavenDoc.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Motivation
- Allow the compiler CLI to invoke the RavenDoc documentation generator so HTML documentation can be produced as part of the CLI workflow.
- Make RavenDoc the default documentation tool while preserving the existing comment-emitter path for emitting markdown/xml comment artifacts.
- Place generated RavenDoc output next to the emitted assembly by default for convenient consumption.

### Description
- Added a `--doc-tool` CLI option and `DocumentationTool` enum to select between `RavenDoc` (default) and the existing comment emitter, with a `TryParseDocumentationTool` helper to parse the option.
- When `--doc-tool` is `ravendoc`, the CLI now calls `DocumentationGenerator.ProcessCompilation(compilation, outputPath)` and defaults the `documentationOutputPath` to `Path.Combine(outputDirectory, $"{assemblyName}.docs")`.
- Added `documentationFormatExplicitlySet` logic and a warning to ignore `--doc-format xml` when `RavenDoc` is selected because RavenDoc only supports Markdown.
- Added a project reference to `RavenDoc` in `src/Raven.Compiler/Raven.Compiler.csproj` and updated help text for `--doc-tool` and `--doc-format`.

### Testing
- Attempted to refresh generated code via the repository generators with `dotnet run` but `dotnet` was not available in the environment so generators were not executed (failed).
- Attempted to run `dotnet build --property WarningLevel=0` but `dotnet` was not available so build was not executed (failed).
- Attempted to run `dotnet test test/Raven.CodeAnalysis.Tests` but `dotnet` was not available so tests were not executed (failed).
- No automated tests were run successfully in this environment; change was committed locally and ready for CI verification where `dotnet` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e77f69ab4832f8e76a9910e7828ba)