### PR TITLE
Validate extension conversion constraints during inference

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/ConversionOperatorCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/ConversionOperatorCodeGenTests.cs
@@ -43,4 +43,5 @@ class NumberBox {
 
         Assert.Equal(42, converted);
     }
+
 }

--- a/test/Raven.CodeAnalysis.Tests/Semantics/ConversionOperatorBindingTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/ConversionOperatorBindingTests.cs
@@ -1,7 +1,11 @@
+using System;
+using System.IO;
 using System.Linq;
 
 using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
 using Raven.CodeAnalysis.Testing;
+using Raven.CodeAnalysis.Tests;
 
 using Xunit;
 
@@ -33,5 +37,67 @@ public class ConversionOperatorBindingTests : CompilationTestBase
         Assert.DoesNotContain(
             diagnostics,
             d => d.Descriptor == CompilerDiagnostics.CannotConvertFromTypeToType);
+    }
+
+    [Fact]
+    public void ExtensionConversion_PicksConstraintCompatibleOperator()
+    {
+        var ravenCoreSourcePath = Path.GetFullPath(Path.Combine(
+            "..", "..", "..", "..", "..", "src", "Raven.Core", "Option.rav"));
+        var ravenCoreSource = File.ReadAllText(ravenCoreSourcePath);
+
+        var ravenCoreTree = SyntaxTree.ParseText(ravenCoreSource);
+        var ravenCoreCompilation = Compilation.Create(
+            "raven-core-option-fixture",
+            [ravenCoreTree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var ravenCoreAssemblyPath = Path.Combine(Path.GetTempPath(), $"raven-core-option-fixture-{Guid.NewGuid():N}.dll");
+
+        try
+        {
+            using var ravenCoreStream = new MemoryStream();
+            var ravenCoreEmit = ravenCoreCompilation.Emit(ravenCoreStream);
+            Assert.True(ravenCoreEmit.Success, string.Join(Environment.NewLine, ravenCoreEmit.Diagnostics));
+
+            File.WriteAllBytes(ravenCoreAssemblyPath, ravenCoreStream.ToArray());
+
+            var ravenCoreReference = MetadataReference.CreateFromFile(ravenCoreAssemblyPath);
+
+            const string source = """
+import System.*
+
+let value = Option<int>.None
+let result: int? = value
+""";
+
+            var (compilation, tree) = CreateCompilation(
+                source,
+                options: new CompilationOptions(OutputKind.ConsoleApplication),
+                references: [.. TestMetadataReferences.Default, ravenCoreReference]);
+            var diagnostics = compilation.GetDiagnostics();
+
+            Assert.True(diagnostics.IsEmpty, string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+
+            var model = compilation.GetSemanticModel(tree);
+            var declarators = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ToArray();
+            var valueDeclarator = declarators.Single(d => d.Identifier.ValueText == "value");
+            var resultDeclarator = declarators.Single(d => d.Identifier.ValueText == "result");
+            var valueSymbol = Assert.IsAssignableFrom<ILocalSymbol>(model.GetDeclaredSymbol(valueDeclarator));
+            var resultSymbol = Assert.IsAssignableFrom<ILocalSymbol>(model.GetDeclaredSymbol(resultDeclarator));
+
+            var conversion = compilation.ClassifyConversion(valueSymbol.Type, resultSymbol.Type, includeUserDefined: true);
+
+            Assert.True(conversion.Exists);
+            Assert.True(conversion.IsUserDefined);
+            Assert.NotNull(conversion.MethodSymbol);
+            Assert.Equal("OptionExtensions2", conversion.MethodSymbol?.ContainingType?.Name);
+        }
+        finally
+        {
+            if (File.Exists(ravenCoreAssemblyPath))
+                File.Delete(ravenCoreAssemblyPath);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Extension conversion candidate construction could infer type arguments that violate type-parameter constraints and therefore produce invalid constructed conversions (e.g. a `class`-constrained operator inferred for a value type).  
- This caused invalid user-defined conversions to be selected and later fail during code emission.  

### Description
- Validate inferred method type arguments and containing-type type arguments inside `TryConstructExtensionConversion` in `src/Raven.CodeAnalysis/Compilation.Conversions.cs` and reject constructions that don't satisfy constraints.  
- Added helper functions `SatisfiesTypeParameterConstraints` and `SatisfiesContainingTypeConstraints` that use existing constraint checks to verify inferred substitutions.  
- Added a semantic test `ExtensionConversion_PicksConstraintCompatibleOperator` in `test/Raven.CodeAnalysis.Tests/Semantics/ConversionOperatorBindingTests.cs` to ensure `Option<int>` selects the `struct`-constrained implicit operator.  
- Minor test formatting cleanup in `test/Raven.CodeAnalysis.Tests/CodeGen/ConversionOperatorCodeGenTests.cs`.

### Testing
- Ran `scripts/codex-build.sh` to build the solution components and generators, which completed successfully.  
- Executed the focused unit test with `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter ExtensionConversion_PicksConstraintCompatibleOperator`, which passed.  
- Targeted compilation/emit checks for the `Option` consumer scenario were performed via the added test and succeeded.  
- Full solution test runs were not performed here because other unrelated baseline failures exist in separate test projects and were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695805ade9e4832f9b939abf1904b507)