### PR TITLE
Document extension operator and conversion operator support

### DIFF
--- a/docs/lang/proposals/drafts/conversion-from-option-to-nullable.md
+++ b/docs/lang/proposals/drafts/conversion-from-option-to-nullable.md
@@ -39,7 +39,7 @@ This proposal depends on separate features: user-defined conversion operators an
 
 * ✅ Syntax and binding for `explicit operator` / `implicit operator` declarations are implemented.
 * ✅ Conversion operators are discovered during cast binding and implicit conversion checks used by overload resolution.
-* ⏳ Static extension conversion operators remain blocked on the extension operator work.
+* ✅ Static extension conversion operators are supported and can be discovered during conversion checks.
 
 ## Motivation
 

--- a/docs/lang/proposals/drafts/operator-overloading-plan.md
+++ b/docs/lang/proposals/drafts/operator-overloading-plan.md
@@ -11,7 +11,7 @@
 
 ## Implementation status (current)
 * ✅ **Syntax surface and tokens**: `operator` contextual keyword, overloadable operator tokens, `OperatorDeclarationSyntax`, parser support (classes + extensions), and normalizer/formatting support are implemented. Specification + grammar updates are in place.
-* 🟡 **Declaration binding**: operator declarations bind into symbols with static/public/arity diagnostics and metadata name mapping. Extension operator declarations are rejected (diagnostic only) and are not bound into symbols.
+* 🟡 **Declaration binding**: operator declarations bind into symbols with static/public/arity diagnostics and metadata name mapping. Extension operator declarations are bound and participate in member lookup/overload resolution.
 * 🟡 **Consumption**: unary and binary operator binding now use overload resolution for user-defined operators (including extension operators) and bind to operator method invocations; nullable/literal lifting remains pending.
 * ⏳ **Codegen + lowering**: no changes yet for emitting operator methods or ensuring bound operator invocations survive lowering.
 * ⏳ **IDE/semantic model**: `GetDeclaredSymbol` is supported for class/interface operator declarations; richer symbol info for call sites and diagnostics remain.
@@ -39,7 +39,7 @@
 3. 🟡 **Declaration binding and lookup**
    * Update `TypeMemberBinder`/`DeclarationTable` to include operator members when walking type syntax, producing operator symbols alongside methods/constructors.
    * Ensure operators participate in member lookup via their metadata names (e.g., `op_Addition`) and that overload sets are disambiguated by parameter types.
-   * For extensions, allow operator declarations and wire extension operator lookup so consuming sites can see them when the receiver type matches.
+   * For extensions, allow operator declarations and wire extension operator lookup so consuming sites can see them when the receiver type matches. (Done.)
 
 4. 🟡 **Overload resolution for consumption**
    * Expand binary/unary binding in `BlockBinder` to gather operator candidates from both operand types and applicable extensions, using the operator metadata name and enforcing static binding rules. (Done for static extension operators.)

--- a/docs/lang/spec/classes-and-members.md
+++ b/docs/lang/spec/classes-and-members.md
@@ -352,8 +352,8 @@ contextual keyword followed by one of the supported operator tokens (`+`, `-`,
 parenthesized parameter list, optional return-type arrow, and either a block
 body or expression body. Operators must be `public static`, and the parameter
 count must match the chosen operator (unary or binary). Operator declarations
-are currently limited to classes and structs; extensions cannot declare
-operators yet.
+are supported in classes, structs, and extensions; extension operators follow
+the same `public static` requirements as type members.
 
 ```raven
 class Vector
@@ -362,6 +362,11 @@ class Vector
     public static operator -(value: Vector) -> Vector { /* ... */ }
 }
 ```
+
+Extensions may also declare `implicit operator` and `explicit operator`
+conversion members. These conversion operators are `public static` and are
+resolved using the same extension lookup rules as other static extension
+members.
 
 ### Invocation operator
 

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -47,7 +47,8 @@ ExtensionDeclaration     ::= 'extension' Identifier 'for' Type ExtensionBody ;
 ExtensionBody            ::= '{' {ExtensionMember} '}' ;
 ExtensionMember          ::= ExtensionMethodDeclaration
                            | ExtensionPropertyDeclaration
-                           | OperatorDeclaration ;
+                           | OperatorDeclaration
+                           | ConversionOperatorDeclaration ;
 ExtensionMethodDeclaration
                            ::= ExtensionMethodModifiers?
                                Identifier '(' ParameterList? ')'


### PR DESCRIPTION
### Motivation

- Bring the language specification and proposals in-line with implemented support for operators declared in `extension` blocks.
- Clarify that extension-declared operators follow the same `public static` rules as type members and participate in lookup/overload resolution.
- Surface that `implicit operator`/`explicit operator` conversion members can be declared on extensions and are discoverable during conversion checks.
- Update the grammar to formally permit conversion operator declarations inside extension bodies.

### Description

- Updated `docs/lang/spec/classes-and-members.md` to state that operator declarations are supported in classes, structs, and extensions and to document extension `implicit`/`explicit` conversion operators.
- Extended `docs/lang/spec/grammar.ebnf` so `ExtensionMember` can include `ConversionOperatorDeclaration` in addition to `OperatorDeclaration`.
- Updated `docs/lang/proposals/drafts/operator-overloading-plan.md` to reflect that extension operator declarations are bound and participate in member lookup/overload resolution.
- Updated `docs/lang/proposals/drafts/conversion-from-option-to-nullable.md` to mark static extension conversion operators as supported and discoverable during conversion checks.

### Testing

- Ran `scripts/codex-build.sh` and code generation/build steps completed successfully.
- Attempted `dotnet test Raven.sln --property WarningLevel=0` which failed immediately due to MSBuild property syntax handling for that flag.
- Ran `dotnet test Raven.sln /p:WarningLevel=0` which executed but produced multiple failing unit tests across `Raven.CodeAnalysis.*` and `Raven.Editor.Tests`, so the test run did not fully succeed.
- No additional automated tests were added for the specification changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a46c3d4b8832f88cc8f75e18b3a9e)