### PR TITLE
Handle forward-declared types in binding

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -136,7 +136,7 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
 
     public SpecialType SpecialType => SpecialType.None;
 
-    public virtual INamedTypeSymbol? BaseType { get; }
+    public virtual INamedTypeSymbol? BaseType { get; private set; }
 
     public TypeKind TypeKind { get; }
 
@@ -181,6 +181,12 @@ internal partial class SourceNamedTypeSymbol : SourceSymbol, INamedTypeSymbol
     internal void SetInterfaces(IEnumerable<INamedTypeSymbol> interfaces)
     {
         _interfaces = interfaces.ToImmutableArray();
+        _allInterfaces = null;
+    }
+
+    internal void SetBaseType(INamedTypeSymbol baseType)
+    {
+        BaseType = baseType;
         _allInterfaces = null;
     }
 


### PR DESCRIPTION
### Motivation

- Remove declaration-order sensitivity by ensuring types (namespaces, classes, interfaces, enums, unions, extensions) are predeclared before resolving base lists and members so lookups succeed regardless of declaration order. 
- Allow updating a source type's base type after its initial declaration to support deferred resolution when the base is declared later. 
- Merge interface lists when multiple declarations contribute interfaces to the same type so all declared interfaces are observed. 
- Avoid reintroducing duplicate members or inconsistent state when registering nested types or unions.

### Description

- Predeclare symbols in `RegisterNamespaceMembers` by collecting and creating `SourceNamedTypeSymbol` / `SourceDiscriminatedUnionSymbol` instances first, then perform a second pass to resolve base lists, bind members and create binders; changes are in `src/Raven.CodeAnalysis/SemanticModel.Binding.cs`. 
- Make `BaseType` writable on `SourceNamedTypeSymbol` and add `SetBaseType` to allow deferred base assignment, in `src/Raven.CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs`. 
- Add support for merging interfaces via `MergeInterfaces` helpers and ensure `SetInterfaces` is used to combine existing and newly resolved interfaces. 
- Update `RegisterUnionDeclaration` to accept an optional existing union symbol so unions declared earlier are bound to the same symbol rather than recreated.

### Testing

- Ran the repository build and generation script with `scripts/codex-build.sh`, which completed successfully and produced updated generated artifacts and built projects. 
- Ran the test suite with `dotnet test /property:WarningLevel=0`, which showed failures: two failing tests in `Raven.CodeAnalysis.Testing.DiagnosticVerifierTest` (`GetResult_WithMatchedDiagnostics` and `GetResult_WithIgnoredDiagnostics`) reporting an unexpected `RAV1003` diagnostic, and a build error in `Raven.Editor` related to `Color.BrightBlack`. 
- Attempted to run `dotnet format Raven.sln --include <files> --no-restore`, but the formatting run was cancelled/hung while loading the workspace and was not completed. 
- The changes build cleanly for `Raven.CodeAnalysis` and `Raven.Compiler` in the `scripts/codex-build.sh` run, but some test projects and `Raven.Editor` still require follow-up fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618fbb0a00832f83313d162a270478)