### PR TITLE
Support `new()` and `notnull` generic constraints in binder and codegen

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -1633,6 +1633,12 @@ internal abstract class Binder
                 allSatisfied = false;
             }
 
+            if ((constraintKind & TypeParameterConstraintKind.Constructor) != 0 && !SemanticFacts.SatisfiesConstructorConstraint(typeArgument))
+            {
+                ReportConstraintViolation(typeArgument, "new()", typeParameter, displayName, getArgumentLocation(i));
+                allSatisfied = false;
+            }
+
             if ((constraintKind & TypeParameterConstraintKind.TypeConstraint) != 0)
             {
                 var constraintTypes = typeParameter.ContainingSymbol is SubstitutedMethodSymbol substituted &&
@@ -1755,6 +1761,12 @@ internal abstract class Binder
             if ((constraintKind & TypeParameterConstraintKind.NotNull) != 0 && !SemanticFacts.SatisfiesNotNullConstraint(typeArgument))
             {
                 ReportConstraintViolation(typeArgument, "notnull", typeParameter, displayName, getArgumentLocation(i));
+                allSatisfied = false;
+            }
+
+            if ((constraintKind & TypeParameterConstraintKind.Constructor) != 0 && !SemanticFacts.SatisfiesConstructorConstraint(typeArgument))
+            {
+                ReportConstraintViolation(typeArgument, "new()", typeParameter, displayName, getArgumentLocation(i));
                 allSatisfied = false;
             }
 

--- a/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Raven.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -182,6 +182,9 @@ internal class CodeGenerator
 
         builder.SetGenericParameterAttributes(attributes);
 
+        if ((parameter.ConstraintKind & TypeParameterConstraintKind.NotNull) != 0)
+            builder.SetCustomAttribute(CreateNullableAnnotationAttribute(isNullable: false));
+
         if (parameter.ConstraintTypes.IsDefaultOrEmpty)
             return;
 
@@ -235,8 +238,8 @@ internal class CodeGenerator
     ConstructorInfo? _extensionMarkerNameCtor;
     ConstructorInfo? _extensionAttributeCtor;
 
-    bool _emitTypeUnionAttribute = true;
-    bool _emitNullType = true;
+    readonly bool _emitTypeUnionAttribute = true;
+    readonly bool _emitNullType = true;
     bool _emitExtensionMarkerNameAttribute = true;
 
     internal void ApplyCustomAttributes(ImmutableArray<AttributeData> attributes, Action<CustomAttributeBuilder> apply)
@@ -402,6 +405,12 @@ internal class CodeGenerator
 
         EnsureNullableAttributeType();
         return new CustomAttributeBuilder(_nullableCtor!, new object[] { (byte)2 });
+    }
+
+    internal CustomAttributeBuilder CreateNullableAnnotationAttribute(bool isNullable)
+    {
+        EnsureNullableAttributeType();
+        return new CustomAttributeBuilder(_nullableCtor!, new object[] { isNullable ? (byte)2 : (byte)1 });
     }
 
     internal CustomAttributeBuilder? CreateTupleElementNamesAttribute(ITypeSymbol type)

--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -569,6 +569,12 @@ internal sealed class OverloadResolver
                 return false;
             }
 
+            if ((constraintKind & TypeParameterConstraintKind.Constructor) != 0 &&
+                !SemanticFacts.SatisfiesConstructorConstraint(typeArgument))
+            {
+                return false;
+            }
+
             if ((constraintKind & TypeParameterConstraintKind.TypeConstraint) == 0)
                 continue;
 


### PR DESCRIPTION
### Motivation
- Enforce the `new()` (parameterless constructor) constraint when validating type arguments so generic constraints behave as specified.
- Ensure `notnull` constraint information is preserved/emitted in generated metadata so runtime/consumers see non-nullable generic parameters.
- Keep overload resolution consistent with the new constructor constraint checks to avoid binding invalid generic candidates.

### Description
- Added `SatisfiesConstructorConstraint` to `SemanticFacts` to evaluate `new()` constraints for value types, type parameters, and named types.
- Hooked constructor-constraint validation into binder checks (`Binder.ValidateTypeArgumentConstraints` and method variant) and into overload filtering (`OverloadResolver`).
- Emit `notnull` annotation metadata for generic parameters in `CodeGenerator.ApplyGenericParameterConstraints` by adding `CreateNullableAnnotationAttribute` and applying it for `notnull` parameters.
- Minor codegen cleanup: made a couple of internal flags `readonly` and added the nullable-annotation helper used by codegen.

### Testing
- Ran the provided build script: `scripts/codex-build.sh` (succeeded).
- Ran full test suite: `dotnet test Raven.sln /p:WarningLevel=0` which reported failures; specifically, two failing tests in `Raven.CodeAnalysis.Testing` (`DiagnosticVerifierTest.GetResult_WithMatchedDiagnostics`, `GetResult_WithIgnoredDiagnostics`) and one failing test in `Raven.Editor.Tests` (`ProgramTests.ShowCompletion_NoItems_DoesNotShowWindow`), while other test projects (e.g. `TypeUnionAnalyzer.Tests`) passed.
- Note: an earlier `dotnet test Raven.sln --property WarningLevel=0` invocation failed due to MSBuild switch syntax; the corrected command above was used for the reported results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f26f60cc832fbbb4db29140c3b82)