### PR TITLE
Rename CasePattern syntax node to MemberPattern

### DIFF
--- a/docs/lang/proposals/discriminated-unions.md
+++ b/docs/lang/proposals/discriminated-unions.md
@@ -1,7 +1,7 @@
 # Proposal: Discriminated unions
 
 > ✅ The syntax described here is implemented in the parser and semantic model
-> (including case pattern binding and exhaustiveness). Code generation lowers
+> (including member pattern binding and exhaustiveness). Code generation lowers
 > to implicit conversions and `TryGet*` helpers for the union cases.
 
 Discriminated unions are value types that represent a fixed set of alternative shapes. Each alternative is modeled as a distinct nested struct type whose constructor is declared inline with the union definition. The compiler emits `TryGet*` helpers for each case and pattern matching is expressed in terms of these helpers, ensuring exhaustiveness.
@@ -61,12 +61,12 @@ func describe(token: Token) -> string {
 }
 ```
 
-**Note:** The arms (for example, `.Identifier(text)`) use the `CasePattern`
+**Note:** The arms (for example, `.Identifier(text)`) use the `MemberPattern`
 syntax from _grammar.ebnf_: a leading `.` resolves the case against the current
 scrutinee, and an optional qualifier (such as `Token.Identifier`) forces lookup
 against a specific union type.
 
-Case patterns accept the same payload shape declared on the case. A
+Member patterns accept the same payload shape declared on the case. A
 parameterless case may be matched with either `.Unknown` or `.Unknown()`, while
 payload-bearing cases unpack each element positionally:
 
@@ -81,7 +81,7 @@ let description = token match {
 
 Adding an explicit qualifier bypasses the scrutinee's static type and is useful
 when the union flows in as an interface or object. The parser treats the
-qualifier as part of the case path; binding validates that the qualifier and
+qualifier as part of the member path; binding validates that the qualifier and
 case belong to the same union and enforces payload arity at the pattern site.
 
 ```csharp

--- a/docs/lang/proposals/drafts/simplify-case-pattern.md
+++ b/docs/lang/proposals/drafts/simplify-case-pattern.md
@@ -1,7 +1,7 @@
-# Proposal: Simplify case pattern
+# Proposal: Simplify member pattern
 
 ## Summary
 
-Remove the `.Foo` to `Foo`
+Remove the `.Foo` to `Foo` for member patterns.
 
 Consistency

--- a/docs/lang/spec/grammar.ebnf
+++ b/docs/lang/spec/grammar.ebnf
@@ -319,7 +319,7 @@ PrimaryPattern           ::= ParenthesizedPattern
                            | DeclarationPattern
                            | TuplePattern
                            | DiscardPattern
-                           | CasePattern
+                           | MemberPattern
                            | PropertyPattern ;
 
 ConstantPattern          ::= Literal | ConstantPatternOperand ;
@@ -354,8 +354,8 @@ TuplePatternElementDesignation
 
 DiscardPattern           ::= '_' | Type '_' ;
 
-CasePattern              ::= CasePath [ '(' PatternList? ')' ] ;
-CasePath                 ::= '.' Identifier
+MemberPattern            ::= MemberPath [ '(' PatternList? ')' ] ;
+MemberPath               ::= '.' Identifier
                            | Type '.' Identifier ;
 
 PatternList              ::= Pattern {',' Pattern} ;

--- a/docs/lang/spec/language-specification.md
+++ b/docs/lang/spec/language-specification.md
@@ -1345,17 +1345,17 @@ Patterns compose from the following primitives.
     `var`).
   * Writing `var p` produces a mutable binding.
 
-#### Discriminated union case patterns
+#### Member patterns
 
-* `.Case` / `Type.Case` — **case pattern**. Matches a discriminated union case by
-  name.
+* `.Case` / `Type.Case` — **member pattern**. Matches a named member by name,
+  including discriminated union cases, constants, or nested types.
 
   * The leading `.` resolves against the current scrutinee.
-  * Case payloads may supply nested subpatterns matching the case’s parameter
-    list, e.g. `.Identifier(text)` or `Result<int>.Error(let message)`.
-  * Parentheses are optional for parameterless cases.
+  * Member payloads may supply nested subpatterns matching the member’s
+    parameter list, e.g. `.Identifier(text)` or `Result<int>.Error(let message)`.
+  * Parentheses are optional for parameterless members.
   * Payload arity must match the declared parameters.
-  * Each nested subpattern is typed to the corresponding case parameter.
+  * Each nested subpattern is typed to the corresponding member parameter.
   * A payload element introduces a new binding **only** when it uses
     `let`/`val`/`var`. A bare identifier is a value pattern that matches an
     existing in-scope symbol.

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -1719,7 +1719,7 @@ partial class BlockBinder : Binder
                         return;
                     }
 
