### PR TITLE
Validate literal patterns against expected types

### DIFF
--- a/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
+++ b/src/Raven.CodeAnalysis/Syntax/InternalSyntax/Parser/Parsers/PatternSyntaxParser.cs
@@ -520,6 +520,12 @@ internal class PatternSyntaxParser : SyntaxParser
         // Parse as expression (NOT a pattern). This enables: `x`, `x.y`, `SomeType.StaticField`, etc.
         var expr = new ExpressionSyntaxParser(this).ParseExpression();
 
+        if (!IsValidConstantPatternExpression(expr))
+        {
+            checkpoint.Dispose();
+            return false;
+        }
+
         // Only accept if the next token can legally terminate a pattern at this precedence level.
         // This avoids capturing type declarations like `Foo bar`.
         if (!IsPatternTerminator(PeekToken()))
@@ -532,6 +538,16 @@ internal class PatternSyntaxParser : SyntaxParser
         // static field, etc. If it binds to a type, it can be interpreted as a type/declaration pattern.
         constantPattern = ConstantPattern(expr);
         return true;
+    }
+
+    private static bool IsValidConstantPatternExpression(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax => true,
+            MemberAccessExpressionSyntax => true,
+            _ => false
+        };
     }
 
     private bool IsPatternTerminator(SyntaxToken token)


### PR DESCRIPTION
### Motivation
- Prevent expressions like `Foo(_, true)` from being mis-parsed as constant patterns and ensure literal/declaration patterns are type-checked against the scrutinee so invalid matches are diagnosed.

### Description
- Restrict the speculative constant-pattern parse to only accept identifier or member-access expressions by adding `IsValidConstantPatternExpression` in `PatternSyntaxParser.cs` so record/positional forms are not stolen by the constant-path.
- Propagate the optional `inputType` into `BindDeclarationPattern` and validate `LiteralTypeSymbol` literals against the expected `inputType` using `Compilation.ClassifyConversion`, emitting `MatchExpressionArmPatternInvalid` and returning a discard pattern on mismatch in `BoundIsPatternExpression.cs`.
- Use `literalType.Name` when reporting the diagnostic message so the reported pattern representation matches expectations.

### Testing
- Ran the focused unit test `dotnet test test/Raven.CodeAnalysis.Tests /property:WarningLevel=0 --filter "IsPattern_WithIncompatibleLiteralPattern_ReportsDiagnostic"` which passed.
- A full `dotnet test /property:WarningLevel=0` was attempted earlier but failed initially due to missing generated syntax types before running generators (baseline build step); the focused test was used to verify the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc105206c832f9e8c55bf233a0e46)