### PR TITLE
Add `final` modifier to seal overrides

### DIFF
--- a/docs/lang/spec/classes-and-members.md
+++ b/docs/lang/spec/classes-and-members.md
@@ -41,6 +41,9 @@ class Counter
 * Methods/ctors/properties/indexers may use arrow bodies.
 * Members can be marked `static` to associate them with the type rather than an instance.
 
+Use `final` alongside `override` to seal an override and prevent further overrides in derived types (`final override` in Raven,
+equivalent to C#'s `sealed override`). The compiler reports an error if `final` is applied without `override`.
+
 `const` fields behave like their local counterparts: they must specify a
 compile-time constant initializer, and the compiler records the folded value in
 metadata. Raven treats these declarations as implicitly `static` even if the

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -12,7 +12,7 @@ AliasDirective           ::= 'alias' Identifier '=' Type ; (* Target may be a fu
 
 MemberModifiers          ::= { MemberModifier } ;
 MemberModifier           ::= AccessModifier
-                           | 'static' | 'abstract' | 'virtual' | 'override' | 'sealed'
+                           | 'static' | 'abstract' | 'virtual' | 'override' | 'final' | 'sealed'
                            | 'readonly' | 'async' | 'extern' ;
 
 AccessModifier           ::= 'public' | 'internal' | 'protected' | 'private' ;

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -53,7 +53,7 @@ classifies each keyword as either reserved or contextual.
 | Kind | Keywords |
 | --- | --- |
 | Reserved | `and`, `as`, `await`, `base`, `bool`, `break`, `catch`, `char`, `class`, `const`, `continue`, `default`, `double`, `each`, `else`, `enum`, `false`, `finally`, `for`, `func`, `goto`, `if`, `int`, `interface`, `is`, `let`, `match`, `new`, `not`, `null`, `object`, `or`, `return`, `self`, `string`, `struct`, `throw`, `true`, `try`, `typeof`, `var`, `when`, `while`, `yield` |
-| Contextual | `abstract`, `alias`, `explicit`, `get`, `implicit`, `import`, `in`, `init`, `internal`, `namespace`, `open`, `operator`, `partial`, `out`, `override`, `private`, `protected`, `public`, `ref`, `sealed`, `set`, `static`, `unit`, `using`, `val`, `virtual` |
+| Contextual | `abstract`, `alias`, `explicit`, `final`, `get`, `implicit`, `import`, `in`, `init`, `internal`, `namespace`, `open`, `operator`, `partial`, `out`, `override`, `private`, `protected`, `public`, `ref`, `sealed`, `set`, `static`, `unit`, `using`, `val`, `virtual` |
 
 Reserved keywords are always treated as keywords and therefore unavailable for use as identifiers—even when a construct makes
 their presence optional (for example, omitting `each` in a `for` expression). Contextual keywords behave like ordinary

--- a/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs
@@ -361,7 +361,7 @@ internal class TypeMemberBinder : Binder
         var isAsync = modifiers.Any(m => m.Kind == SyntaxKind.AsyncKeyword);
         var isVirtual = modifiers.Any(m => m.Kind == SyntaxKind.VirtualKeyword);
         var isOverride = modifiers.Any(m => m.Kind == SyntaxKind.OverrideKeyword);
-        var isSealed = modifiers.Any(m => m.Kind == SyntaxKind.SealedKeyword);
+        var isSealed = modifiers.Any(m => m.Kind is SyntaxKind.SealedKeyword or SyntaxKind.FinalKeyword);
         var isAbstract = modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
         var defaultAccessibility = AccessibilityUtilities.GetDefaultMemberAccessibility(_containingType);
         var methodAccessibility = AccessibilityUtilities.DetermineAccessibility(modifiers, defaultAccessibility);
@@ -1298,7 +1298,7 @@ internal class TypeMemberBinder : Binder
         var isAbstract = modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
         var isVirtual = modifiers.Any(m => m.Kind == SyntaxKind.VirtualKeyword);
         var isOverride = modifiers.Any(m => m.Kind == SyntaxKind.OverrideKeyword);
-        var isSealed = modifiers.Any(m => m.Kind == SyntaxKind.SealedKeyword);
+        var isSealed = modifiers.Any(m => m.Kind is SyntaxKind.SealedKeyword or SyntaxKind.FinalKeyword);
         var defaultAccessibility = AccessibilityUtilities.GetDefaultMemberAccessibility(_containingType);
         var propertyAccessibility = AccessibilityUtilities.DetermineAccessibility(modifiers, defaultAccessibility);
         var explicitInterfaceSpecifier = propertyDecl.ExplicitInterfaceSpecifier;
@@ -1781,7 +1781,7 @@ internal class TypeMemberBinder : Binder
         var isAbstract = modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
         var isVirtual = modifiers.Any(m => m.Kind == SyntaxKind.VirtualKeyword);
         var isOverride = modifiers.Any(m => m.Kind == SyntaxKind.OverrideKeyword);
-        var isSealed = modifiers.Any(m => m.Kind == SyntaxKind.SealedKeyword);
+        var isSealed = modifiers.Any(m => m.Kind is SyntaxKind.SealedKeyword or SyntaxKind.FinalKeyword);
         var defaultAccessibility = AccessibilityUtilities.GetDefaultMemberAccessibility(_containingType);
         var eventAccessibility = AccessibilityUtilities.DetermineAccessibility(modifiers, defaultAccessibility);
         var explicitInterfaceSpecifier = eventDecl.ExplicitInterfaceSpecifier;
@@ -2272,7 +2272,7 @@ internal class TypeMemberBinder : Binder
         var isStatic = hasStaticModifier; var isAbstract = modifiers.Any(m => m.Kind == SyntaxKind.AbstractKeyword);
         var isVirtual = modifiers.Any(m => m.Kind == SyntaxKind.VirtualKeyword);
         var isOverride = modifiers.Any(m => m.Kind == SyntaxKind.OverrideKeyword);
-        var isSealed = modifiers.Any(m => m.Kind == SyntaxKind.SealedKeyword);
+        var isSealed = modifiers.Any(m => m.Kind is SyntaxKind.SealedKeyword or SyntaxKind.FinalKeyword);
         var defaultAccessibility = AccessibilityUtilities.GetDefaultMemberAccessibility(_containingType);
         var indexerAccessibility = AccessibilityUtilities.DetermineAccessibility(modifiers, defaultAccessibility);
         var explicitInterfaceSpecifier = indexerDecl.ExplicitInterfaceSpecifier;

--- a/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
+++ b/src/Raven.CodeAnalysis/DiagnosticDescriptors.xml
@@ -192,12 +192,12 @@
     Message="Member '{memberName}' cannot be virtual because the containing type '{typeName}' is sealed"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0309" Identifier="SealedMemberMustOverride"
-    Title="'sealed' modifier requires override"
-    Message="Member '{memberName}' cannot be marked 'sealed' because it is not an override"
+    Title="'final' modifier requires override"
+    Message="Member '{memberName}' cannot be marked 'final' because it is not an override"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0310" Identifier="CannotOverrideSealedMember"
-    Title="Cannot override sealed member"
-    Message="Member '{memberName}' cannot override sealed member '{overriddenMemberName}'"
+    Title="Cannot override final member"
+    Message="Member '{memberName}' cannot override final member '{overriddenMemberName}'"
     Category="compiler" Severity="Error" EnabledByDefault="true" Description="" HelpLinkUri="" />
   <Descriptor Id="RAV0311" Identifier="StaticMemberCannotBeVirtualOrOverride"
     Title="Static members cannot be virtual or override"

--- a/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs
@@ -1225,9 +1225,9 @@ public static partial class SymbolExtensions
                     if (method.IsAbstract)
                         parts.Add("abstract");
 
-                    // C#-style: sealed override
+                    // C#-style: final override
                     if (method.IsSealed && method.IsOverride)
-                        parts.Add("sealed");
+                        parts.Add("final");
 
                     if (method.IsVirtual)
                         parts.Add("virtual");

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/CompilationUnitSyntaxParser.cs
@@ -85,7 +85,8 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
             SyntaxKind.EnumKeyword or SyntaxKind.UnionKeyword or SyntaxKind.StructKeyword or SyntaxKind.ClassKeyword or
             SyntaxKind.InterfaceKeyword or SyntaxKind.ExtensionKeyword or SyntaxKind.OpenBracketToken or
             SyntaxKind.PublicKeyword or SyntaxKind.PrivateKeyword or SyntaxKind.InternalKeyword or SyntaxKind.ProtectedKeyword or
-            SyntaxKind.StaticKeyword or SyntaxKind.AbstractKeyword or SyntaxKind.SealedKeyword or SyntaxKind.OpenKeyword or
+            SyntaxKind.StaticKeyword or SyntaxKind.AbstractKeyword or SyntaxKind.FinalKeyword or SyntaxKind.SealedKeyword or
+            SyntaxKind.OpenKeyword or
             SyntaxKind.PartialKeyword or SyntaxKind.OverrideKeyword or SyntaxKind.AsyncKeyword;
     }
 
@@ -141,7 +142,8 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
                  nextToken.IsKind(SyntaxKind.PublicKeyword) || nextToken.IsKind(SyntaxKind.PrivateKeyword) ||
                  nextToken.IsKind(SyntaxKind.InternalKeyword) || nextToken.IsKind(SyntaxKind.ProtectedKeyword) ||
                  nextToken.IsKind(SyntaxKind.StaticKeyword) || nextToken.IsKind(SyntaxKind.AbstractKeyword) ||
-                 nextToken.IsKind(SyntaxKind.SealedKeyword) || nextToken.IsKind(SyntaxKind.OpenKeyword) ||
+                 nextToken.IsKind(SyntaxKind.FinalKeyword) || nextToken.IsKind(SyntaxKind.SealedKeyword) ||
+                 nextToken.IsKind(SyntaxKind.OpenKeyword) ||
                  nextToken.IsKind(SyntaxKind.PartialKeyword) ||
                  nextToken.IsKind(SyntaxKind.OverrideKeyword) ||
                  nextToken.IsKind(SyntaxKind.OpenBracketToken))
