### PR TITLE
Emit default nullable value when converting null in codegen

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -1042,6 +1042,12 @@ internal class ExpressionGenerator : Generator
 
     private void EmitNullableConversion(ITypeSymbol from, NullableTypeSymbol nullableTo)
     {
+        if (from.TypeKind == TypeKind.Null)
+        {
+            EmitDefaultValue(nullableTo);
+            return;
+        }
+
         if (from is NullableTypeSymbol fromNullable)
         {
             if (SymbolEqualityComparer.Default.Equals(fromNullable.UnderlyingType, nullableTo.UnderlyingType))


### PR DESCRIPTION
### Motivation
- Prevent codegen from throwing `NotSupportedException` when emitting conversions from `null` to nullable value types.
- Ensure conversions like `null` → `T?` emit a valid default nullable value instead of failing during IL emission.

### Description
- Add a null-case guard in `EmitNullableConversion` to handle `from.TypeKind == TypeKind.Null` and call `EmitDefaultValue(nullableTo)`.
- Change made in `src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs` to emit default nullable values for null inputs.

### Testing
- Ran `scripts/codex-build.sh` which completed successfully and performed code generation and builds.
- Ran `dotnet test Raven.sln` but the test execution encountered pre-existing test failures and an MSBuild termination, so the full suite did not pass.
- Ran `dotnet format Raven.sln --include src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs --no-restore` to format the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958281c4770832f8c3d3cab7464f566)