### PR TITLE
Add argument operations to operation model

### DIFF
--- a/src/Raven.CodeAnalysis/Operations/OperationFactory.cs
+++ b/src/Raven.CodeAnalysis/Operations/OperationFactory.cs
@@ -26,6 +26,9 @@ internal static class OperationFactory
         if (syntax is InterpolationSyntax interpolation)
             return new InterpolationOperation(semanticModel, interpolation, isImplicit);
 
+        if (syntax is ArgumentSyntax argumentSyntax && bound is BoundExpression boundArgument)
+            return new ArgumentOperation(semanticModel, boundArgument, argumentSyntax, isImplicit);
+
         return bound switch
         {
             BoundBlockStatement block => new BlockOperation(semanticModel, block, kind, syntax, block.LocalsToDispose, type, isImplicit),

--- a/src/Raven.CodeAnalysis/Operations/OperationKind.cs
+++ b/src/Raven.CodeAnalysis/Operations/OperationKind.cs
@@ -211,6 +211,11 @@ public enum OperationKind
     Invocation,
 
     /// <summary>
+    /// An argument in a call or object creation.
+    /// </summary>
+    Argument,
+
+    /// <summary>
     /// An object creation expression.
     /// </summary>
     ObjectCreation,

--- a/src/Raven.CodeAnalysis/Operations/OperationNodes.cs
+++ b/src/Raven.CodeAnalysis/Operations/OperationNodes.cs
@@ -765,6 +765,36 @@ internal sealed class AwaitOperation : Operation, IAwaitOperation
     }
 }
 
+internal sealed class ArgumentOperation : Operation, IArgumentOperation
+{
+    private IOperation? _value;
+    private string? _name;
+
+    internal ArgumentOperation(
+        SemanticModel semanticModel,
+        BoundExpression bound,
+        ArgumentSyntax syntax,
+        bool isImplicit)
+        : base(semanticModel, OperationKind.Argument, syntax, bound.Type, isImplicit)
+    {
+    }
+
+    public IOperation? Value => _value ??= SemanticModel.GetOperation(((ArgumentSyntax)Syntax).Expression);
+
+    public string? Name => _name ??= ((ArgumentSyntax)Syntax).NameColon is { Name: IdentifierNameSyntax identifier }
+        ? identifier.Identifier.ValueText
+        : null;
+
+    public bool IsNamed => Name is not null;
+
+    protected override ImmutableArray<IOperation> GetChildrenCore()
+    {
+        return Value is null
+            ? ImmutableArray<IOperation>.Empty
+            : ImmutableArray.Create(Value);
+    }
+}
+
 internal sealed class InvocationOperation : Operation, IInvocationOperation
 {
     private readonly BoundInvocationExpression _bound;

--- a/src/Raven.CodeAnalysis/Operations/Operations.cs
+++ b/src/Raven.CodeAnalysis/Operations/Operations.cs
@@ -235,6 +235,15 @@ public interface IInvocationOperation : IOperation
     ImmutableArray<IOperation> Arguments { get; }
 }
 
+public interface IArgumentOperation : IOperation
+{
+    IOperation? Value { get; }
+
+    string? Name { get; }
+
+    bool IsNamed { get; }
+}
+
 public interface IDelegateCreationOperation : IOperation
 {
 }

--- a/src/Raven.CodeAnalysis/SemanticModel.Operations.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.Operations.cs
@@ -36,6 +36,9 @@ public partial class SemanticModel
             };
         }
 
+        if (bound is null && node is ArgumentSyntax argument)
+            bound = GetBoundNode(argument.Expression);
+
         if (bound is null && node is InterpolatedStringContentSyntax && node.Parent is InterpolatedStringExpressionSyntax parentExpression)
             bound = GetBoundNode(parentExpression);
 


### PR DESCRIPTION
### Motivation
- Represent individual call/object-creation arguments in the operation tree so analyzers/consumers can inspect argument values and names. 
- Preserve information about named arguments and connect argument syntax nodes to bound expressions. 
- Make argument nodes part of the same `IOperation` model as other expression/statement operations. 

### Description
- Add `OperationKind.Argument` to `OperationKind` to identify argument operations. 
- Introduce `IArgumentOperation` in `Operations.cs` and implement `ArgumentOperation` in `OperationNodes.cs` exposing `Value`, `Name`, and `IsNamed`. 
- Wire creation of `ArgumentOperation` in `OperationFactory.Create` for `ArgumentSyntax` nodes and adjust `SemanticModel.GetOperation` to obtain bound nodes for `ArgumentSyntax` expressions. 

### Testing
- Ran `scripts/codex-build.sh` and the solution build steps completed successfully with 0 errors and 0 warnings. 
- Ran `dotnet format` on the modified files to apply formatting. 
- Attempted `dotnet test Raven.sln --no-build`, which failed due to VSTest reporting invalid test assembly arguments (external test runner invocation issue), not compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a35e5bfb4832f8b359637ce951a96)