### PR TITLE
Add interpolated string IOperation nodes

### DIFF
--- a/src/Raven.CodeAnalysis/Operations/OperationFactory.cs
+++ b/src/Raven.CodeAnalysis/Operations/OperationFactory.cs
@@ -17,6 +17,15 @@ internal static class OperationFactory
 
         var isImplicit = bound is BoundExpression implicitExpr && implicitExpr.Reason != BoundExpressionReason.None;
 
+        if (syntax is InterpolatedStringExpressionSyntax interpolatedString && bound is BoundExpression boundExpression)
+            return new InterpolatedStringOperation(semanticModel, boundExpression, interpolatedString, isImplicit);
+
+        if (syntax is InterpolatedStringTextSyntax interpolatedText)
+            return new InterpolatedStringTextOperation(semanticModel, interpolatedText, isImplicit);
+
+        if (syntax is InterpolationSyntax interpolation)
+            return new InterpolationOperation(semanticModel, interpolation, isImplicit);
+
         return bound switch
         {
             BoundBlockStatement block => new BlockOperation(semanticModel, block, kind, syntax, block.LocalsToDispose, type, isImplicit),

--- a/src/Raven.CodeAnalysis/Operations/OperationKind.cs
+++ b/src/Raven.CodeAnalysis/Operations/OperationKind.cs
@@ -106,6 +106,21 @@ public enum OperationKind
     Literal,
 
     /// <summary>
+    /// An interpolated string expression.
+    /// </summary>
+    InterpolatedString,
+
+    /// <summary>
+    /// Literal text inside an interpolated string.
+    /// </summary>
+    InterpolatedStringText,
+
+    /// <summary>
+    /// An interpolation inside an interpolated string.
+    /// </summary>
+    Interpolation,
+
+    /// <summary>
     /// A default value expression.
     /// </summary>
     DefaultValue,

--- a/src/Raven.CodeAnalysis/Operations/Operations.cs
+++ b/src/Raven.CodeAnalysis/Operations/Operations.cs
@@ -100,6 +100,25 @@ public interface ILiteralOperation : IOperation
     object Value { get; }
 }
 
+public interface IInterpolatedStringOperation : IOperation
+{
+    ImmutableArray<IInterpolatedStringContentOperation> Contents { get; }
+}
+
+public interface IInterpolatedStringContentOperation : IOperation
+{
+}
+
+public interface IInterpolatedStringTextOperation : IInterpolatedStringContentOperation
+{
+    string Text { get; }
+}
+
+public interface IInterpolationOperation : IInterpolatedStringContentOperation
+{
+    IOperation? Expression { get; }
+}
+
 public interface IDefaultValueOperation : IOperation
 {
 }

--- a/src/Raven.CodeAnalysis/SemanticModel.Operations.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.Operations.cs
@@ -36,6 +36,9 @@ public partial class SemanticModel
             };
         }
 
+        if (bound is null && node is InterpolatedStringContentSyntax && node.Parent is InterpolatedStringExpressionSyntax parentExpression)
+            bound = GetBoundNode(parentExpression);
+
         if (bound is null)
             return null;
 


### PR DESCRIPTION
### Motivation

- Provide Roslyn-like operation support for interpolated strings so semantic analyses and tooling can inspect interpolated content as operations.
- Surface literal text and interpolation parts of an interpolated string via the `SemanticModel` to enable downstream analyzers and codegen.
- Keep operation shapes consistent with existing `IOperation` hierarchy and `OperationKind` enum.

### Description

- Added new `OperationKind` values: `InterpolatedString`, `InterpolatedStringText`, and `Interpolation`.
- Introduced interfaces `IInterpolatedStringOperation`, `IInterpolatedStringContentOperation`, `IInterpolatedStringTextOperation`, and `IInterpolationOperation` in `Operations.cs`.
- Implemented `InterpolatedStringOperation`, `InterpolatedStringTextOperation`, and `InterpolationOperation` in `OperationNodes.cs` and wired creation logic in `OperationFactory.Create` to return these nodes for the corresponding syntax nodes.
- Taught `SemanticModel.GetOperation` to fallback to the parent `InterpolatedStringExpression` bound node when asked for `InterpolatedStringContentSyntax` so content operations can be produced.

### Testing

- Ran `scripts/codex-build.sh` to run generators and build the solution, which completed successfully and produced the updated assemblies.
- Ran `dotnet format` on the modified files to apply formatting changes.
- Ran `dotnet test Raven.sln`; the test run exercised many projects but reported failures in editor and testing harnesses: `Raven.Editor.Tests.ProgramTests.ShowCompletion_NoItems_DoesNotShowWindow`, `Raven.Editor.Tests.ProgramTests.HideCompletion_RefocusesEditor`, `Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics`, and `Raven.CodeAnalysis.Testing.DiagnosticVerifierTest.GetResult_WithIgnoredDiagnostics`.
- The test run was interrupted while `Raven.CodeAnalysis.Samples.Tests` was running, so not all tests completed in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ad8c3390832f89fd9dd1722e7edd)