### PR TITLE
Add static extension member lookup and tests

### DIFF
--- a/docs/lang/proposals/drafts/conversion-from-option-to-nullable.md
+++ b/docs/lang/proposals/drafts/conversion-from-option-to-nullable.md
@@ -202,6 +202,7 @@ This proposal assumes the following language features, each of which deserves it
 
      * Methods declared directly on the type.
      * Static extension members for that type.
+   * Static extension members participate in `TargetType.Member` lookup and are also imported via `import TargetType.*`.
 
 Without those, this proposal is not implementable, but it serves as a concrete motivating use case for them.
 

--- a/docs/lang/proposals/drafts/static-extension-members.md
+++ b/docs/lang/proposals/drafts/static-extension-members.md
@@ -18,6 +18,15 @@ class Foo {}
 
 Static methods and static properties.
 
+## Lookup
+
+Static extension members participate in static member lookup. When binding
+`Type.Member`, the compiler first resolves real static members on `Type`. If no
+match is found, it searches in-scope extension containers whose receiver type is
+compatible with `Type` (including implicit conversions and nullability).
+Wildcard-importing the target type (`import Type.*`) also brings static
+extension members into unqualified lookup.
+
 ## Interesting points
 
 Allow for operator overloading via extensions: incl. operators, conversion, indexers, callable.

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -645,8 +645,8 @@ the first argument whenever the member is invoked. The `self` parameter behaves
 like a `let` binding: it cannot be reassigned but may be used to access members
 or forwarded to other calls. Extension members default to `public`
 accessibility and may be marked `internal` to restrict their visibility; other
-modifiers are rejected. As a result, extensions cannot declare `protected`,
-`private`, or `static` members.
+modifiers are rejected. As a result, extensions cannot declare `protected` or
+`private` members.
 
 #### Extension methods
 
