### PR TITLE
Attach documentation comments to field symbols

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -233,7 +233,7 @@ internal class TypeMemberBinder : Binder
                 _containingType,
                 CurrentNamespace!.AsSourceNamespace(),
                 [decl.GetLocation()],
-                [decl.GetReference()],
+                [decl.GetReference(), fieldDecl.GetReference()],
                 initializerForSymbol,
                 declaredAccessibility: fieldAccessibility
             );

--- a/test/Raven.CodeAnalysis.Tests/Semantics/DocumentationCommentSemanticTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/DocumentationCommentSemanticTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+
+using Raven.CodeAnalysis.Documentation;
+using Raven.CodeAnalysis.Symbols;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public sealed class DocumentationCommentSemanticTests : CompilationTestBase
+{
+    [Fact]
+    public void FieldDocumentationComment_AttachesToFieldSymbol()
+    {
+        const string source = """
+class C {
+    /// Field docs
+    public val species = "Homo sapiens"
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        var model = compilation.GetSemanticModel(tree);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var field = Assert.IsAssignableFrom<IFieldSymbol>(model.GetDeclaredSymbol(declarator));
+
+        var comment = field.GetDocumentationComment();
+
+        Assert.NotNull(comment);
+        Assert.Equal(DocumentationFormat.Markdown, comment!.Format);
+        Assert.Equal("Field docs", comment.Content);
+    }
+}


### PR DESCRIPTION
### Motivation
- Documentation comments placed on a `FieldDeclarationSyntax` were not being associated with the resulting `IFieldSymbol` because only the variable declarator reference was provided to the symbol.
- The intent is to ensure documentation trivia written above a field declaration becomes available via `GetDocumentationComment()` on the `IFieldSymbol`.

### Description
- Include the field declaration syntax reference when constructing `SourceFieldSymbol` in `TypeMemberBinder.BindFieldDeclaration` by adding `fieldDecl.GetReference()` to the declaring references list.
- Add a unit test `DocumentationCommentSemanticTests.FieldDocumentationComment_AttachesToFieldSymbol` in `test/Raven.CodeAnalysis.Tests/Semantics/DocumentationCommentSemanticTests.cs` that asserts a field symbol receives its documentation comment and format.
- The change affects `src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs` and adds the test file under `test/Raven.CodeAnalysis.Tests/Semantics`.

### Testing
- Added unit test `DocumentationCommentSemanticTests.FieldDocumentationComment_AttachesToFieldSymbol` which verifies `field.GetDocumentationComment()` returns a non-null `DocumentationComment` with expected `Format` and `Content`.
- Attempted to refresh generated code with `dotnet run` for generators but `dotnet` was unavailable so generation was not performed.
- Attempted `dotnet build --property WarningLevel=0` and `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal` but both could not run due to `dotnet` not being available in the environment, so automated tests were not executed.
- No test failures were observed locally because the test run could not be performed; the newly added test should be validated in CI or a local environment with the .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e85d42ed4832f86a07faf81d174d0)