### PR TITLE
Emit non-lifted user-defined conversions early and allow implicit nullable->reference boxing

### DIFF
--- a/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/Generators/ExpressionGenerator.cs
@@ -855,6 +855,12 @@ internal class ExpressionGenerator : Generator
         var fromClrType = ResolveClrType(from);
         var toClrType = ResolveClrType(to);
 
+        if (conversion.IsUserDefined && !conversion.IsLifted && conversion.MethodSymbol is IMethodSymbol userDefinedMethod)
+        {
+            ILGenerator.Emit(OpCodes.Call, GetMethodInfo(userDefinedMethod));
+            return;
+        }
+
         if (to is NullableTypeSymbol nullableReference && !nullableReference.UnderlyingType.IsValueType)
         {
             EmitConversion(from, nullableReference.UnderlyingType, conversion);
@@ -978,12 +984,6 @@ internal class ExpressionGenerator : Generator
         if (conversion.IsPointer)
         {
             ILGenerator.Emit(OpCodes.Conv_U);
-            return;
-        }
-
-        if (conversion.IsUserDefined && conversion.MethodSymbol is IMethodSymbol m)
-        {
-            ILGenerator.Emit(OpCodes.Call, GetMethodInfo(m));
             return;
         }
 

--- a/src/Raven.CodeAnalysis/Compilation.Conversions.cs
+++ b/src/Raven.CodeAnalysis/Compilation.Conversions.cs
@@ -214,8 +214,9 @@ public partial class Compilation
                 var conv3 = ClassifyConversion(nullableSource.UnderlyingType, destination, includeUserDefined);
                 if (conv3.Exists)
                 {
+                    var isImplicit = !destination.IsValueType && conv3.IsImplicit;
                     return Finalize(new Conversion(
-                        isImplicit: false,
+                        isImplicit: isImplicit,
                         isIdentity: conv3.IsIdentity,
                         isNumeric: conv3.IsNumeric,
                         isReference: conv3.IsReference,


### PR DESCRIPTION
### Motivation

- Interpolated string lowering was failing to bind `string.Concat` when arguments were nullable value types because nullable-to-reference boxing conversions were marked explicit, which prevented overload resolution and caused `Console.WriteLine` calls to be dropped.  
- User-defined implicit conversions (e.g. `Option<T> -> T`) must be emitted before nullable lowering when they are not lifted to avoid falling through to `NotSupportedException`.  
- The intent is to both emit non-lifted user-defined conversions at the correct time and treat nullable-to-reference boxing as implicit so overload resolution succeeds for interpolated strings.

### Description

- Added an early emission branch in `ExpressionGenerator.EmitConversion` to call the user-defined method when `conversion.IsUserDefined && !conversion.IsLifted` by using `GetMethodInfo` and `OpCodes.Call`.  
- Removed the redundant/late user-defined conversion emission so non-lifted user-defined conversions are not missed and do not fall through to an exception.  
- Updated `Compilation.Conversions.cs` so that when classifying a conversion from a nullable source to a non-value-type destination the result uses `isImplicit = !destination.IsValueType && conv3.IsImplicit`, making nullable-to-reference boxing implicit when the underlying conversion is implicit.  
- Preserved existing lifted nullable conversion and other conversion paths so behavior for lifted conversions and value-type targets remains unchanged.

### Testing

- Ran `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Compilation.Conversions.cs --no-restore`, which completed successfully.  
- No full test suite was executed in this rollout (`dotnet test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69582ffdfadc832faf43cafb69356170)