### PR TITLE
Enforce valid inheritance modifier combinations during member binding

### DIFF
--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -195,6 +195,10 @@
     Title="Static members cannot be virtual or override"
     Message="Static member '{memberName}' cannot be marked '{modifier}'"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
+  <Descriptor Id="RAV0326" Identifier="InvalidMemberModifierCombination"
+    Title="Invalid modifier combination"
+    Message="Member '{memberName}' cannot be marked both '{modifier1}' and '{modifier2}'"
+    Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0316" Identifier="OptionalParameterDefaultValueCannotConvert"
     Title="Optional parameter default value cannot be converted"
     Message="The default value for optional parameter '{parameterName}' cannot be converted to type '{parameterType}'"


### PR DESCRIPTION
### Motivation

- Ensure inheritance modifiers (`abstract`, `virtual`, `override`, `sealed`, `static`) are validated consistently while binding members so invalid combinations are rejected at bind time.
- Prevent illegal modifier combinations that would otherwise lead to incorrect symbol state or surprising diagnostics later in the pipeline.

### Description

- Added `ValidateInheritanceModifiers` to `TypeMemberBinder` and invoked it when binding methods, properties, and indexers to centralize modifier validation logic.
- Propagated the `isAbstract` flag to accessor method symbols by passing `isAbstract: isAbstract` when creating `SourceMethodSymbol` instances for property and indexer accessors.
- Added a new diagnostic descriptor `RAV0326` (`InvalidMemberModifierCombination`) in `src/Raven.CodeAnalysis/DiagnosticDescriptors.xml` and regenerated diagnostic sources.

### Testing

- Ran the build script `scripts/codex-build.sh`, which completed successfully.
- Ran the diagnostics generator with `dotnet run` for `tools/DiagnosticsGenerator`, which produced updated diagnostics successfully.
- Ran `dotnet format` on the modified files, which completed successfully.
- Attempted `dotnet test`, but the test run encountered existing baseline failures in the repository and was not completed (no new test coverage was added by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f684185c832fb6142d54d7ab6870)