@@ -718,6 +718,19 @@ extension ListExt for List<int>
     }
 }
 ```
+
+#### Static extension members
+
+Extensions may also declare `static` methods and properties. Static extension
+members are associated with the receiver type and are accessed through static
+member lookup (`Type.Member`) or by importing the target type (`import
+Type.*`). When binding a static member access, the compiler first resolves real
+static members on the type; if no match is found, it searches in-scope extension
+containers whose receiver type is compatible with the target type. Receiver
+compatibility follows the same implicit conversion and nullability rules used
+for extension methods, so constructed and nested types participate normally.
+Static extension members do not synthesize `self` and are emitted as ordinary
+static members on the extension container.
 
 #### Pipe operator
 

--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -215,6 +215,28 @@ internal abstract class Binder
         return ParentBinder?.LookupExtensionProperties(name, receiverType, includePartialMatches) ?? Enumerable.Empty<IPropertySymbol>();
     }
 
+    public virtual IEnumerable<IMethodSymbol> LookupExtensionStaticMethods(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
+    {
+        if (receiverType is null)
+            return Enumerable.Empty<IMethodSymbol>();
+
+        if (receiverType.TypeKind == TypeKind.Error)
+            return Enumerable.Empty<IMethodSymbol>();
+
+        return ParentBinder?.LookupExtensionStaticMethods(name, receiverType, includePartialMatches) ?? Enumerable.Empty<IMethodSymbol>();
+    }
+
+    public virtual IEnumerable<IPropertySymbol> LookupExtensionStaticProperties(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
+    {
+        if (receiverType is null)
+            return Enumerable.Empty<IPropertySymbol>();
+
+        if (receiverType.TypeKind == TypeKind.Error)
+            return Enumerable.Empty<IPropertySymbol>();
+
+        return ParentBinder?.LookupExtensionStaticProperties(name, receiverType, includePartialMatches) ?? Enumerable.Empty<IPropertySymbol>();
+    }
+
     protected IEnumerable<IMethodSymbol> GetExtensionMethodsFromScope(
         INamespaceOrTypeSymbol scope,
         string? name,
@@ -251,6 +273,42 @@ internal abstract class Binder
         }
     }
 
+    protected IEnumerable<IMethodSymbol> GetExtensionStaticMethodsFromScope(
+        INamespaceOrTypeSymbol scope,
+        string? name,
+        ITypeSymbol receiverType,
+        bool includePartialMatches)
+    {
+        foreach (var method in EnumerateExtensionStaticMethods(scope, name, includePartialMatches))
+        {
+            if (!IsExtensionStaticCandidateForReceiver(method, receiverType, includePartialMatches))
+                continue;
+
+            if (!IsSymbolAccessible(method))
+                continue;
+
+            yield return AdjustExtensionStaticMethodForReceiver(method, receiverType);
+        }
+    }
+
+    protected IEnumerable<IPropertySymbol> GetExtensionStaticPropertiesFromScope(
+        INamespaceOrTypeSymbol scope,
+        string? name,
+        ITypeSymbol receiverType,
+        bool includePartialMatches)
+    {
+        foreach (var property in EnumerateExtensionStaticProperties(scope, name, includePartialMatches))
+        {
+            if (!IsExtensionStaticCandidateForReceiver(property, receiverType, includePartialMatches))
+                continue;
+
+            if (!IsSymbolAccessible(property))
+                continue;
+
+            yield return AdjustExtensionStaticPropertyForReceiver(property, receiverType);
+        }
+    }
+
     private IMethodSymbol AdjustExtensionForReceiver(IMethodSymbol method, ITypeSymbol receiverType)
     {
         if (!method.IsExtensionMethod || receiverType is null || receiverType.TypeKind == TypeKind.Error)
@@ -272,6 +330,59 @@ internal abstract class Binder
             return property;
 
         if (!TryCreateConstructedExtension(accessor, receiverType, out var constructedAccessor))
+            return property;
+
+        if (constructedAccessor.ContainingSymbol is IPropertySymbol constructedProperty)
+            return constructedProperty;
+
+        if (constructedAccessor.ContainingType is INamedTypeSymbol containingType)
+        {
+            var propertyAccessorDefinition = (property.GetMethod ?? property.SetMethod)?.OriginalDefinition
+                ?? property.GetMethod
+                ?? property.SetMethod;
+
+            var propertyCandidate = containingType
+                .GetMembers(property.Name)
+                .OfType<IPropertySymbol>()
+                .FirstOrDefault(candidate =>
+                {
+                    var candidateAccessor = (candidate.GetMethod ?? candidate.SetMethod)?.OriginalDefinition
+                        ?? candidate.GetMethod
+                        ?? candidate.SetMethod;
+
+                    return propertyAccessorDefinition is not null &&
+                        candidateAccessor is not null &&
+                        SymbolEqualityComparer.Default.Equals(candidateAccessor, propertyAccessorDefinition);
+                });
+
+            if (propertyCandidate is not null)
+                return propertyCandidate;
+        }
+
+        return property;
+    }
+
+    private IMethodSymbol AdjustExtensionStaticMethodForReceiver(IMethodSymbol method, ITypeSymbol receiverType)
+    {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            return method;
+
+        if (!TryCreateConstructedStaticExtension(method, receiverType, out var constructed))
+            return method;
+
+        return constructed;
+    }
+
+    private IPropertySymbol AdjustExtensionStaticPropertyForReceiver(IPropertySymbol property, ITypeSymbol receiverType)
+    {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            return property;
+
+        var accessor = property.GetMethod ?? property.SetMethod;
+        if (accessor is null)
+            return property;
+
+        if (!TryCreateConstructedStaticExtension(accessor, receiverType, out var constructedAccessor))
             return property;
 
         if (constructedAccessor.ContainingSymbol is IPropertySymbol constructedProperty)
@@ -357,6 +468,59 @@ internal abstract class Binder
         return false;
     }
 
+    private bool TryCreateConstructedStaticExtension(IMethodSymbol method, ITypeSymbol receiverType, out IMethodSymbol constructed)
+    {
+        constructed = method;
+
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            return false;
+
+        if (method.ContainingType is not INamedTypeSymbol container)
+            return false;
+
+        var containerDefinition = container.ConstructedFrom ?? container;
+        if (!containerDefinition.IsGenericType || containerDefinition.TypeParameters.IsDefaultOrEmpty || containerDefinition.TypeParameters.Length == 0)
+            return false;
+
+        var receiverTypeSyntax = containerDefinition.GetExtensionReceiverType();
+        if (receiverTypeSyntax is null || receiverTypeSyntax.TypeKind == TypeKind.Error)
+            return false;
+
+        var substitutions = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(SymbolEqualityComparer.Default);
+
+        if (!TryUnifyExtensionReceiver(receiverTypeSyntax, receiverType, substitutions))
+            return false;
+
+        var typeArguments = new ITypeSymbol[containerDefinition.TypeParameters.Length];
+
+        for (int i = 0; i < containerDefinition.TypeParameters.Length; i++)
+        {
+            var typeParameter = containerDefinition.TypeParameters[i];
+            if (!substitutions.TryGetValue(typeParameter, out var typeArgument))
+                return false;
+
+            typeArguments[i] = typeArgument;
+        }
+
+        var constructedContainer = containerDefinition.Construct(typeArguments);
+        if (constructedContainer is not INamedTypeSymbol namedContainer)
+            return false;
+
+        var originalDefinition = method.OriginalDefinition ?? method;
+
+        foreach (var candidate in namedContainer.GetMembers(method.Name).OfType<IMethodSymbol>())
+        {
+            var candidateOriginal = candidate.OriginalDefinition ?? candidate;
+            if (SymbolEqualityComparer.Default.Equals(candidateOriginal, originalDefinition))
+            {
+                constructed = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private bool IsExtensionPropertyCandidateForReceiver(
         IPropertySymbol property,
         ITypeSymbol receiverType,
@@ -386,6 +550,37 @@ internal abstract class Binder
             return true;
 
         var conversion = Compilation.ClassifyConversion(receiverType, parameterType);
+        return conversion.Exists && conversion.IsImplicit;
+    }
+
+    private bool IsExtensionStaticCandidateForReceiver(
+        ISymbol member,
+        ITypeSymbol receiverType,
+        bool includePartialMatches)
+    {
+        if (member.ContainingType is not INamedTypeSymbol containingType)
+            return false;
+
+        var extensionReceiverType = containingType.GetExtensionReceiverType();
+        if (extensionReceiverType is null)
+            return false;
+
+        if (includePartialMatches)
+            return true;
+
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            return true;
+
+        if (extensionReceiverType.TypeKind == TypeKind.Error)
+            return true;
+
+        if (ContainsTypeParameters(extensionReceiverType))
+            return true;
+
+        if (SymbolEqualityComparer.Default.Equals(extensionReceiverType, receiverType))
+            return true;
+
+        var conversion = Compilation.ClassifyConversion(receiverType, extensionReceiverType);
         return conversion.Exists && conversion.IsImplicit;
     }
 
@@ -615,6 +810,58 @@ internal abstract class Binder
         }
     }
 
+    private static IEnumerable<IMethodSymbol> EnumerateExtensionStaticMethods(
+        INamespaceOrTypeSymbol scope,
+        string? name,
+        bool includePartialMatches)
+    {
+        if (scope is INamespaceSymbol ns)
+        {
+            foreach (var member in ns.GetMembers())
+            {
+                if (member is INamedTypeSymbol typeMember)
+                {
+                    foreach (var method in EnumerateExtensionStaticMethods(typeMember, name, includePartialMatches))
+                        yield return method;
+                }
+                else if (member is INamespaceSymbol nestedNs)
+                {
+                    foreach (var method in EnumerateExtensionStaticMethods(nestedNs, name, includePartialMatches))
+                        yield return method;
+                }
+            }
+
+            yield break;
+        }
+
+        if (scope is not INamedTypeSymbol type)
+            yield break;
+
+        if (type.GetExtensionReceiverType() is null)
+            yield break;
+
+        var members = includePartialMatches || string.IsNullOrEmpty(name)
+            ? type.GetMembers().OfType<IMethodSymbol>()
+            : type.GetMembers(name!).OfType<IMethodSymbol>();
+
+        foreach (var member in members)
+        {
+            if (member.IsExtensionMethod || !member.IsStatic)
+                continue;
+
+            if (!includePartialMatches && name is not null && member.Name != name)
+                continue;
+
+            yield return member;
+        }
+
+        foreach (var nested in type.GetMembers().OfType<INamedTypeSymbol>())
+        {
+            foreach (var method in EnumerateExtensionStaticMethods(nested, name, includePartialMatches))
+                yield return method;
+        }
+    }
+
     private static IEnumerable<IPropertySymbol> EnumerateExtensionProperties(
         INamespaceOrTypeSymbol scope,
         string? name,
@@ -660,6 +907,58 @@ internal abstract class Binder
         foreach (var nested in type.GetMembers().OfType<INamedTypeSymbol>())
         {
             foreach (var property in EnumerateExtensionProperties(nested, name, includePartialMatches))
+                yield return property;
+        }
+    }
+
+    private static IEnumerable<IPropertySymbol> EnumerateExtensionStaticProperties(
+        INamespaceOrTypeSymbol scope,
+        string? name,
+        bool includePartialMatches)
+    {
+        if (scope is INamespaceSymbol ns)
+        {
+            foreach (var member in ns.GetMembers())
+            {
+                if (member is INamedTypeSymbol typeMember)
+                {
+                    foreach (var property in EnumerateExtensionStaticProperties(typeMember, name, includePartialMatches))
+                        yield return property;
+                }
+                else if (member is INamespaceSymbol nestedNs)
+                {
+                    foreach (var property in EnumerateExtensionStaticProperties(nestedNs, name, includePartialMatches))
+                        yield return property;
+                }
+            }
+
+            yield break;
+        }
+
+        if (scope is not INamedTypeSymbol type)
+            yield break;
+
+        if (type.GetExtensionReceiverType() is null)
+            yield break;
+
+        var members = includePartialMatches || string.IsNullOrEmpty(name)
+            ? type.GetMembers().OfType<IPropertySymbol>()
+            : type.GetMembers(name!).OfType<IPropertySymbol>();
+
+        foreach (var property in members)
+        {
+            if (property.IsExtensionProperty() || !property.IsStatic)
+                continue;
+
+            if (!includePartialMatches && name is not null && property.Name != name)
+                continue;
+
+            yield return property;
+        }
+
+        foreach (var nested in type.GetMembers().OfType<INamedTypeSymbol>())
+        {
+            foreach (var property in EnumerateExtensionStaticProperties(nested, name, includePartialMatches))
                 yield return property;
         }
     }

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -80,4 +80,50 @@ class NamespaceBinder : Binder
             if (seen.Add(property))
                 yield return property;
     }
+
+    public override IEnumerable<IMethodSymbol> LookupExtensionStaticMethods(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
+    {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            yield break;
+
+        var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var method in GetExtensionStaticMethodsFromScope(_namespaceSymbol, name, receiverType, includePartialMatches))
+            if (seen.Add(method))
+                yield return method;
+
+        foreach (var declaredType in _declaredTypes)
+        {
+            foreach (var method in GetExtensionStaticMethodsFromScope(declaredType, name, receiverType, includePartialMatches))
+                if (seen.Add(method))
+                    yield return method;
+        }
+
+        foreach (var method in base.LookupExtensionStaticMethods(name, receiverType, includePartialMatches))
+            if (seen.Add(method))
+                yield return method;
+    }
+
+    public override IEnumerable<IPropertySymbol> LookupExtensionStaticProperties(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
+    {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            yield break;
+
+        var seen = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var property in GetExtensionStaticPropertiesFromScope(_namespaceSymbol, name, receiverType, includePartialMatches))
+            if (seen.Add(property))
+                yield return property;
+
+        foreach (var declaredType in _declaredTypes)
+        {
+            foreach (var property in GetExtensionStaticPropertiesFromScope(declaredType, name, receiverType, includePartialMatches))
+                if (seen.Add(property))
+                    yield return property;
+        }
+
+        foreach (var property in base.LookupExtensionStaticProperties(name, receiverType, includePartialMatches))
+            if (seen.Add(property))
+                yield return property;
+    }
 }

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -1727,6 +1727,12 @@ public partial class SemanticModel
 
     private void RegisterExtensionMembers(ExtensionDeclarationSyntax extensionDecl, ExtensionDeclarationBinder extensionBinder)
     {
+        if (extensionBinder.ContainingSymbol is SourceNamedTypeSymbol extensionSymbol)
+        {
+            var receiverType = extensionBinder.ResolveType(extensionDecl.ReceiverType);
+            extensionSymbol.SetExtensionReceiverType(receiverType);
+        }
+
         foreach (var member in extensionDecl.Members)
         {
             switch (member)

--- a/src/Raven.CodeAnalysis/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/SymbolExtensions.cs
@@ -93,4 +93,15 @@ public static partial class SymbolExtensions
             _ => null
         };
     }
+
+    public static ITypeSymbol? GetExtensionReceiverType(this INamedTypeSymbol type)
+    {
+        return type switch
+        {
+            SourceNamedTypeSymbol sourceType when sourceType.IsExtensionDeclaration => sourceType.ExtensionReceiverType,
+            ConstructedNamedTypeSymbol constructed when constructed.OriginalDefinition is SourceNamedTypeSymbol sourceType
+                => sourceType.ExtensionReceiverType is { } receiverType ? constructed.Substitute(receiverType) : null,
+            _ => null
+        };
+    }
 }

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -13,6 +13,7 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     private ImmutableArray<INamedTypeSymbol>? _allInterfaces;
     private ImmutableArray<ITypeParameterSymbol> _typeParameters = ImmutableArray<ITypeParameterSymbol>.Empty;
     private ImmutableArray<ITypeSymbol> _typeArguments = ImmutableArray<ITypeSymbol>.Empty;
+    private ITypeSymbol? _extensionReceiverType;
 
     public SourceNamedTypeSymbol(string name, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations, SyntaxReference[] declaringSyntaxReferences, Accessibility declaredAccessibility = Accessibility.NotApplicable)
         : base(SymbolKind.Type, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences, declaredAccessibility)
@@ -70,6 +71,7 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     public bool HasNonPartialDeclaration { get; private set; }
 
     public bool IsExtensionDeclaration { get; private set; }
+    internal ITypeSymbol? ExtensionReceiverType => _extensionReceiverType;
 
     public ImmutableArray<INamedTypeSymbol> Interfaces => _interfaces;
     public ImmutableArray<INamedTypeSymbol> AllInterfaces =>
@@ -185,6 +187,14 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     {
         IsExtensionDeclaration = true;
         IsSealed = true;
+    }
+
+    internal void SetExtensionReceiverType(ITypeSymbol? receiverType)
+    {
+        if (!IsExtensionDeclaration)
+            return;
+
+        _extensionReceiverType = receiverType;
     }
 
     internal void SetTypeParameters(IEnumerable<ITypeParameterSymbol> typeParameters)

--- a/test/Raven.CodeAnalysis.Tests/Semantics/StaticExtensionMemberSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/StaticExtensionMemberSemanticTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public sealed class StaticExtensionMemberSemanticTests : CompilationTestBase
+{
+    [Fact]
+    public void StaticExtensionMethod_QualifiedLookup_BindsToExtensionContainer()
+    {
+        const string source = """
+class Widget { }
+
+extension WidgetExtensions for Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+let created = Widget.Build(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var methodDecl = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "Build");
+        var methodSymbol = Assert.IsAssignableFrom<IMethodSymbol>(model.GetDeclaredSymbol(methodDecl));
+
+        Assert.False(methodSymbol.IsExtensionMethod);
+
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        Assert.True(SymbolEqualityComparer.Default.Equals(methodSymbol, boundInvocation.Method));
+        Assert.Null(boundInvocation.ExtensionReceiver);
+    }
+
+    [Fact]
+    public void StaticExtensionMethod_WildcardImport_EnablesUnqualifiedAccess()
+    {
+        const string source = """
+import Widget.*
+
+class Widget { }
+
+extension WidgetExtensions for Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+let created = Build(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        Assert.Equal("WidgetExtensions", boundInvocation.Method.ContainingType?.Name);
+    }
+
+    [Fact]
+    public void StaticExtensionMethod_PrefersRealStaticMembers()
+    {
+        const string source = """
+class Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+extension WidgetExtensions for Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+let created = Widget.Build(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        Assert.Equal("Widget", boundInvocation.Method.ContainingType?.Name);
+    }
+
+    [Fact]
+    public void StaticExtensionMethod_InfersExtensionContainerTypeArguments()
+    {
+        const string source = """
+class Box<T> { }
+
+extension BoxExtensions<T> for Box<T> {
+    public static Wrap(value: T) -> Box<T> {
+        return Box<T>()
+    }
+}
+
+let boxed = Box<int>.Wrap(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        var containingType = Assert.IsAssignableFrom<INamedTypeSymbol>(boundInvocation.Method.ContainingType);
+        Assert.Equal("BoxExtensions", containingType.Name);
+
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var typeArgument = Assert.Single(containingType.TypeArguments);
+        Assert.True(SymbolEqualityComparer.Default.Equals(intType, typeArgument));
+    }
+
+    [Fact]
+    public void StaticExtensionProperty_QualifiedLookup_BindsToExtensionContainer()
+    {
+        const string source = """
+class Counter { }
+
+extension CounterExtensions for Counter {
+    public static Total: int {
+        get { return 42; }
+    }
+}
+
+let total = Counter.Total
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var memberAccess = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Single(node => node.Name.Identifier.Text == "Total");
+
+        var boundAccess = Assert.IsType<BoundMemberAccessExpression>(model.GetBoundNode(memberAccess));
+        var propertySymbol = Assert.IsAssignableFrom<IPropertySymbol>(boundAccess.Member);
+        Assert.False(propertySymbol.IsExtensionProperty());
+        Assert.Equal("CounterExtensions", propertySymbol.ContainingType?.Name);
+    }
+}


### PR DESCRIPTION
### Motivation

- Enable declaring and resolving `static` members inside `extension X for T` containers so libraries can add type-level helpers (conversion/operators/indexers) without modifying the target type. 
- Ensure static extension members participate in static lookup (`Type.Member`) and wildcard imports (`import Type.*`) and follow the same receiver-compatibility rules used for instance extensions. 
- Distinguish instance extension members (which synthesize a `self` parameter) from static extension members (which do not synthesize `self` and are emitted as ordinary static members on the extension container). 
- Update language docs and proposals to reflect the final lookup rules and examples.

### Description

- Track extension receiver types on extension container symbols by adding `ExtensionReceiverType` to `SourceNamedTypeSymbol` and setting it in `SemanticModel.RegisterExtensionMembers` via `SetExtensionReceiverType`. 
- Add `GetExtensionReceiverType` helper to `SymbolExtensions` to support constructed generic containers and substitution. 
- Implement static-extension-aware lookup APIs: `LookupExtensionStaticMethods` and `LookupExtensionStaticProperties` on `Binder`, with concrete implementations in `ImportBinder`, `NamespaceBinder`, and fallbacks via new `GetExtensionStatic*FromScope` helpers. 
- Enumerate and match static extension members with `EnumerateExtensionStaticMethods` / `EnumerateExtensionStaticProperties`, reuse unification logic (`TryUnifyExtensionReceiver`) and construction (`TryCreateConstructedStaticExtension`) for generic containers, and wire lookup into `BlockBinder` so `Type.Member`, `member-binding`, and wildcard imports consider static extensions (while preserving precedence of real static members). 
- Make `TypeMemberBinder` treat extension-declared instance members as extension members only when the member is non-`static`, preserving existing behavior for `static` members declared inside extension containers. 
- Update spec/proposal docs (`docs/lang/spec/language-specification.md`, `docs/lang/proposals/drafts/static-extension-members.md`, and conversion proposal) to document static extension lookup and examples. 
- Add semantic tests `test/Raven.CodeAnalysis.Tests/Semantics/StaticExtensionMemberSemanticTests.cs` covering qualified lookup, wildcard import lookup, precedence over real static members, generic container type argument inference, and static property access.

### Testing

- No build or test run was executed in this environment because `dotnet` is not available; `dotnet build`/`dotnet test` were not run here. 
- Added unit tests in `test/Raven.CodeAnalysis.Tests/Semantics/StaticExtensionMemberSemanticTests.cs` that exercise qualified/static-access lookup, wildcard imports, precedence, and generic inference. 
- Existing extension machinery and overload/unification code paths were reused and extended; no automated regressions were run locally. 
- Follow-up verification should run the prescribed generator steps and `dotnet build`/`dotnet test` from the repository root (see `AGENTS.md`) to validate the new tests and behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e79e735f4832fa97a825aafb92392)