### PR TITLE
Handle nullable reference types during codegen projection

### DIFF
--- a/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
+++ b/src/Raven.CodeAnalysis/Symbols/Constructed/ConstructedMethodSymbol.cs
@@ -1027,7 +1027,9 @@ internal sealed class ConstructedMethodSymbol : IMethodSymbol
         if (symbol is NullableTypeSymbol nullable)
         {
             var underlying = GetProjectedRuntimeType(nullable.UnderlyingType, codeGen, treatUnitAsVoid, isTopLevel: false);
-            return typeof(Nullable<>).MakeGenericType(underlying);
+            return nullable.UnderlyingType.IsValueType
+                ? typeof(Nullable<>).MakeGenericType(underlying)
+                : underlying;
         }
 
         if (symbol is LiteralTypeSymbol literal)


### PR DESCRIPTION
### Motivation
- Fix a codegen crash where projecting a nullable reference type attempted to construct `Nullable<T>` with a reference type argument, causing a `TypeLoadException` during emission.

### Description
- In `ConstructedMethodSymbol.GetProjectedRuntimeType`, when encountering a `NullableTypeSymbol` only construct `Nullable<>` for value-type underlying types and return the underlying runtime type for nullable reference types.

### Testing
- Ran `dotnet test /property:WarningLevel=0` against the solution and the run failed due to existing `Raven.CodeAnalysis` build errors about missing syntax types (baseline failures), so no green test run could be completed yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bfd4f570c832fa79f91770544e4b3)