-                    if (patternSyntax is CasePatternSyntax caseSyntax && caseSyntax.ArgumentList is { } argumentList)
+                    if (patternSyntax is MemberPatternSyntax caseSyntax && caseSyntax.ArgumentList is { } argumentList)
                     {
                         var parameterTypes = casePattern.CaseSymbol.ConstructorParameters;
                         var elementCount = Math.Min(parameterTypes.Length, casePattern.Arguments.Length);

--- a/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/BoundIsPatternExpression.cs
@@ -345,7 +345,7 @@ internal partial class BlockBinder
             TuplePatternSyntax t => BindTuplePattern(t, inputType),
             UnaryPatternSyntax u => BindUnaryPattern(u, inputType),
             BinaryPatternSyntax b => BindBinaryPattern(b, inputType),
-            CasePatternSyntax c => BindCasePattern(c, inputType),
+            MemberPatternSyntax c => BindCasePattern(c, inputType),
             PropertyPatternSyntax p => BindPropertyPattern(p, inputType),
             RelationalPatternSyntax r => BindRelationalPattern(r, inputType),
             _ => throw new NotImplementedException($"Unknown pattern kind: {syntax.Kind}")
@@ -814,7 +814,7 @@ internal partial class BlockBinder
         };
     }
 
-    private BoundPattern BindCasePattern(CasePatternSyntax syntax, ITypeSymbol? inputType)
+    private BoundPattern BindCasePattern(MemberPatternSyntax syntax, ITypeSymbol? inputType)
     {
         var qualifierType = syntax.Path.Qualifier is null
             ? null
@@ -888,7 +888,7 @@ internal partial class BlockBinder
     }
 
     private BoundPattern BindCasePatternAsConstant(
-        CasePatternSyntax syntax,
+        MemberPatternSyntax syntax,
         ITypeSymbol? qualifierType,
         ITypeSymbol? inputType)
     {

--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
@@ -64,7 +64,7 @@ internal class PatternSyntaxParser : SyntaxParser
 
         if (PeekToken().IsKind(SyntaxKind.DotToken))
         {
-            return ParseCasePattern(qualifier: null, dotToken: ReadToken());
+            return ParseMemberPattern(qualifier: null, dotToken: ReadToken());
         }
 
         if (PeekToken().IsKind(SyntaxKind.OpenParenToken))
@@ -145,7 +145,7 @@ internal class PatternSyntaxParser : SyntaxParser
 
         if (ConsumeToken(SyntaxKind.DotToken, out var dotToken))
         {
-            return ParseCasePattern(type, dotToken);
+            return ParseMemberPattern(type, dotToken);
         }
 
         // Optionally consume a variable designation
@@ -320,7 +320,7 @@ internal class PatternSyntaxParser : SyntaxParser
         return TuplePattern(openParenToken, List(elementList.ToArray()), closeParenToken);
     }
 
-    private CasePatternSyntax ParseCasePattern(TypeSyntax? qualifier, SyntaxToken dotToken)
+    private MemberPatternSyntax ParseMemberPattern(TypeSyntax? qualifier, SyntaxToken dotToken)
     {
         var identifierToken = ReadToken();
         if (identifierToken.Kind != SyntaxKind.IdentifierToken)
@@ -329,13 +329,13 @@ internal class PatternSyntaxParser : SyntaxParser
             UpdateLastToken(identifierToken);
         }
 
-        var argumentList = ParseCasePatternArgumentList();
-        var path = CasePatternPath(qualifier, dotToken, identifierToken);
+        var argumentList = ParseMemberPatternArgumentList();
+        var path = MemberPatternPath(qualifier, dotToken, identifierToken);
 
-        return CasePattern(path, argumentList);
+        return MemberPattern(path, argumentList);
     }
 
-    private CasePatternArgumentListSyntax? ParseCasePatternArgumentList()
+    private MemberPatternArgumentListSyntax? ParseMemberPatternArgumentList()
     {
         if (!PeekToken().IsKind(SyntaxKind.OpenParenToken))
             return null;
@@ -357,7 +357,7 @@ internal class PatternSyntaxParser : SyntaxParser
 
         ConsumeTokenOrMissing(SyntaxKind.CloseParenToken, out var closeParenToken);
 
-        return CasePatternArgumentList(openParenToken, List(arguments.ToArray()), closeParenToken);
+        return MemberPatternArgumentList(openParenToken, List(arguments.ToArray()), closeParenToken);
     }
 
     private VariableDesignationSyntax ParseDesignation(bool allowBindingKeyword = true)

--- a/src/Raven.CodeAnalysis/Syntax/Model.xml
+++ b/src/Raven.CodeAnalysis/Syntax/Model.xml
@@ -639,9 +639,9 @@
     <Slot Name="OperatorToken" Type="Token" />
     <Slot Name="Expression" Type="Expression" />
   </Node>
-  <Node Name="CasePattern" Inherits="Pattern">
-    <Slot Name="Path" Type="CasePatternPath" />
-    <Slot Name="ArgumentList" Type="CasePatternArgumentList" IsNullable="true" />
+  <Node Name="MemberPattern" Inherits="Pattern">
+    <Slot Name="Path" Type="MemberPatternPath" />
+    <Slot Name="ArgumentList" Type="MemberPatternArgumentList" IsNullable="true" />
   </Node>
   <Node Name="VariablePattern" Inherits="Pattern">
     <Slot Name="BindingKeyword" Type="Token" />