@@ -289,6 +291,7 @@ internal class CompilationUnitSyntaxParser : SyntaxParser
                      SyntaxKind.ProtectedKeyword or
                      SyntaxKind.StaticKeyword or
                      SyntaxKind.AbstractKeyword or
+                     SyntaxKind.FinalKeyword or
                      SyntaxKind.SealedKeyword or
                      SyntaxKind.PartialKeyword or
                      SyntaxKind.VirtualKeyword or

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/EnumDeclarationParser.cs
@@ -89,6 +89,7 @@ internal class EnumDeclarationParser : SyntaxParser
                      SyntaxKind.ProtectedKeyword or
                      SyntaxKind.StaticKeyword or
                      SyntaxKind.AbstractKeyword or
+                     SyntaxKind.FinalKeyword or
                      SyntaxKind.SealedKeyword or
                      SyntaxKind.PartialKeyword or
                      SyntaxKind.VirtualKeyword or

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NamespaceParser.cs
@@ -138,7 +138,8 @@ internal class NamespaceDeclarationParser : SyntaxParser
                  nextToken.IsKind(SyntaxKind.PublicKeyword) || nextToken.IsKind(SyntaxKind.PrivateKeyword) ||
                  nextToken.IsKind(SyntaxKind.InternalKeyword) || nextToken.IsKind(SyntaxKind.ProtectedKeyword) ||
                  nextToken.IsKind(SyntaxKind.StaticKeyword) || nextToken.IsKind(SyntaxKind.AbstractKeyword) ||
