### PR TITLE
Support target-typed member patterns in matching

### DIFF
--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -1265,6 +1265,10 @@ Patterns compose from the following primitives.
   Value patterns are *not* bindings. To introduce a new binding, an explicit
   binding keyword (`let`, `val`, or `var`) is required.
 
+* `.Member` — **target-typed value pattern**. When the scrutinee type is known
+  (for example, an enum type or a type with static fields), the leading-dot
+  expression resolves against that target type and matches the resulting value.
+
 > **Note:** A bare identifier in pattern position is context-sensitive. If the
 > name resolves to a value symbol, it forms a value pattern. Otherwise, it is
 > interpreted as a type name and participates in a type or declaration pattern.

--- a/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs
@@ -131,6 +131,36 @@ let result = false match {
     }
 
     [Fact]
+    public void MatchExpression_WithTargetTypedMemberPattern_ResolvesAgainstInputType()
+    {
+        const string code = """
+enum Species {
+    Human,
+    Dog
+}
+
+class Character(name: string, species: Species, age: int) {
+    public Name: string => name
+
+    public Species: Species => species
+
+    public Age: int => age
+}
+
+let character = new Character("Rex", .Dog, 4)
+
+let result = character match {
+    { Age: not > 34, Species: .Dog } => true
+    _ => false
+}
+""";
+
+        var verifier = CreateVerifier(code);
+
+        verifier.Verify();
+    }
+
+    [Fact]
     public void MatchExpression_WithTypedDiscardArm_IsCatchAll()
     {
         const string code = """
@@ -699,4 +729,3 @@ let result = value match {
         verifier.Verify();
     }
 }
-


### PR DESCRIPTION
### Motivation

- Allow target-typed expressions (leading-dot member access for enums/static fields) to be used where an expression is expected inside patterns, matching language spec intent (e.g., `{ Age: not > 34, Species: .Dog }`).
- Reuse member-binding lookup logic for patterns so case-patterns fall back to value/constant patterns when the scrutinee is not a discriminated union.
- Update documentation and add a semantic test to cover the new scenario.

### Description

- Refactored member-binding to accept an explicit expected type by extracting `BindTargetTypedMemberAccess` and overloads of `BindMemberBindingExpression` to bind leading-dot expressions against a known target type (`src/Raven.CodeAnalysis/Binder/BlockBinder.MemberAccess.cs`).
- Extended constant-pattern binding to consume `MemberBindingExpressionSyntax` and route through target-typed member access, with a new helper `BindConstantPatternFromExpression` to centralize constant-pattern checks (`src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs`).
- Modified case-pattern binding to fall back to a target-typed constant/member lookup when no discriminated-union type is available, via `BindCasePatternAsConstant` so leading-dot syntax can resolve as a value pattern against the input type.
- Added language-spec documentation describing `.Member` as a target-typed value pattern (`docs/lang/spec/language-specification.md`).
- Added a semantic unit test `MatchExpression_WithTargetTypedMemberPattern_ResolvesAgainstInputType` to exercise matching against an enum/static-field leading-dot member (`test/Raven.CodeAnalysis.Tests/Semantics/MatchExpressionTests.cs`).

### Testing

- Ran the focused test project with `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj /property:WarningLevel=0`; the test run executed but produced multiple unrelated failures across the suite and eventually the run was interrupted with an MSBuild child-node error (MSB4166), so the run did not complete successfully.
- A repository-wide `dotnet test /property:WarningLevel=0` was attempted earlier and also surfaced baseline compilation/test failures unrelated to these changes; these existing failures prevented a fully green test pass in this environment.
- The new semantic test is present and exercised by the local test invocation, but full-suite stability will need addressing of the unrelated baseline failures before a clean green run can be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4cd14bbc832f94dae05348992ab0)