### PR TITLE
Add static extension member lookup and tests

### DIFF
--- a/docs/lang/proposals/drafts/conversion-from-option-to-nullable.md
+++ b/docs/lang/proposals/drafts/conversion-from-option-to-nullable.md
@@ -202,6 +202,7 @@ This proposal assumes the following language features, each of which deserves it
 
      * Methods declared directly on the type.
      * Static extension members for that type.
+   * Static extension members participate in `TargetType.Member` lookup and are also imported via `import TargetType.*`.
 
 Without those, this proposal is not implementable, but it serves as a concrete motivating use case for them.
 

--- a/docs/lang/proposals/drafts/static-extension-members.md
+++ b/docs/lang/proposals/drafts/static-extension-members.md
@@ -18,6 +18,15 @@ class Foo {}
 
 Static methods and static properties.
 
+## Lookup
+
+Static extension members participate in static member lookup. When binding
+`Type.Member`, the compiler first resolves real static members on `Type`. If no
+match is found, it searches in-scope extension containers whose receiver type is
+compatible with `Type` (including implicit conversions and nullability).
+Wildcard-importing the target type (`import Type.*`) also brings static
+extension members into unqualified lookup.
+
 ## Interesting points
 
 Allow for operator overloading via extensions: incl. operators, conversion, indexers, callable.

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -645,8 +645,8 @@ the first argument whenever the member is invoked. The `self` parameter behaves
 like a `let` binding: it cannot be reassigned but may be used to access members
 or forwarded to other calls. Extension members default to `public`
 accessibility and may be marked `internal` to restrict their visibility; other
-modifiers are rejected. As a result, extensions cannot declare `protected`,
-`private`, or `static` members.
+modifiers are rejected. As a result, extensions cannot declare `protected` or
+`private` members.
 
 #### Extension methods
 