-                 nextToken.IsKind(SyntaxKind.SealedKeyword) || nextToken.IsKind(SyntaxKind.OpenKeyword) ||
+                 nextToken.IsKind(SyntaxKind.FinalKeyword) || nextToken.IsKind(SyntaxKind.SealedKeyword) ||
+                 nextToken.IsKind(SyntaxKind.OpenKeyword) ||
                  nextToken.IsKind(SyntaxKind.PartialKeyword) || nextToken.IsKind(SyntaxKind.OverrideKeyword) ||
                  nextToken.IsKind(SyntaxKind.OpenBracketToken))
         {
@@ -243,6 +244,7 @@ internal class NamespaceDeclarationParser : SyntaxParser
                      SyntaxKind.ProtectedKeyword or
                      SyntaxKind.StaticKeyword or
                      SyntaxKind.AbstractKeyword or
+                     SyntaxKind.FinalKeyword or
                      SyntaxKind.SealedKeyword or
                      SyntaxKind.PartialKeyword or
                      SyntaxKind.VirtualKeyword or

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/SyntaxParser.cs
@@ -37,6 +37,7 @@ internal class SyntaxParser : ParseContext
                      SyntaxKind.ProtectedKeyword or
                      SyntaxKind.StaticKeyword or
                      SyntaxKind.AbstractKeyword or
+                     SyntaxKind.FinalKeyword or
                      SyntaxKind.SealedKeyword or
                      SyntaxKind.PartialKeyword or
                      SyntaxKind.VirtualKeyword or

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/UnionDeclarationParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/UnionDeclarationParser.cs
@@ -106,6 +106,7 @@ internal class UnionDeclarationParser : SyntaxParser
                     SyntaxKind.ProtectedKeyword or
                     SyntaxKind.StaticKeyword or
                     SyntaxKind.AbstractKeyword or
+                    SyntaxKind.FinalKeyword or
                     SyntaxKind.SealedKeyword or
                     SyntaxKind.PartialKeyword or
                     SyntaxKind.VirtualKeyword or

--- a/src/Raven.CodeAnalysis/Syntax/Tokens.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Tokens.xml
@@ -68,6 +68,7 @@
   <TokenKind Name="ProtectedKeyword" Text="protected" IsReservedWord="false" />
   <TokenKind Name="StaticKeyword" Text="static" IsReservedWord="false" />
   <TokenKind Name="AbstractKeyword" Text="abstract" IsReservedWord="false" />
+  <TokenKind Name="FinalKeyword" Text="final" IsReservedWord="false" />
   <TokenKind Name="SealedKeyword" Text="sealed" IsReservedWord="false" />
   <TokenKind Name="PartialKeyword" Text="partial" IsReservedWord="false" />
   <TokenKind Name="OpenKeyword" Text="open" IsReservedWord="false" />


### PR DESCRIPTION
### Motivation

- Allow an override to be explicitly sealed so derived classes cannot override it (Raven syntax: `final override`).
- Match common language semantics (C#'s `sealed override`) while keeping Raven's existing `sealed` class/hierarchy semantics intact.
- Expose the feature in syntax, binding, diagnostics, and documentation so the modifier is parsed, validated, and visible to users.

### Description

- Add a `FinalKeyword` token and treat `final` as a contextual modifier in the lexer/grammar and EBNF (`src/Raven.CodeAnalysis/Syntax/Tokens.xml`, `docs/lang/spec/grammar.ebnf`, `docs/lang/spec/language-specification.md`).
- Update parser modifier lists to accept `final` in type/member modifier positions (`SyntaxParser` and related parser files under `src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers`).
- Treat `final` like a sealed override in the binder by including `FinalKeyword` when computing `isSealed` and reusing existing validation paths in `TypeMemberBinder` (`src/Raven.CodeAnalysis/Binder/TypeMemberBinder.cs`).
- Update symbol display and diagnostics to use the `final` wording and show `final` for sealed overrides (`src/Raven.CodeAnalysis/Symbols/SymbolExtensions.cs`, `src/Raven.CodeAnalysis/DiagnosticDescriptors.xml`), and document `final override` in the language spec (`docs/lang/spec/classes-and-members.md`).

### Testing

- Ran `dotnet test /property:WarningLevel=0` (baseline run) which failed prior to regenerating syntax artifacts due to missing generated syntax types; this indicated generators needed to run first.  
- Ran `scripts/codex-build.sh` to regenerate syntax/diagnostic artifacts and build the solution, and the build completed successfully.  
- Ran `dotnet format` on the modified files which produced workspace loading warnings but completed; no additional unit-test runs were executed after the regeneration in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961493ed848832f8fde535122465d88)