### PR TITLE
Ensure ISymbol referenceability defaults and add tests for IsImplicitlyDeclared/CanBeReferencedByName

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Symbol.cs
@@ -147,7 +147,18 @@ internal abstract class Symbol : ISymbol
 
     public virtual DocumentationComment? GetDocumentationComment() => null;
 
-    public virtual bool CanBeReferencedByName { get; } = false;
+    public virtual bool CanBeReferencedByName => this switch
+    {
+        INamespaceOrTypeSymbol => true,
+        IMethodSymbol => true,
+        IEventSymbol => true,
+        IPropertySymbol => true,
+        IFieldSymbol => true,
+        IParameterSymbol => true,
+        ILocalSymbol => true,
+        ILabelSymbol => true,
+        _ => false
+    };
 
     public bool Equals(ISymbol? other, SymbolEqualityComparer comparer)
     {

--- a/test/Raven.CodeAnalysis.Tests/Semantics/EntryPointDiagnosticsTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/EntryPointDiagnosticsTests.cs
@@ -203,4 +203,21 @@ class Program {
         var program = global.LookupType("Program");
         Assert.Null(program);
     }
+
+    [Fact]
+    public void TopLevelStatements_SynthesizeImplicitEntryPoint()
+    {
+        var tree = SyntaxTree.ParseText("let x = 0");
+        var compilation = Compilation.Create(
+            "app",
+            [tree],
+            TestMetadataReferences.Default,
+            new CompilationOptions(OutputKind.ConsoleApplication));
+
+        var entryPoint = compilation.GetEntryPoint();
+
+        var method = Assert.IsAssignableFrom<IMethodSymbol>(entryPoint);
+        Assert.True(method.IsImplicitlyDeclared);
+        Assert.True(method.CanBeReferencedByName);
+    }
 }

--- a/test/Raven.CodeAnalysis.Tests/Symbols/SymbolPropertyTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Symbols/SymbolPropertyTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Semantics.Tests;
+using Raven.CodeAnalysis.Syntax;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Tests;
+
+public sealed class SymbolPropertyTests : CompilationTestBase
+{
+    [Fact]
+    public void CanBeReferencedByName_IsTrueForNamedSymbols()
+    {
+        const string source = """
+class Widget {
+    val field = 1
+
+    M(value: int) -> int {
+        let local = value
+        return local
+    }
+}
+""";
+
+        var (compilation, tree) = CreateCompilation(source);
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+
+        var fieldDeclarator = root.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(declarator => declarator.Parent?.Parent is FieldDeclarationSyntax);
+        var localDeclarator = root.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(declarator => declarator.Parent?.Parent is LocalDeclarationStatementSyntax);
+        var methodSyntax = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var parameterSyntax = methodSyntax.ParameterList.Parameters.Single();
+
+        var fieldSymbol = Assert.IsAssignableFrom<IFieldSymbol>(model.GetDeclaredSymbol(fieldDeclarator));
+        var methodSymbol = Assert.IsAssignableFrom<IMethodSymbol>(model.GetDeclaredSymbol(methodSyntax));
+        var parameterSymbol = Assert.IsAssignableFrom<IParameterSymbol>(model.GetDeclaredSymbol(parameterSyntax));
+        var localSymbol = Assert.IsAssignableFrom<ILocalSymbol>(model.GetDeclaredSymbol(localDeclarator));
+
+        Assert.True(fieldSymbol.CanBeReferencedByName);
+        Assert.True(methodSymbol.CanBeReferencedByName);
+        Assert.True(parameterSymbol.CanBeReferencedByName);
+        Assert.True(localSymbol.CanBeReferencedByName);
+
+        Assert.False(fieldSymbol.IsImplicitlyDeclared);
+        Assert.False(methodSymbol.IsImplicitlyDeclared);
+        Assert.False(parameterSymbol.IsImplicitlyDeclared);
+        Assert.False(localSymbol.IsImplicitlyDeclared);
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure `ISymbol` exposes consistent `CanBeReferencedByName` semantics across symbol kinds so API consumers see correct referenceability. 
- Make sure `IsImplicitlyDeclared` is observable for synthesized symbols (e.g. entry point bridge methods) and respected by consumers.
- Provide unit tests to codify the intended behavior and prevent regressions.

### Description

- Change the default implementation of `Symbol.CanBeReferencedByName` to pattern-match on symbol interfaces and return `true` for named/referenceable symbols (`INamespaceOrTypeSymbol`, `IMethodSymbol`, `IEventSymbol`, `IPropertySymbol`, `IFieldSymbol`, `IParameterSymbol`, `ILocalSymbol`, `ILabelSymbol`).
- Add `test/Raven.CodeAnalysis.Tests/Symbols/SymbolPropertyTests.cs` to verify `CanBeReferencedByName` and `IsImplicitlyDeclared` for typical named symbols. 
- Add a test to `test/Raven.CodeAnalysis.Tests/Semantics/EntryPointDiagnosticsTests.cs` asserting that top-level statements synthesize an implicit entry point which is `IsImplicitlyDeclared` and `CanBeReferencedByName`.

### Testing

- Ran `scripts/codex-build.sh` which completed and built `Raven.CodeAnalysis` and `ravc` successfully.
- Ran `dotnet format Raven.sln --include ... --no-restore` which completed with workspace load warnings but applied formatting.
- Started `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj /property:WarningLevel=0`; the run executed but reported failures in unrelated tests (`ConditionalAccessTests.ConditionalAccess_NullableValue_ReturnsValue`, `ConditionalAccessTests.ConditionalAccess_NullReference_ReturnsNull`, and `EventTests.Event_AddRemoveInvoke_WiresHandlers`) and the run was ultimately interrupted (MSBuild child node error) before completion; the newly added tests were compiled and included in the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614c3f9374832f9110398ae0b40c68)