### PR TITLE
Handle non-named types in type binding

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -3599,6 +3599,11 @@ partial class BlockBinder : Binder
             return new BoundTypeExpression(constructed);
         }
 
+        if (symbol is ITypeSymbol nonNamedType)
+        {
+            return new BoundTypeExpression(EnsureTypeAccessible(nonNamedType, location));
+        }
+
         var alternate = FindAccessibleNamedType(name, requestedArity);
         if (alternate is not null)
         {


### PR DESCRIPTION
### Motivation
- Allow type name resolution to succeed when `LookupType` returns a non-named `ITypeSymbol` (for example a type parameter) so usages like `IEnumerable<T>` resolve `T` instead of emitting a missing-name diagnostic.

### Description
- In `src/Raven.CodeAnalysis/Binder/BlockBinder.cs` return `new BoundTypeExpression(EnsureTypeAccessible(nonNamedType, location))` when the resolved symbol is an `ITypeSymbol` that is not an `INamedTypeSymbol`, before falling back to `FindAccessibleNamedType` and reporting `TheNameDoesNotExistInTheCurrentContext`.

### Testing
- Ran `dotnet test /property:WarningLevel=0`, which failed due to missing generated types (e.g., `SyntaxKind`) in `Raven.CodeAnalysis`, so automated tests did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be2b8143c832fa660322802182d3e)