### PR TITLE
Clarify when to run codex-build and document `dotnet test` WarningLevel usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,10 @@
 
 **Before making changes:** run the test suite once to establish a baseline.
 
-**Before building/tests** you need to build the solution by running this script:
+**Before building/tests** run the solution build script only when needed:
+
+- The first time you compile in a fresh workspace or after a clean checkout.
+- Any time the syntax/bound model inputs that drive generation change (e.g., updates under `tools/*Generator`, `src/Raven.CodeAnalysis` model definitions, or generator config files).
 
 ```bash
 scripts/codex-build.sh
@@ -15,6 +18,13 @@ scripts/codex-build.sh
 *This will make sure that the essentials (Raven.CodeAnalysis) is being correctly built*
 
 Afterwards, you might just have to run `dotnet build <project path> --property WarningLevel=0` in order to build specific projects - unless you need to rebuild the entire syntax model or bound nodes.
+
+**Running tests with WarningLevel=0:** use one of the following forms.
+
+```bash
+dotnet test <project-file-path> /property:WarningLevel=0
+dotnet test /property:WarningLevel=0
+```
 
 **Coding guidelines:** follow idiomatic .NET style; treat compiler components as immutable; prefer diagnostics over exceptions; keep services loosely coupled via interfaces/DI.
 


### PR DESCRIPTION
### Motivation

- Reduce unnecessary generator runs by making it clear `scripts/codex-build.sh` is only needed for fresh workspaces or when generation inputs change. 
- Avoid confusion about the exact `dotnet test` syntax for disabling warnings by documenting the correct `/property:WarningLevel=0` forms. 

### Description

- Update `AGENTS.md` build guidance to run `scripts/codex-build.sh` only on first compile in a fresh workspace or when syntax/bound model inputs change. 
- Add an explicit code block showing the `scripts/codex-build.sh` invocation and list the circumstances that require it. 
- Document the exact `dotnet test` forms to use with `WarningLevel=0` as `dotnet test <project-file-path> /property:WarningLevel=0` and `dotnet test /property:WarningLevel=0`.

### Testing

- Ran `scripts/codex-build.sh`, which executed generators and built `Raven.CodeAnalysis` successfully. 
- Ran `dotnet test /property:WarningLevel=0`, which started the full test suite but produced multiple test failures and an aborted run due to a stack overflow in `Raven.CodeAnalysis.Tests`. 
- No changes to production code were made, only documentation updates, so no additional unit test fixes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696101be0218832f97db157cca82ea10)