### PR TITLE
Use `Conversion.IsNullable` and `GetPlainType` across unification, binding, and conversions

### DIFF
--- a/docs/investigations/nullable-flow-api.md
+++ b/docs/investigations/nullable-flow-api.md
@@ -115,6 +115,18 @@ The changes affect multiple layers of the compiler pipeline and public APIs:
 4. **Flow + diagnostics**: update flow analysis and diagnostics to consume `IsNullable` and emit missing-metadata guidance.
 5. **Tests & validation**: add targeted tests for nullable flow checks, metadata defaults, and `MakeNullable`/`StripNullable` behavior.
 
+## Progress
+- ✅ `SemanticModel.GetTypeInfo(ExpressionSyntax)` now surfaces the unconverted expression type as `TypeInfo.Type`, while leaving `ConvertedType` intact.
+- ✅ Added `Conversion.IsNullable` and a `GetPlainType` helper to centralize nullability and plain-type access.
+- ✅ Began routing conversion identity checks through `Conversion.IsNullable` to centralize nullability logic.
+- ✅ Updated async return helpers to unwrap nullable decorators via `GetPlainType`.
+- ✅ Applied `Conversion.IsNullable` in overload scoring to avoid direct nullable wrapper checks.
+- ✅ Conditional access lookup now unwraps nullable decorators via `GetPlainType`.
+- ✅ Null-coalescing binding now unwraps nullable decorators via `GetPlainType`.
+- ✅ Extension-receiver unification now relies on `Conversion.IsNullable` and `GetPlainType`.
+- ⏳ `GetTypeInfo` still needs declared/flow/effective-nullable handling per the unified nullability model.
+- ⏳ `EffectiveNullableType`, metadata defaults, and flow diagnostics updates remain outstanding.
+
 ## Current state vs. proposed implementation checklist
 ### Likely existing (verify in code)
 - `NullableTypeSymbol` exists as a wrapper.
@@ -123,7 +135,6 @@ The changes affect multiple layers of the compiler pipeline and public APIs:
 
 ### Needs to be implemented or changed
 - `GetTypeInfo` to return declared/flow/effective-nullable types.
-- `Conversion.IsNullable` helper to unify conversion-time nullability checks.
 - `EffectiveNullableType` to represent internal nullable shape for interop and flow.
 - Nullable metadata reader to detect `NullableContextAttribute`/`NullableAttribute`.
 - Update all consumers to prefer `ITypeSymbol.IsNullable` and `MakeNullable`/`StripNullable` instead of inspecting `Nullable<T>`.

--- a/src/Raven.CodeAnalysis/Binder/AsyncReturnTypeUtilities.cs
+++ b/src/Raven.CodeAnalysis/Binder/AsyncReturnTypeUtilities.cs
@@ -22,8 +22,7 @@ internal static class AsyncReturnTypeUtilities
         // If the body already produces a task-shaped value, keep it as-is instead of wrapping it
         // again. This prevents double-tasking async lambdas such as `async () => 42` when generic
         // delegate inference substitutes `Task<T>` into the body type.
-        if (normalized is NullableTypeSymbol { UnderlyingType: var underlying })
-            normalized = underlying;
+        normalized = normalized.GetPlainType();
 
         if (normalized.SpecialType == SpecialType.System_Threading_Tasks_Task ||
             normalized is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Threading_Tasks_Task_T })
@@ -54,8 +53,7 @@ internal static class AsyncReturnTypeUtilities
 
     public static ITypeSymbol? ExtractAsyncResultType(Compilation compilation, ITypeSymbol asyncReturnType)
     {
-        if (asyncReturnType is NullableTypeSymbol nullable)
-            asyncReturnType = nullable.UnderlyingType;
+        asyncReturnType = asyncReturnType.GetPlainType();
 
         if (asyncReturnType.SpecialType == SpecialType.System_Threading_Tasks_Task)
             return compilation.GetSpecialType(SpecialType.System_Unit);

--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -651,12 +651,14 @@ internal abstract class Binder
                 return false;
             }
 
