### PR TITLE
Fix wildcard import parsing after multiline comments

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/NameSyntaxParser.cs
@@ -329,18 +329,18 @@ internal class NameSyntaxParser : SyntaxParser
     {
         var name = PeekToken();
 
+        if (name.IsKind(SyntaxKind.StarToken))
+        {
+            ReadToken();
+            return WildcardName(name);
+        }
+
         if (!IsIdentifierToken(name)
             && HasLeadingEndOfLineTrivia(name))
         {
             AddDiagnostic(DiagnosticInfo.Create(CompilerDiagnostics.IdentifierExpected, GetSpanOfLastToken()));
             return IdentifierName(
                 MissingToken(SyntaxKind.IdentifierToken), Diagnostics);
-        }
-
-        if (name.IsKind(SyntaxKind.StarToken))
-        {
-            ReadToken();
-            return WildcardName(name);
         }
 
         if (CanTokenBeIdentifier(name))

--- a/test/Raven.CodeAnalysis.Tests/Syntax/Parser/ImportDirectiveTriviaTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/Parser/ImportDirectiveTriviaTests.cs
@@ -1,0 +1,35 @@
+using Raven.CodeAnalysis;
+using Raven.CodeAnalysis.Syntax;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Raven.CodeAnalysis.Syntax.Parser.Tests;
+
+public class ImportDirectiveTriviaTests
+{
+    [Fact]
+    public void MultilineCommentBeforeImports_DoesNotSplitWildcardDirective()
+    {
+        var code = """
+                   /*
+
+                   BUG: This seems to be because of the ordering of the declarations interface types can't be created or resolved:
+                   I think this is a matter of fixing the compiler passes.
+                   Also, make sure that similar issue is not occurring in other places.
+                   */
+                   import System.*;
+                   import System.Console.*;
+
+                   WriteLine(20)
+                   """;
+
+        var tree = SyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+
+        root.Imports.Count.ShouldBe(2);
+        root.Imports[0].Name.ToString().ShouldBe("System.*");
+        root.Imports[1].Name.ToString().ShouldBe("System.Console.*");
+    }
+}


### PR DESCRIPTION
### Motivation
- Multiline block comments before import directives could leave a stray `*` token unconsumed so wildcard imports were parsed incorrectly and leaked into subsequent statements.
- The change aims to ensure wildcard names are recognized before end-of-line diagnostics are applied so import directives like `import System.*;` remain intact after comments.

### Description
- Move the `StarToken` (`*`) handling earlier in `ParseUnqualifiedName` so wildcard names are consumed before the leading end-of-line diagnostic check in `NameSyntaxParser.ParseUnqualifiedName`.
- Add a regression test `ImportDirectiveTriviaTests.MultilineCommentBeforeImports_DoesNotSplitWildcardDirective` in `test/Raven.CodeAnalysis.Tests/Syntax/Parser/ImportDirectiveTriviaTests.cs` that verifies two wildcard import directives following a multiline comment are parsed as two import directives.
- Run `dotnet format` on the modified files to apply formatting.

### Testing
- Ran `dotnet format Raven.sln --include <files> --no-restore` on the changed files (workspace-load warnings were reported during formatting).
- Ran the repository build via `scripts/codex-build.sh` which completed and `Raven.CodeAnalysis` compiled successfully.
- Ran `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj /property:WarningLevel=0` which executed tests but reported multiple preexisting test failures across the suite; the run produced many failing cases (these appear unrelated to the small parser change) and the test run was ultimately interrupted when execution hung/was terminated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4502360c832fa5d8a610dd2879df)