### PR TITLE
Invocation operator: interface support and virtual/abstract modifiers

### DIFF
--- a/docs/lang/proposals/invocation-operator.md
+++ b/docs/lang/proposals/invocation-operator.md
@@ -8,7 +8,7 @@ You can define one or more unique invocation operators for your type.
 
 ## Syntax
 
-The syntax for declaring an invocation operator is this. (as defined in a class)
+The syntax for declaring an invocation operator is this. (as defined in a class or interface)
 
 ```raven
 public class Test {
@@ -17,6 +17,8 @@ public class Test {
     }
 }
 ```
+
+In classes, invocation operators can be marked `virtual` or `abstract` and may be overridden like other members.
 
 When "invoking" an instance of a type with an invocation operator:
 
@@ -50,4 +52,3 @@ var x = test.Invoke(2);
 ## Notes
 
 The `Invoke` method mirrors the one of delegates.
-

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -600,6 +600,8 @@ Console.WriteLine("Test")
 The `()` call operator invokes a function-valued expression. If the target
 expression's type defines an invocation operator via a `self` method, that
 member is invoked instead; see [Invocation operator](#invocation-operator).
+Invocation operators can be declared on classes or interfaces. Class
+declarations may mark them `virtual` or `abstract` to support overrides.
 
 When the target has optional parameters, omitted trailing arguments are filled
 in using the defaults declared on the parameter list. The supplied arguments are

--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -348,6 +348,7 @@ internal class TypeMemberBinder : Binder
         var isVirtual = modifiers.Any(m => m.Kind == SyntaxKind.VirtualKeyword);
         var isOverride = modifiers.Any(m => m.Kind == SyntaxKind.OverrideKeyword);
         var isSealed = modifiers.Any(m => m.Kind == SyntaxKind.SealedKeyword);
+        var isAbstract = modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
         var defaultAccessibility = AccessibilityUtilities.GetDefaultMemberAccessibility(_containingType);
         var methodAccessibility = AccessibilityUtilities.DetermineAccessibility(modifiers, defaultAccessibility);
 
@@ -357,6 +358,7 @@ internal class TypeMemberBinder : Binder
             isVirtual = false;
             isOverride = false;
             isSealed = false;
+            isAbstract = false;
             methodAccessibility = modifiers.Any(m => m.Kind == SyntaxKind.InternalKeyword)
                 ? Accessibility.Internal
                 : Accessibility.Public;
@@ -368,6 +370,7 @@ internal class TypeMemberBinder : Binder
             isVirtual = false;
             isOverride = false;
             isSealed = false;
+            isAbstract = false;
             methodAccessibility = Accessibility.Private;
         }
 
@@ -387,6 +390,7 @@ internal class TypeMemberBinder : Binder
             isVirtual = false;
             isOverride = false;
             isSealed = false;
+            isAbstract = false;
         }
 
         if (isVirtual && !isOverride && _containingType.IsSealed)
@@ -418,6 +422,7 @@ internal class TypeMemberBinder : Binder
             isVirtual: isVirtual,
             isOverride: isOverride,
             isSealed: isSealed,
+            isAbstract: isAbstract,
             declaredAccessibility: methodAccessibility);
 
         var isExtensionMember = isExtensionContainer && !hasStaticModifier;
@@ -577,7 +582,7 @@ internal class TypeMemberBinder : Binder
             }
         }
 
-        methodSymbol.UpdateModifiers(isVirtual, isOverride, isSealed);
+        methodSymbol.UpdateModifiers(isVirtual, isOverride, isSealed, isAbstract);
 
         CheckForDuplicateSignature(metadataName, displayName, signatureArray, identifierToken.GetLocation(), methodDecl);
 

--- a/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -482,6 +482,12 @@ internal class MethodGenerator
             return;
         }
 
+        if (MethodSymbol.IsAbstract)
+        {
+            _bodyEmitted = true;
+            return;
+        }
+
         if (!_liftedExtensionParameters.IsDefaultOrEmpty && _liftedExtensionBuilders is not null)
             TypeGenerator.CodeGen.RegisterGenericParameters(_liftedExtensionParameters, _liftedExtensionBuilders);
 

--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
@@ -18,6 +18,7 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
     private bool _isOverride;
     private bool _isVirtual;
     private bool _isSealed;
+    private bool _isAbstract;
     private bool _declaredInExtension;
     private ImmutableArray<AttributeData> _lazyReturnTypeAttributes;
     private bool? _lazyIsExtensionMethod;
@@ -51,6 +52,7 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
         bool isVirtual = false,
         bool isOverride = false,
         bool isSealed = false,
+        bool isAbstract = false,
         Accessibility declaredAccessibility = Accessibility.NotApplicable)
             : base(SymbolKind.Method, name, containingSymbol, containingType, containingNamespace, locations, declaringSyntaxReferences, declaredAccessibility)
     {
@@ -63,7 +65,8 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
         MethodKind = methodKind;
 
         _isOverride = isOverride;
-        _isVirtual = isVirtual || isOverride;
+        _isAbstract = isAbstract;
+        _isVirtual = isVirtual || isOverride || isAbstract;
         _isSealed = isSealed;
     }
 
@@ -114,7 +117,7 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
 
     public IMethodSymbol? OriginalDefinition => this;
 