-            if (argumentType is NullableTypeSymbol nullableArgument)
+            if (Conversion.IsNullable(argumentType))
             {
-                if (TryUnifyNamedType(paramNamed, nullableArgument.UnderlyingType as INamedTypeSymbol, substitutions))
+                var plainArgument = argumentType.GetPlainType();
+
+                if (TryUnifyNamedType(paramNamed, plainArgument as INamedTypeSymbol, substitutions))
                     return true;
 
-                foreach (var iface in nullableArgument.AllInterfaces)
+                foreach (var iface in plainArgument.AllInterfaces)
                 {
                     if (TryUnifyNamedType(paramNamed, iface, substitutions))
                         return true;
@@ -669,13 +671,15 @@ internal abstract class Binder
         if (parameterType is IArrayTypeSymbol paramArray && argumentType is IArrayTypeSymbol argArray)
             return TryUnifyExtensionReceiver(paramArray.ElementType, argArray.ElementType, substitutions);
 
-        if (parameterType is NullableTypeSymbol paramNullable)
+        if (Conversion.IsNullable(parameterType))
         {
-            if (argumentType is NullableTypeSymbol argNullable)
-                return TryUnifyExtensionReceiver(paramNullable.UnderlyingType, argNullable.UnderlyingType, substitutions);
+            var plainParameter = parameterType.GetPlainType();
+
+            if (Conversion.IsNullable(argumentType))
+                return TryUnifyExtensionReceiver(plainParameter, argumentType.GetPlainType(), substitutions);
 
             if (!argumentType.IsValueType)
-                return TryUnifyExtensionReceiver(paramNullable.UnderlyingType, argumentType, substitutions);
+                return TryUnifyExtensionReceiver(plainParameter, argumentType, substitutions);
 
             return false;
         }

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.MemberAccess.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.MemberAccess.cs
@@ -338,10 +338,7 @@ partial class BlockBinder
         type = type.UnwrapLiteralType() ?? type;
 
         // Raven nullable wrapper
-        if (type is NullableTypeSymbol nullable)
-            return nullable.UnderlyingType;
-
-        return type;
+        return type.GetPlainType();
     }
 
     // ============================

--- a/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
+++ b/src/Raven.CodeAnalysis/Binder/BlockBinder.cs
@@ -704,9 +704,7 @@ partial class BlockBinder : Binder
 
         // If the left is nullable, the result is typically the non-nullable left type
         // combined with the right type.
-        var leftNonNullable = leftType is NullableTypeSymbol nullable
-            ? nullable.UnderlyingType
-            : leftType;
+        var leftNonNullable = leftType.GetPlainType();
 
         var resultType = TypeSymbolNormalization.NormalizeUnion(new[] { leftNonNullable, rightType });
 

--- a/src/Raven.CodeAnalysis/Compilation.Conversions.cs
+++ b/src/Raven.CodeAnalysis/Compilation.Conversions.cs
@@ -183,8 +183,8 @@ public partial class Compilation
         }
 
         if (source.MetadataIdentityEquals(destination) &&
-            source is not NullableTypeSymbol &&
-            destination is not NullableTypeSymbol)
+            !Conversion.IsNullable(source) &&
+            !Conversion.IsNullable(destination))
         {
             return Finalize(new Conversion(isImplicit: true, isIdentity: true));
         }

--- a/src/Raven.CodeAnalysis/Conversion.cs
+++ b/src/Raven.CodeAnalysis/Conversion.cs
@@ -116,6 +116,11 @@ public struct Conversion
             methodSymbol: MethodSymbol);
     }
 
+    public static bool IsNullable(ITypeSymbol? typeSymbol)
+    {
+        return typeSymbol?.IsNullable ?? false;
+    }
+
     public static bool operator ==(Conversion left, Conversion right) => left.Equals(right);
     public static bool operator !=(Conversion left, Conversion right) => !left.Equals(right);
 }

