### PR TITLE
Expand generic-math-constraints investigation with prior attempt details and restart plan

### DIFF
--- a/docs/investigations/generic-math-constraints.md
+++ b/docs/investigations/generic-math-constraints.md
@@ -15,6 +15,79 @@ Document the current failure when compiling the `generic-math-error.rav` sample 
 - `Substitute` rebuilds generic named types by invoking `Construct` whenever any argument changes, which immediately triggers `NormalizeTypeArguments` for the new `ConstructedNamedTypeSymbol`. With self-referential constraints like `INumber<TSelf>`, this loop can re-enter substitution on the same `(type parameter, argument)` pair indefinitely because there is no memoization or visited tracking.【F:src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs†L43-L103】【F:src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs†L131-L189】
 - `SubstituteNamedType` also eagerly constructs nested generic types when substitutions are available, again without a guard to short-circuit previously substituted parameter/argument pairs. This expands the recursion surface when constraints or interface closures contain other generic references.【F:src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedNamedTypeSymbol.cs†L234-L284】
 
+## Previous Attempt (for reference)
+### Constructed type caching & substitution guards
+- Added a `ConstructedNamedTypeSymbol.Create(...)` factory with a concurrent cache to canonicalize constructed named types.
+- Introduced a `SubstitutionTrace` (`AsyncLocal`) to track in-progress substitutions, avoid re-entrant loops, and memoize substituted results.
+- Added debug flags (`RAVEN_DEBUG_CONSTRUCTED_NAMED_TYPE`, `RAVEN_DEBUG_COMPILATION`) and conditional file output for tracing.
+
+### Type parameter equality adjustments
+- `TypeParameterSubstitutionComparer` switched to comparing type parameters by `Ordinal`/`Name` + containing symbol key rather than the full `SymbolEqualityComparer`, to avoid recursion and improve stability.
+
+### Caching policy changes
+- Caching was disabled for synthesized mutable types (state machines/iterators) to avoid stale constructed symbols.
+
+### Tests added
+- `ConstructedNamedTypeSymbolTests` coverage for:
+  - Canonicalization: `ConstructedType_FromMetadata_CanonicalizesByArguments`
+  - Comparer fallback behavior
+  - State machine refresh after mutation
+  - Recursive field substitutions
+
+### Build/workflow changes
+- Added `scripts/codex-build.sh` to run generators and build in a stable order.
+- Marked the script as preferred in `AGENTS.md`.
+- Added investigation docs for samples build/run and generic math constraints.
+
+## Additional Findings From the Attempted Implementation
+### Substitution & caching behavior
+- Recursion originates from generic constraints (`INumber<TSelf>`) that repeatedly construct and substitute the same named types.
+- Guarding re-entrant substitution is necessary, but it must not return partial results (avoid emitting a partially substituted `ConstructedNamedTypeSymbol`).
+- Canonicalizing constructed types helps reduce duplication but must avoid caching mutable synthesized types.
+
+### Debug/diagnostics
+- File I/O for traces is useful but must be strictly gated (environment variables) and throttled to avoid flooding.
+
+### Build reliability
+- Generators and MSBuild tasks can collide or fail in agent environments (file locks, missing generated types).
+- A stable sequence is required: generators → `Raven.CodeAnalysis` → `Raven.Compiler` (no core) → emit `Raven.Core` → `Raven.Compiler` (with core).
+
+### Sample build/run status
+- With the codex build script, samples partially compile.
+- Some failures are known (discriminated unions, pattern binding, overload inference gaps).
+- `test-result3.rav` still hits an emission crash (`FieldInfo` null).
+- Runtime failures include missing `runtimeconfig.json`, `BadImageFormat` in async/generators, and missing `TestDep.dll`.
+
+## Restart Plan (what to re-implement cleanly)
+### A) Core substitution & caching
+- Rebuild constructed-type caching around explicit factory usage with a clear cache key.
+- Re-implement recursion guards in `Substitute`:
+  - Track in-progress substitutions separately from completed memoized results.
+  - Ensure re-entrance never returns partial substitutions.
+
+### B) Comparer stability
+- Re-implement type parameter comparison:
+  - Use `Ordinal`/`Name` + containing-type key (only when the containing type is stable).
+  - Avoid recursion into symbol equality.
+
+### C) Debugging
+- Keep debug trace files strictly behind env flags.
+- Throttle output to avoid flooding.
+
+### D) Build workflow for agents
+- Provide a reliable agent-only build sequence:
+  - generators → `Raven.CodeAnalysis` → `Raven.Compiler` (no core) → emit `Raven.Core` → `Raven.Compiler` (with core)
+- Ensure output directories exist before emitting.
+
+## Suggested Re-implementation Checkpoints
+- ✅ Generators run independently without invoking MSBuild targets.
+- ✅ `Raven.CodeAnalysis` builds without missing generated syntax types.
+- ✅ `Raven.Compiler` builds without `Raven.Core` and can emit `Raven.Core` via `ravc`.
+- ✅ Substitution re-entrance is guarded without returning partial results.
+- ✅ Constructed type caching excludes mutable synthesized types.
+- ✅ Tests for caching/substitution pass.
+- ✅ Samples build/run, with remaining failures categorized and documented.
+
 ## Next Steps
 - Add lightweight instrumentation (e.g., a recursion depth counter and an `ImmutableHashSet` of `(parameter, argument)` pairs) around `NormalizeTypeArguments`/`Substitute` to capture the exact loop triggered by `INumber<TSelf>`.
 - Introduce a recursion guard or memoization cache inside `Substitute` (and the equality path that calls it) so re-visiting the same substitution returns the existing symbol instead of reconstructing it.


### PR DESCRIPTION
### Motivation
- Capture and consolidate findings about recursive substitutions and construction of `ConstructedNamedTypeSymbol` (e.g., issues resolving `AllInterfaces`/`INumber<TSelf>` paths).
- Preserve details from the prior attempted fix (caching/substitution guards, comparer changes, and test/workflow tweaks) so the next implementation can be planned cleanly.
- Document agent-friendly build/workflow steps and current sample status to reduce flakiness when reproducing the issue in CI/agents.
- Provide a clear restart plan and checkpoints to re-implement caching/substitution behavior safely.

### Description
- Updated `docs/investigations/generic-math-constraints.md` to include a summary of the previous attempt, its changes, and why it didn’t fully resolve recursion/memoization issues.
- Added detailed findings about substitution/caching behavior, debug/diagnostics guidance, and build reliability observations for agent environments.
- Added a concrete restart plan covering (A) constructed-type caching & recursion guards, (B) type-parameter comparer stability, (C) gated debugging, and (D) a reliable agent-only build sequence.
- Recorded suggested checkpoints and regression targets (canonicalization, excluding synthesized mutable types from caching, guarded substitution, and tests to cover these cases).

### Testing
- Ran `dotnet build --property WarningLevel=0`, which completed successfully and produced project outputs.
- Ran `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal`, which executed the suite but aborted due to a stack overflow; summary at the abort: 67 passed, 8 failed, 4 skipped, and the run was aborted by the test host.
- The failing test run demonstrates existing recursion/equals/hashcode paths still need work before re-enabling the prior caching/substitution approach.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69505a3799b0832fac33ceaf30d2e175)