### PR TITLE
Validate literal patterns against positional element types

### DIFF
--- a/test/Raven.CodeAnalysis.Tests/Semantics/IsPatternExpressionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Semantics/IsPatternExpressionTests.cs
@@ -1,0 +1,26 @@
+using Raven.CodeAnalysis.Testing;
+using Raven.CodeAnalysis.Tests;
+
+namespace Raven.CodeAnalysis.Semantics.Tests;
+
+public class IsPatternExpressionTests : DiagnosticTestBase
+{
+    [Fact]
+    public void IsPattern_WithIncompatibleLiteralPattern_ReportsDiagnostic()
+    {
+        const string code = """
+record class Foo(Value: bool, Data: (int, int))
+
+func Test(x: object?) {
+    if x is Foo(_, true) {
+    }
+}
+""";
+
+        var verifier = CreateVerifier(
+            code,
+            [new DiagnosticResult("RAV2102").WithAnySpan().WithArguments("true", "(int, int)")]);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
### Motivation

- Positional/property pattern matching accepted literal constant patterns without verifying they are convertible to the expected element/property type, which could silently produce invalid matches or later codegen/runtime surprises.

### Description

- Add validation for literal-backed constant patterns in `BindConstantPatternFromExpression` by classifying a conversion from the `LiteralTypeSymbol` to the expected `inputType` and reporting `RAV2102` when no conversion exists.
- On incompatible literal patterns return a `BoundDiscardPattern(Compilation.ErrorTypeSymbol, BoundExpressionReason.TypeMismatch)` to avoid producing an invalid bound constant pattern.
- Add a unit test `IsPattern_WithIncompatibleLiteralPattern_ReportsDiagnostic` to assert that an incompatible literal in a positional `is` pattern emits `RAV2102`.

### Testing

- Ran the solution build via `scripts/codex-build.sh` which completed successfully.
- Ran `dotnet test /property:WarningLevel=0` (full test run) and observed unrelated failures in `Raven.CodeAnalysis.Testing` and `Raven.Editor.Tests` during the CI-local run, so the suite did not fully pass in this environment.
- Ran `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj /property:WarningLevel=0` and observed multiple existing test failures or interruptions unrelated to this change; the newly added test was included in the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bbc3631d0832faa29ea75713677aa)