### PR TITLE
Add tests for nullable type parameters and lifted nullable conversions

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs
@@ -102,6 +102,39 @@ public sealed class ClassifyConversionTests : CompilationTestBase
         Assert.True(conversion.Exists);
         Assert.False(conversion.IsImplicit);
         Assert.True(conversion.IsIdentity);
+        Assert.True(conversion.IsLifted);
+    }
+
+    [Fact]
+    public void NullableValueType_ToNullableDestination_IsLiftedNumericConversion()
+    {
+        var compilation = CreateCompilation();
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var longType = compilation.GetSpecialType(SpecialType.System_Int64);
+        var nullableInt = new NullableTypeSymbol(intType, null, null, null, []);
+        var nullableLong = new NullableTypeSymbol(longType, null, null, null, []);
+
+        var conversion = compilation.ClassifyConversion(nullableInt, nullableLong);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.True(conversion.IsNumeric);
+        Assert.True(conversion.IsLifted);
+        Assert.False(conversion.IsIdentity);
+    }
+
+    [Fact]
+    public void NullableValueType_ToNullableReference_DoesNotConvert()
+    {
+        var compilation = CreateCompilation();
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        var nullableInt = new NullableTypeSymbol(intType, null, null, null, []);
+        var nullableString = new NullableTypeSymbol(stringType, null, null, null, []);
+
+        var conversion = compilation.ClassifyConversion(nullableInt, nullableString);
+
+        Assert.False(conversion.Exists);
     }
 
     [Theory]


### PR DESCRIPTION
### Motivation

- Add unit coverage for `T?` behavior when `T` is `struct`, `class`, `notnull`, and unconstrained to validate type binding and constraint handling.
- Verify lifted nullable conversion behavior, including numeric lifting and invalid conversions to nullable references.
- Ensure the compiler emits the appropriate diagnostic when a `notnull` type parameter is made nullable.

### Description

- Added tests to `test/Raven.CodeAnalysis.Tests/Semantics/NullableTypeTests.cs` that assert `NullableTypeSyntax` wraps type parameters and that `T : notnull` produces a constraint diagnostic.
- Added tests to `test/Raven.CodeAnalysis.Tests/Semantics/ClassifyConversionTests.cs` asserting `IsLifted` on nullable conversions and covering lifted numeric conversions and invalid nullable->reference conversions.
- Ran code formatting with `dotnet format` on the modified test files and regenerated code artifacts via the repository generators.

### Testing

- Ran generators with `(cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f)`, `(cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/BoundNodeGenerator -- -f)`, and `(cd src/Raven.CodeAnalysis && dotnet run --project ../../tools/DiagnosticsGenerator -- -f)`, and all succeeded.
- Ran `dotnet format` on the modified test files, which completed with workspace warnings but no fatal errors.
- `dotnet build --property WarningLevel=0` failed due to a compile error: `CS0136: A local or parameter named 'conv' cannot be declared in this scope` in `src/Raven.CodeAnalysis/Compilation.Conversions.cs`, so tests were not executed.
- `dotnet test` was not run because the build failed and needs the naming conflict fix before tests can be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957c763ea38832fb566c0f4d3b3e427)