### PR TITLE
Add inheritance and interface listings to RavenDoc type pages

### DIFF
--- a/samples/test105.rav
+++ b/samples/test105.rav
@@ -7,7 +7,11 @@ val x = f.RaiseEvent(2)
 
 Console.WriteLine(x)
 
-public class Foo {
+public interface IFoo {
+
+}
+
+public class Foo : IFoo {
     public RaiseEvent(x: int) -> int {
         Raised?.Invoke(self, EventArgs.Empty)
         return 42

--- a/src/RavenDoc/DocumentationGenerator.cs
+++ b/src/RavenDoc/DocumentationGenerator.cs
@@ -66,11 +66,13 @@ public static class DocumentationGenerator
 
         BaseTypeDisplayFormat =
             SymbolDisplayFormat.FullyQualifiedFormat
-                .WithTypeQualificationStyle(SymbolDisplayTypeQualificationStyle.NameOnly);
+                .WithTypeQualificationStyle(SymbolDisplayTypeQualificationStyle.NameOnly)
+                .WithKindOptions(SymbolDisplayKindOptions.None);
 
         ContainingTypeDisplayFormat =
             SymbolDisplayFormat.FullyQualifiedFormat
-                .WithTypeQualificationStyle(SymbolDisplayTypeQualificationStyle.NameOnly);
+                .WithTypeQualificationStyle(SymbolDisplayTypeQualificationStyle.NameOnly)
+                .WithKindOptions(SymbolDisplayKindOptions.None);
 
         ContainingNamespaceDisplayFormat =
             SymbolDisplayFormat.FullyQualifiedFormat
@@ -1232,7 +1234,7 @@ a.broken-xref { color: var(--muted); pointer-events: none; text-decoration: none
         if (implementedInterfaces.Length > 0)
         {
             var interfaceLinks = implementedInterfaces
-                .Select(type => FormatTypeLink(currentDir, type, BaseTypeDisplayFormat));
+                .Select(type => FormatTypeLink(currentDir, (ITypeSymbol)type, BaseTypeDisplayFormat));
             sb.AppendLine($"**Implements**: {string.Join(", ", interfaceLinks)}<br />");
         }
         if (typeSymbol.ContainingType is not null)


### PR DESCRIPTION
### Motivation
- Improve RavenDoc type pages by showing full inheritance chains to make type hierarchies explicit in generated docs.
- Show the interfaces a type implements so readers can quickly understand contracts implemented by a type.
- Centralize link formatting for types to ensure consistent cross-page links.

### Description
- Add `GetInheritanceChain(ITypeSymbol)` to compute the inheritance chain for a given type and `FormatTypeLink` to render a linked, escaped display name for a type.
- Update `GenerateTypePage` to render an `**Inheritance**` line that joins type links with `→` and an `**Implements**` line listing implemented interfaces.
- Deduplicate interfaces using `SymbolEqualityComparer.Default` and order them for stable output, and switch the containing-type listing to use `FormatTypeLink`.
- Minor refactors/formatting in `DocumentationGenerator.cs` (using reorder and a `static` local function) to keep code tidy.

### Testing
- Ran `dotnet test /property:WarningLevel=0`, which failed due to missing generated syntax symbols in `Raven.CodeAnalysis` (preexisting/generated file dependency), so no green test run was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618bb77db8832f9c0f46f3571d0128)