--- a/src/Raven.CodeAnalysis/NullableTypeSymbolExtensions.cs
+++ b/src/Raven.CodeAnalysis/NullableTypeSymbolExtensions.cs
@@ -4,6 +4,16 @@ namespace Raven.CodeAnalysis;
 
 public static class NullableTypeSymbolExtensions
 {
+    public static ITypeSymbol GetPlainType(this ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol is NullableTypeSymbol { UnderlyingType: var underlying })
+        {
+            return underlying;
+        }
+
+        return typeSymbol;
+    }
+
     public static ITypeSymbol MakeNullable(this ITypeSymbol typeSymbol)
     {
         if (typeSymbol.IsNullable)

--- a/src/Raven.CodeAnalysis/OverloadResolver.cs
+++ b/src/Raven.CodeAnalysis/OverloadResolver.cs
@@ -1109,7 +1109,7 @@ internal sealed class OverloadResolver
 
             var conversionScore = GetConversionScore(conversion);
 
-            if (parameter.Type is NullableTypeSymbol nullableParam && argType is not NullableTypeSymbol)
+            if (parameter.Type is NullableTypeSymbol nullableParam && !Conversion.IsNullable(argType))
             {
                 var liftedConversion = compilation.ClassifyConversion(argType, nullableParam.UnderlyingType);
                 if (liftedConversion.Exists)
@@ -1138,8 +1138,7 @@ internal sealed class OverloadResolver
             var lambdaAsyncResult = AsyncReturnTypeUtilities.ExtractAsyncResultType(compilation, lambdaAsyncReturn)
                 ?? lambdaAsyncReturn;
 
-            if (delegateReturnType is NullableTypeSymbol nullable)
-                delegateReturnType = nullable.UnderlyingType;
+            delegateReturnType = delegateReturnType.GetPlainType();
 
             if (delegateReturnType.SpecialType == SpecialType.System_Void)
             {

--- a/src/Raven.CodeAnalysis/SemanticModel.cs
+++ b/src/Raven.CodeAnalysis/SemanticModel.cs
@@ -162,7 +162,7 @@ public partial class SemanticModel
 
         ITypeSymbol? convertedType = boundExpr.Type;
 
-        return new TypeInfo(boundExpr.Type, convertedType);
+        return new TypeInfo(naturalType, convertedType);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Centralize nullable handling so callers stop branching on `NullableTypeSymbol` directly and consistently ignore nullable decorators where appropriate.
- Reduce duplicated nullable-unwrapping logic in overload scoring, conditional access, null-coalescing, async-return inference, extension-receiver unification, and conversion identity checks.

### Description
- Added `GetPlainType` to `NullableTypeSymbolExtensions` and `Conversion.IsNullable` to centralize plain-type access and nullable testing, and used them in multiple call sites.
- Updated extension-receiver unification in `Binder` to use `Conversion.IsNullable` and `GetPlainType` when comparing parameter and argument shapes.
- Replaced direct nullable unwraps with `GetPlainType` in `AsyncReturnTypeUtilities`, `OverloadResolver` (async compatibility / overload scoring), `BlockBinder.MemberAccess` (conditional access lookup), and `BlockBinder.BindNullCoalesceExpression` (null-coalescing binding).
- Routed conversion-identity checks through `Conversion.IsNullable` in `Compilation.Conversions` and adjusted `SemanticModel.GetTypeInfo` to return the unconverted/natural expression type as `TypeInfo.Type` while preserving `ConvertedType`.
- Updated the progress notes in `docs/investigations/nullable-flow-api.md` to record the extension-receiver unification change.

### Testing
- Ran `dotnet format Raven.sln --include src/Raven.CodeAnalysis/Binder/Binder.cs docs/investigations/nullable-flow-api.md --no-restore`, which completed successfully.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b49e5144832f930eb4cd051332f9)