@@ -663,12 +663,12 @@
     <Slot Name="NameColon" Type="NameColon" IsNullable="true" />
     <Slot Name="Pattern" Type="Pattern" />
   </Node>
-  <Node Name="CasePatternPath" Inherits="Node">
+  <Node Name="MemberPatternPath" Inherits="Node">
     <Slot Name="Qualifier" Type="Type" IsNullable="true" />
     <Slot Name="DotToken" Type="Token" DefaultToken="DotToken" />
     <Slot Name="Identifier" Type="Token" />
   </Node>
-  <Node Name="CasePatternArgumentList" Inherits="Node">
+  <Node Name="MemberPatternArgumentList" Inherits="Node">
     <Slot Name="OpenParenToken" Type="Token" DefaultToken="OpenParenToken" />
     <Slot Name="Arguments" Type="SeparatedList" ElementType="Pattern" />
     <Slot Name="CloseParenToken" Type="Token" DefaultToken="CloseParenToken" />

--- a/test/Raven.CodeAnalysis.Tests/Syntax/PatternSyntaxParserTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Syntax/PatternSyntaxParserTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
+
 using Raven.CodeAnalysis;
 using Raven.CodeAnalysis.Syntax;
+
 using Xunit;
 
 namespace Raven.CodeAnalysis.Syntax.Tests;
@@ -83,12 +85,12 @@ public class PatternSyntaxParserTests
     }
 
     [Fact]
-    public void CasePattern_WithShorthandPath_Parses()
+    public void MemberPattern_WithShorthandPath_Parses()
     {
         var (pattern, tree) = ParsePattern(".Identifier(let text)");
         var sourceText = tree.GetText() ?? throw new InvalidOperationException("Missing source text.");
 
-        var casePattern = Assert.IsType<CasePatternSyntax>(pattern);
+        var casePattern = Assert.IsType<MemberPatternSyntax>(pattern);
         Assert.Equal(".Identifier(let text)", sourceText.ToString(casePattern.Span));
         Assert.Null(casePattern.Path.Qualifier);
         Assert.Equal("Identifier", casePattern.Path.Identifier.ValueText);
@@ -104,12 +106,12 @@ public class PatternSyntaxParserTests
     }
 
     [Fact]
-    public void CasePattern_WithQualifierAndPayload_Parses()
+    public void MemberPattern_WithQualifierAndPayload_Parses()
     {
         var (pattern, tree) = ParsePattern("Token.Identifier(let text)");
         var sourceText = tree.GetText() ?? throw new InvalidOperationException("Missing source text.");
 
-        var casePattern = Assert.IsType<CasePatternSyntax>(pattern);
+        var casePattern = Assert.IsType<MemberPatternSyntax>(pattern);
         Assert.Equal("Token.Identifier(let text)", sourceText.ToString(casePattern.Span));
         Assert.Equal("Token", Assert.IsType<IdentifierNameSyntax>(casePattern.Path.Qualifier).Identifier.ValueText);
         Assert.Equal("Identifier", casePattern.Path.Identifier.ValueText);


### PR DESCRIPTION
### Motivation
- Broaden the pattern concept: the syntax previously named `CasePattern` should represent matching any named member (union cases, constants, nested types), so rename it to `MemberPattern` to reflect that intent.
- Keep parser/binder/semantics consistent with documentation by aligning syntax node names and grammar with the expanded member-pattern concept.

### Description
- Renamed the syntax model node from `CasePattern` to `MemberPattern` in `src/Raven.CodeAnalysis/Syntax/Model.xml`, and regenerated corresponding `generated/` syntax types so the compiler API exposes `MemberPatternSyntax` and related types.
- Updated the parser to `ParseMemberPattern` and `ParseMemberPatternArgumentList`, and changed call sites in `PatternSyntaxParser.cs` to produce `MemberPattern` nodes.
- Adjusted binding and lowering code to accept and handle `MemberPatternSyntax` (changed `BindCasePattern` signature and switch arms) and updated `BlockBinder` to inspect `MemberPatternSyntax` argument lists.
- Updated tests and docs: renamed relevant unit tests to `MemberPattern_*`, and updated `docs/lang/spec/*`, `docs/lang/proposals/*`, and `docs/lang/spec/grammar.ebnf` to use “member pattern” terminology.

### Testing
- Ran the generation/build script `scripts/codex-build.sh`, which regenerated syntax/bound nodes and completed successfully with `Raven.CodeAnalysis` and `Raven.Compiler` building without errors.
- Ran `dotnet format` on the modified files to normalize formatting and it completed (workspace warnings were reported but formatting finished).
- Attempted `dotnet test /property:WarningLevel=0` before running generators which failed due to missing generated syntax types; the full test-suite run was not re-executed after generation in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b6f13afc0832fa8e046421c174c6e)