-    public bool IsAbstract { get; }
+    public bool IsAbstract => _isAbstract;
 
     public bool IsAsync { get; }
 
@@ -190,10 +193,11 @@ internal partial class SourceMethodSymbol : SourceSymbol, IMethodSymbol
 
     internal void SetReturnType(ITypeSymbol returnType) => _returnType = returnType;
 
-    internal void UpdateModifiers(bool isVirtual, bool isOverride, bool isSealed)
+    internal void UpdateModifiers(bool isVirtual, bool isOverride, bool isSealed, bool isAbstract)
     {
         _isOverride = isOverride;
-        _isVirtual = isVirtual || isOverride;
+        _isAbstract = isAbstract;
+        _isVirtual = isVirtual || isOverride || isAbstract;
         _isSealed = isSealed;
     }
 

--- a/test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs
@@ -1,6 +1,9 @@
+using System.Linq;
+
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Symbols;
 using Raven.CodeAnalysis.Syntax;
+
 using Xunit;
 
 namespace Raven.CodeAnalysis.Semantics.Tests;
@@ -27,5 +30,84 @@ let x = t(2)
         var symbol = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;
         Assert.Equal("Invoke", symbol.Name);
     }
+
+    [Fact]
+    public void InvocationOperator_InterfaceDeclaration_BindsInvokeMethod()
+    {
+        var source = """
+interface ICallable {
+    self(value: int) -> int;
 }
 
+class Callable : ICallable {
+    public self(value: int) -> int {
+        return value + 1;
+    }
+}
+
+let callable: ICallable = Callable()
+let result = callable(2)
+""";
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+        var model = compilation.GetSemanticModel(tree);
+        var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Last();
+        var symbol = (IMethodSymbol)model.GetSymbolInfo(invocation).Symbol!;
+        Assert.Equal("Invoke", symbol.Name);
+        Assert.Equal(TypeKind.Interface, symbol.ContainingType.TypeKind);
+        Assert.Equal("ICallable", symbol.ContainingType.Name);
+    }
+
+    [Fact]
+    public void InvocationOperator_Modifiers_AreTrackedOnSymbols()
+    {
+        var source = """
+abstract class Base {
+    public abstract self(value: int) -> int;
+}
+
+class Derived : Base {
+    public override self(value: int) -> int {
+        return value;
+    }
+}
+
+open class VirtualBase {
+    public virtual self(value: int) -> int {
+        return value;
+    }
+}
+
+class VirtualDerived : VirtualBase {
+    public override self(value: int) -> int {
+        return value + 2;
+    }
+}
+""";
+
+        var tree = SyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+        var model = compilation.GetSemanticModel(tree);
+
+        var baseType = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "Base");
+        var baseMethod = baseType.Members.OfType<MethodDeclarationSyntax>().Single();
+        var baseSymbol = (IMethodSymbol)model.GetDeclaredSymbol(baseMethod)!;
+        Assert.True(baseSymbol.IsAbstract);
+        Assert.True(baseSymbol.IsVirtual);
+
+        var derivedType = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "Derived");
+        var derivedMethod = derivedType.Members.OfType<MethodDeclarationSyntax>().Single();
+        var derivedSymbol = (IMethodSymbol)model.GetDeclaredSymbol(derivedMethod)!;
+        Assert.True(derivedSymbol.IsOverride);
+
+        var virtualBaseType = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "VirtualBase");
+        var virtualBaseMethod = virtualBaseType.Members.OfType<MethodDeclarationSyntax>().Single();
+        var virtualBaseSymbol = (IMethodSymbol)model.GetDeclaredSymbol(virtualBaseMethod)!;
+        Assert.True(virtualBaseSymbol.IsVirtual);
+        Assert.False(virtualBaseSymbol.IsOverride);
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow types declared as interfaces to declare invocation operators so calls on interface-typed values can bind to `Invoke` members.
- Enable `virtual`/`abstract` modifiers on invocation operators declared in classes so they behave like other overridable members.
- Ensure the code generator does not emit bodies for abstract/interface-only invocation operators.
- Add tests and docs to capture the new semantics and surface regressions early.

### Description
- Track abstractness on method symbols by adding `_isAbstract` and exposing `IsAbstract` in `SourceMethodSymbol` and updating `UpdateModifiers` to accept `isAbstract`.
- Parse and honor the `abstract` modifier in `TypeMemberBinder` and pass it into `SourceMethodSymbol` creation and modifier update logic.
- Make `MethodGenerator.EmitBody` skip emission for abstract methods (and retain the existing interface-method body skipping behavior).
- Add semantic tests in `test/Raven.CodeAnalysis.Tests/Semantics/InvocationOperatorTests.cs` covering invocation operators on interfaces and modifier propagation, and update docs (`docs/lang/proposals/invocation-operator.md` and `docs/lang/spec/language-specification.md`) to mention interface support and `virtual`/`abstract` usage.

### Testing
- Ran the build script `scripts/codex-build.sh` to regenerate generated sources and build core projects, which completed successfully.
- Ran the full test suite with `dotnet test` earlier which surfaced multiple unrelated, pre-existing test failures (these were not introduced by this change).
- Ran the focused test run for invocation operator tests: `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj --filter InvocationOperatorTests -p:WarningLevel=0`, which passed (3 tests).
- Ensured code formatting with `dotnet format` on modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695acdcf9060832f9b11fe046cf42f1b)