### PR TITLE
Fix nullable reference conversion elision for user-defined conversions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -6339,8 +6339,14 @@ partial class BlockBinder : Binder
             return new BoundLiteralExpression(literalNull.Kind, literalNull.Value, literalNull.Type, targetType);
         }
 
-        if (targetType is NullableTypeSymbol nullableTarget && !nullableTarget.UnderlyingType.IsValueType)
+        if (targetType is NullableTypeSymbol nullableTarget &&
+            !nullableTarget.UnderlyingType.IsValueType &&
+            conversion.IsReference &&
+            expression.Type is { } expressionType &&
+            SymbolEqualityComparer.Default.Equals(expressionType, nullableTarget.UnderlyingType))
+        {
             return expression;
+        }
 
         return new BoundCastExpression(expression, targetType, conversion);
     }


### PR DESCRIPTION
### Motivation

- Prevent elision of conversions that should call user-defined or extension `op_Implicit` when targeting nullable reference unions.
- The compiler previously returned the original expression for `Nullable<T>` (reference underlying) too broadly, which suppressed emitted conversion calls.
- This led to missing/incorrect IL for conversions like the `implicit operator` in `OptionExtensions<T>` and runtime failures when the conversion was expected to run.

### Description

- Tighten the guard in `BlockBinder.ApplyConversion` so the early-return for `NullableTypeSymbol` only occurs when `conversion.IsReference` and the expression type exactly equals the nullable underlying type using `SymbolEqualityComparer.Default.Equals`. 
- This ensures user-defined and extension conversion operators (including `op_Implicit`) are considered and emitted for nullable reference targets instead of being elided.
- The change is implemented in `src/Raven.CodeAnalysis/Binder/BlockBinder.cs` by refining the `if (targetType is NullableTypeSymbol ...)` condition.

### Testing

- Ran the code generation steps (`NodeGenerator`, `BoundNodeGenerator`, `DiagnosticsGenerator`) before building as required by repository guidelines.
- Built the solution with `dotnet build --property WarningLevel=0`, which completed successfully.
- Ran `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal`, which exercised the test suite but encountered many preexisting and unrelated failures; tests did not all pass.
- Manual verification: inspected emitted IL/behavior for the reported conversion scenario and adjusted the binding logic to allow conversion emission (build verified the change introduced no compilation errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951398b7c28832f9079ff7c51485368)