### PR TITLE
Fix await context detection for nested functions

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1267,23 +1267,15 @@ partial class BlockBinder : Binder
 
     private bool IsAwaitExpressionAllowed()
     {
-        static bool IsAsyncSymbol(ISymbol? symbol)
-        {
-            return symbol switch
-            {
-                ILambdaSymbol lambda => lambda.IsAsync,
-                IMethodSymbol method => method.IsAsync,
-                _ => false,
-            };
-        }
-
         for (Binder? current = this; current is not null; current = current.ParentBinder)
         {
-            if (IsAsyncSymbol(current.ContainingSymbol))
-                return true;
-
-            if (current is BlockBinder block && IsAsyncSymbol(block.ContainingSymbol))
-                return true;
+            switch (current.ContainingSymbol)
+            {
+                case ILambdaSymbol lambda:
+                    return lambda.IsAsync;
+                case IMethodSymbol method:
+                    return method.IsAsync;
+            }
         }
 
         return false;


### PR DESCRIPTION
### Motivation
- `await` expressions should only be allowed when the nearest enclosing method or lambda is marked `async`, and nested non-async functions were incorrectly inheriting async allowance from outer scopes.

### Description
- Update `IsAwaitExpressionAllowed` in `src/Raven.CodeAnalysis/Binder/BlockBinder.cs` to inspect the nearest enclosing `ContainingSymbol` and return whether it is an async `ILambdaSymbol` or `IMethodSymbol`.
- Remove the previous helper and additional checks that could allow `await` to be treated as allowed from an outer async context, so the search stops at the nearest enclosing method/lambda.

### Testing
- Ran `dotnet test /property:WarningLevel=0`, which failed due to unrelated missing generated syntax/types in `Raven.CodeAnalysis`, so automated tests could not validate the behavioral change.
- Applied formatting to the modified file with `dotnet format` before committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a66955a5c832fbca55848b0d299f9)