@@ -718,6 +718,19 @@ extension ListExt for List<int>
     }
 }
 ```
+
+#### Static extension members
+
+Extensions may also declare `static` methods and properties. Static extension
+members are associated with the receiver type and are accessed through static
+member lookup (`Type.Member`) or by importing the target type (`import
+Type.*`). When binding a static member access, the compiler first resolves real
+static members on the type; if no match is found, it searches in-scope extension
+containers whose receiver type is compatible with the target type. Receiver
+compatibility follows the same implicit conversion and nullability rules used
+for extension methods, so constructed and nested types participate normally.
+Static extension members do not synthesize `self` and are emitted as ordinary
+static members on the extension container.
 
 #### Pipe operator
 

--- a/src/Raven.CodeAnalysis.Console/Raven.CodeAnalysis.Console.csproj
+++ b/src/Raven.CodeAnalysis.Console/Raven.CodeAnalysis.Console.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console" Version="0.54.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Raven.CodeAnalysis\Raven.CodeAnalysis.csproj" />

--- a/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/NamespaceBinder.cs
@@ -80,4 +80,50 @@ class NamespaceBinder : Binder
             if (seen.Add(property))
                 yield return property;
     }
+
+    public override IEnumerable<IMethodSymbol> LookupExtensionStaticMethods(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
+    {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            yield break;
+
+        var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var method in GetExtensionStaticMethodsFromScope(_namespaceSymbol, name, receiverType, includePartialMatches))
+            if (seen.Add(method))
+                yield return method;
+
+        foreach (var declaredType in _declaredTypes)
+        {
+            foreach (var method in GetExtensionStaticMethodsFromScope(declaredType, name, receiverType, includePartialMatches))
+                if (seen.Add(method))
+                    yield return method;
+        }
+
+        foreach (var method in base.LookupExtensionStaticMethods(name, receiverType, includePartialMatches))
+            if (seen.Add(method))
+                yield return method;
+    }
+
+    public override IEnumerable<IPropertySymbol> LookupExtensionStaticProperties(string? name, ITypeSymbol receiverType, bool includePartialMatches = false)
+    {
+        if (receiverType is null || receiverType.TypeKind == TypeKind.Error)
+            yield break;
+
+        var seen = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var property in GetExtensionStaticPropertiesFromScope(_namespaceSymbol, name, receiverType, includePartialMatches))
+            if (seen.Add(property))
+                yield return property;
+
+        foreach (var declaredType in _declaredTypes)
+        {
+            foreach (var property in GetExtensionStaticPropertiesFromScope(declaredType, name, receiverType, includePartialMatches))
+                if (seen.Add(property))
+                    yield return property;
+        }
+
+        foreach (var property in base.LookupExtensionStaticProperties(name, receiverType, includePartialMatches))
+            if (seen.Add(property))
+                yield return property;
+    }
 }

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -1727,6 +1727,12 @@ public partial class SemanticModel
 
     private void RegisterExtensionMembers(ExtensionDeclarationSyntax extensionDecl, ExtensionDeclarationBinder extensionBinder)
     {
+        if (extensionBinder.ContainingSymbol is SourceNamedTypeSymbol extensionSymbol)
+        {
+            var receiverType = extensionBinder.ResolveType(extensionDecl.ReceiverType);
+            extensionSymbol.SetExtensionReceiverType(receiverType);
+        }
+
         foreach (var member in extensionDecl.Members)
         {
             switch (member)

--- a/src/Raven.CodeAnalysis/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/SymbolExtensions.cs
@@ -93,4 +93,15 @@ public static partial class SymbolExtensions
             _ => null
         };
     }
+
+    public static ITypeSymbol? GetExtensionReceiverType(this INamedTypeSymbol type)
+    {
+        return type switch
+        {
+            SourceNamedTypeSymbol sourceType when sourceType.IsExtensionDeclaration => sourceType.ExtensionReceiverType,
+            ConstructedNamedTypeSymbol constructed when constructed.OriginalDefinition is SourceNamedTypeSymbol sourceType
+                => sourceType.ExtensionReceiverType is { } receiverType ? constructed.Substitute(receiverType) : null,
+            _ => null
+        };
+    }
 }

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -13,6 +13,7 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     private ImmutableArray<INamedTypeSymbol>? _allInterfaces;
     private ImmutableArray<ITypeParameterSymbol> _typeParameters = ImmutableArray<ITypeParameterSymbol>.Empty;
     private ImmutableArray<ITypeSymbol> _typeArguments = ImmutableArray<ITypeSymbol>.Empty;
+    private ITypeSymbol? _extensionReceiverType;
 
     public SourceNamedTypeSymbol(string name, ISymbol containingSymbol, INamedTypeSymbol? containingType, INamespaceSymbol? containingNamespace, Location[] locations, SyntaxReference[] declaringSyntaxReferences, Accessibility declaredAccessibility = Accessibility.NotApplicable)
         : base(SymbolKind.Type, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences, declaredAccessibility)
@@ -70,6 +71,7 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     public bool HasNonPartialDeclaration { get; private set; }
 
     public bool IsExtensionDeclaration { get; private set; }
+    internal ITypeSymbol? ExtensionReceiverType => _extensionReceiverType;
 
     public ImmutableArray<INamedTypeSymbol> Interfaces => _interfaces;
     public ImmutableArray<INamedTypeSymbol> AllInterfaces =>
@@ -185,6 +187,14 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     {
         IsExtensionDeclaration = true;
         IsSealed = true;
+    }
+
+    internal void SetExtensionReceiverType(ITypeSymbol? receiverType)
+    {
+        if (!IsExtensionDeclaration)
+            return;
+
+        _extensionReceiverType = receiverType;
     }
 
     internal void SetTypeParameters(IEnumerable<ITypeParameterSymbol> typeParameters)

--- a/src/Raven.Compiler/Raven.Compiler.csproj
+++ b/src/Raven.Compiler/Raven.Compiler.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.HostModel" Version="3.1.16" />
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console" Version="0.54.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Raven.CodeAnalysis.Tests/Semantics/StaticExtensionMemberSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/StaticExtensionMemberSemanticTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public sealed class StaticExtensionMemberSemanticTests : CompilationTestBase
+{
+    [Fact]
+    public void StaticExtensionMethod_QualifiedLookup_BindsToExtensionContainer()
+    {
+        const string source = """
+class Widget { }
+
+extension WidgetExtensions for Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+let created = Widget.Build(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var methodDecl = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "Build");
+        var methodSymbol = Assert.IsAssignableFrom<IMethodSymbol>(model.GetDeclaredSymbol(methodDecl));
+
+        Assert.False(methodSymbol.IsExtensionMethod);
+
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        Assert.True(SymbolEqualityComparer.Default.Equals(methodSymbol, boundInvocation.Method));
+        Assert.Null(boundInvocation.ExtensionReceiver);
+    }
+
+    [Fact]
+    public void StaticExtensionMethod_WildcardImport_EnablesUnqualifiedAccess()
+    {
+        const string source = """
+import Widget.*
+
+class Widget { }
+
+extension WidgetExtensions for Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+let created = Build(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        Assert.Equal("WidgetExtensions", boundInvocation.Method.ContainingType?.Name);
+    }
+
+    [Fact]
+    public void StaticExtensionMethod_PrefersRealStaticMembers()
+    {
+        const string source = """
+class Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+extension WidgetExtensions for Widget {
+    public static Build(value: int) -> Widget {
+        return Widget()
+    }
+}
+
+let created = Widget.Build(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        Assert.Equal("Widget", boundInvocation.Method.ContainingType?.Name);
+    }
+
+    [Fact]
+    public void StaticExtensionMethod_InfersExtensionContainerTypeArguments()
+    {
+        const string source = """
+class Box<T> { }
+
+extension BoxExtensions<T> for Box<T> {
+    public static Wrap(value: T) -> Box<T> {
+        return Box<T>()
+    }
+}
+
+let boxed = Box<int>.Wrap(1)
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        var boundInvocation = Assert.IsType<BoundInvocationExpression>(model.GetBoundNode(invocation));
+
+        var containingType = Assert.IsAssignableFrom<INamedTypeSymbol>(boundInvocation.Method.ContainingType);
+        Assert.Equal("BoxExtensions", containingType.Name);
+
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var typeArgument = Assert.Single(containingType.TypeArguments);
+        Assert.True(SymbolEqualityComparer.Default.Equals(intType, typeArgument));
+    }
+
+    [Fact]
+    public void StaticExtensionProperty_QualifiedLookup_BindsToExtensionContainer()
+    {
+        const string source = """
+class Counter { }
+
+extension CounterExtensions for Counter {
+    public static Total: int {
+        get { return 42; }
+    }
+}
+
+let total = Counter.Total
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        compilation.EnsureSetup();
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+        var model = compilation.GetSemanticModel(tree);
+        var memberAccess = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Single(node => node.Name.Identifier.Text == "Total");
+
+        var boundAccess = Assert.IsType<BoundMemberAccessExpression>(model.GetBoundNode(memberAccess));
+        var propertySymbol = Assert.IsAssignableFrom<IPropertySymbol>(boundAccess.Member);
+        Assert.False(propertySymbol.IsExtensionProperty());
+        Assert.Equal("CounterExtensions", propertySymbol.ContainingType?.Name);
+    }
+}


### PR DESCRIPTION
### Motivation

- Enable declaring and resolving `static` members inside `extension X for T` containers so libraries can add type-level helpers accessible via `Type.Member` and `import Type.*`.
- Ensure static extension members follow the same receiver-compatibility rules used for instance extensions and support generic extension containers.
- Fix a runtime/compilation bug when constructing generic extension containers where the constructed container needed to be treated as a named type.
- Align `Spectre.Console` package versions used by the compiler and console projects to avoid restore/build downgrades.

### Description

- Track extension receiver types on extension container symbols by adding an `ExtensionReceiverType` field to `SourceNamedTypeSymbol` and set it from `SemanticModel.RegisterExtensionMembers` via `SetExtensionReceiverType`.
- Add `GetExtensionReceiverType` overload in `SymbolExtensions` to support constructed generic containers and substitute type parameters accordingly.
- Implement static-extension-aware lookup APIs on `Binder`: `LookupExtensionStaticMethods` and `LookupExtensionStaticProperties`, plus enumeration helpers `EnumerateExtensionStaticMethods`/`EnumerateExtensionStaticProperties`, and wire them into `ImportBinder`, `NamespaceBinder`, and `BlockBinder` so `Type.Member`, wildcard imports, and member-binding consider static extensions (preserving precedence of real static members).
- Treat extension-declared instance members vs static members correctly in `TypeMemberBinder` by tracking whether the declaration has a `static` modifier and only marking non-`static` members as extension members; also fix the container construction cast used when creating constructed static extensions.

### Testing

- Ran code-generation steps successfully with `NodeGenerator`, `BoundNodeGenerator`, and `DiagnosticsGenerator` (generators executed and produced expected output).
- `dotnet build --property WarningLevel=0` completed successfully for the solution after package version alignment and the construction fix.
- Ran `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal`, which produced test failures (multiple semantic and parser tests failed; see test run logs for examples such as `ObjectCreationTests` and `ParserNewlineTests`).
- Added unit tests `test/Raven.CodeAnalysis.Tests/Semantics/StaticExtensionMemberSemanticTests.cs` that exercise qualified lookup, wildcard import lookup, precedence over real static members, generic container type argument inference, and static property access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e79e735f4832fa97a825aafb92392)