### PR TITLE
Handle unconstrained generic receiver calls in codegen

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/CodeGen/GenericInvocationCodeGenTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/CodeGen/GenericInvocationCodeGenTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+using Raven.CodeAnalysis.Syntax;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public class GenericInvocationCodeGenTests
+{
+    [Fact]
+    public void UnconstrainedTypeParameter_ToString_BoxesValueTypes()
+    {
+        const string code = """
+import System.*
+
+class Formatter {
+    Format<T>(value: T) -> string {
+        return value.ToString()
+    }
+
+    Run() -> string {
+        return Format<int>(42)
+    }
+}
+""";
+
+        var syntaxTree = SyntaxTree.ParseText(code);
+        var references = TestMetadataReferences.Default;
+        var compilation = Compilation.Create("generic_invocation", new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddSyntaxTrees(syntaxTree)
+            .AddReferences(references);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        using var loaded = TestAssemblyLoader.LoadFromStream(peStream, references);
+        var type = loaded.Assembly.GetType("Formatter", true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var method = type.GetMethod("Run", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var value = (string?)method!.Invoke(instance, Array.Empty<object>());
+        Assert.Equal("42", value);
+    }
+}


### PR DESCRIPTION
### Motivation
- Generic instance calls where the receiver is an unconstrained type parameter need special IL so calls like `value.ToString()` work for value types and reference types the same way as in C#.
- The existing emission path did not handle unconstrained `T` receivers correctly and could produce null-reference or incorrect IL at runtime.
- Ensure codegen emits the appropriate `constrained` prefix and loads the implicit receiver safely for instance methods when the receiver is a type parameter.
- Add a regression test to prevent regressions for the `ToString` pattern on unconstrained generics.

### Description
- Detect unconstrained type-parameter receivers in `EmitInvocationExpressionBase` and set `useConstrainedCall` when `receiver` is an `ITypeParameterSymbol` without a `class` constraint.  
- When `useConstrainedCall` is true, emit address handling for the receiver and emit `OpCodes.Constrained` followed by a `Callvirt` to call the target method.  
- Guard implicit receiver emission so that a missing `receiver` loads `this` via `OpCodes.Ldarg_0` before constrained handling.  
- Add `test/Raven.CodeAnalysis.Tests/CodeGen/GenericInvocationCodeGenTests.cs` covering `Format<T>(value: T) => value.ToString()` invoked with an `int` to validate emitted IL and runtime behavior.

### Testing
- Ran the project build script `scripts/codex-build.sh` and it succeeded.  
- Baseline `dotnet test Raven.sln` was executed earlier and reported unrelated failures in other test projects (existing baseline state).  
- Executed the new targeted test with `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter FullyQualifiedName~GenericInvocationCodeGenTests` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959545ec20c832faad9e9b70952f4f9)