### PR TITLE
Fix nullable ctor lookup for generic nullable conversions

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1034,8 +1034,7 @@ internal class ExpressionGenerator : Generator
         ILGenerator.Emit(OpCodes.Ldloca, nullableLocal);
         ILGenerator.Emit(OpCodes.Ldloc, valueLocal);
 
-        var ctor = nullableClrType.GetConstructor(new[] { underlyingClrType })
-            ?? throw new InvalidOperationException($"Missing Nullable constructor for {nullableClrType}");
+        var ctor = GetNullableConstructor(nullableClrType, underlyingClrType);
 
         ILGenerator.Emit(OpCodes.Call, ctor);
         ILGenerator.Emit(OpCodes.Ldloc, nullableLocal);
@@ -1069,8 +1068,7 @@ internal class ExpressionGenerator : Generator
         ILGenerator.Emit(OpCodes.Ldloca, nullableLocal);
         ILGenerator.Emit(OpCodes.Ldloc, valueLocal);
 
-        var ctor = nullableClr.GetConstructor(new[] { underlyingClr })
-            ?? throw new InvalidOperationException($"Missing Nullable constructor for {nullableClr}");
+        var ctor = GetNullableConstructor(nullableClr, underlyingClr);
 
         ILGenerator.Emit(OpCodes.Call, ctor);
         ILGenerator.Emit(OpCodes.Ldloc, nullableLocal);
@@ -1128,8 +1126,7 @@ internal class ExpressionGenerator : Generator
         ILGenerator.Emit(OpCodes.Ldloca, toLocal);
         ILGenerator.Emit(OpCodes.Ldloc, valueLocal);
 
-        var ctor = toClr.GetConstructor(new[] { toUnderlyingClr })
-            ?? throw new InvalidOperationException($"Missing Nullable constructor for {toClr}");
+        var ctor = GetNullableConstructor(toClr, toUnderlyingClr);
 
         ILGenerator.Emit(OpCodes.Call, ctor);
         ILGenerator.Emit(OpCodes.Ldloc, toLocal);

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/Generator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/Generator.cs
@@ -161,6 +161,24 @@ internal abstract class Generator
 
     public MemberInfo? GetMemberBuilder(SourceSymbol sourceSymbol) => MethodGenerator.TypeGenerator.CodeGen.GetMemberBuilder(sourceSymbol);
 
+    protected static ConstructorInfo GetNullableConstructor(Type nullableType, Type underlyingType)
+    {
+        var ctor = nullableType.GetConstructor(new[] { underlyingType });
+        if (ctor is not null)
+            return ctor;
+
+        if (nullableType.IsGenericType && nullableType.ContainsGenericParameters)
+        {
+            var definition = nullableType.GetGenericTypeDefinition();
+            var genericArgument = definition.GetGenericArguments()[0];
+            var definitionCtor = definition.GetConstructor(new[] { genericArgument });
+            if (definitionCtor is not null)
+                return TypeBuilder.GetConstructor(nullableType, definitionCtor);
+        }
+
+        throw new InvalidOperationException($"Missing Nullable constructor for {nullableType}");
+    }
+
     private SemanticModel ResolveSemanticModel(SyntaxNode syntaxNode)
     {
         var syntaxTree = syntaxNode.SyntaxTree!;

--- a/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/StatementGenerator.cs
@@ -710,8 +710,7 @@ internal class StatementGenerator : Generator
                 ILGenerator.Emit(OpCodes.Ldloca, localBuilder);
                 ILGenerator.Emit(OpCodes.Ldloc, temp);
 
-                var ctor = localClr.GetConstructor(new[] { underlyingClr })
-                    ?? throw new InvalidOperationException($"Missing Nullable constructor for {localClr}");
+                var ctor = GetNullableConstructor(localClr, underlyingClr);
                 ILGenerator.Emit(OpCodes.Call, ctor);
                 return;
             }


### PR DESCRIPTION
### Motivation
- Emission of nullable conversions failed for constructed generic nullable types due to resolving the Nullable<T> constructor on a TypeBuilderInstantiation and throwing NotSupportedException.
- The compiler needs a stable way to obtain a `ConstructorInfo` when emitting IL for nullable conversions and nullable local initialization involving generic runtime types.

### Description
- Add a shared helper `GetNullableConstructor(Type nullableType, Type underlyingType)` in `Generator.cs` that resolves the nullable constructor and falls back to `TypeBuilder.GetConstructor` for constructed generic types.
- Replace direct `GetConstructor(...)` calls with `GetNullableConstructor(...)` in `ExpressionGenerator.cs` and `StatementGenerator.cs` to use the new lookup logic when emitting nullable conversions and nullable local initialization.
- Changes affect `src/Raven.CodeAnalysis/CodeGen/Generators/Generator.cs`, `ExpressionGenerator.cs`, and `StatementGenerator.cs`.

### Testing
- Ran the generators with `(cd src/Raven.CodeAnalysis/Syntax && dotnet run --project ../../../tools/NodeGenerator -- -f)`, `BoundNodeGenerator`, and `DiagnosticsGenerator` before building.
- Executed `dotnet build --property WarningLevel=0`, which completed successfully with 0 warnings.
- Ran `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 -v minimal`, which exercised the test suite but produced many test failures and the run was ultimately interrupted/terminated during execution.
- Verified formatting with `dotnet format` on modified files prior to committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ce497ce4832fa1dab3c857e57cc6)