### PR TITLE
Fix extension receiver filtering for generic Result properties

### DIFF
--- a/src/Raven.CodeAnalysis/Binder/Binder.cs
+++ b/src/Raven.CodeAnalysis/Binder/Binder.cs
@@ -567,7 +567,10 @@ internal abstract class Binder
             return true;
 
         if (ContainsTypeParameters(parameterType))
-            return true;
+        {
+            var substitutions = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(SymbolEqualityComparer.Default);
+            return TryUnifyExtensionReceiver(parameterType, receiverType, substitutions);
+        }
 
         if (SymbolEqualityComparer.Default.Equals(parameterType, receiverType))
             return true;
@@ -595,7 +598,10 @@ internal abstract class Binder
             return true;
 
         if (ContainsTypeParameters(extensionReceiverType))
-            return true;
+        {
+            var substitutions = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(SymbolEqualityComparer.Default);
+            return TryUnifyExtensionReceiver(extensionReceiverType, receiverType, substitutions);
+        }
 
         if (SymbolEqualityComparer.Default.Equals(extensionReceiverType, receiverType))
             return true;
@@ -1012,7 +1018,10 @@ internal abstract class Binder
             return true;
 
         if (ContainsTypeParameters(parameterType))
-            return true;
+        {
+            var substitutions = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(SymbolEqualityComparer.Default);
+            return TryUnifyExtensionReceiver(parameterType, receiverType, substitutions);
+        }
 
         if (SymbolEqualityComparer.Default.Equals(parameterType, receiverType))
             return true;

--- a/test/Raven.CodeAnalysis.Tests/Bugs/ResultExtensionPropertyResolutionTests.cs
+++ b/test/Raven.CodeAnalysis.Tests/Bugs/ResultExtensionPropertyResolutionTests.cs
@@ -1,0 +1,23 @@
+using Raven.CodeAnalysis.Testing;
+
+namespace Raven.CodeAnalysis.Tests.Bugs;
+
+public class ResultExtensionPropertyResolutionTests : DiagnosticTestBase
+{
+    [Fact]
+    public void ResultIsErrorBindsToSingleTypeResultExtension()
+    {
+        string testCode =
+            """
+            import System.*
+
+            val res: Result<int> = .Error("Bang")
+
+            Console.WriteLine("Is error: ${res.IsError}")
+            """;
+
+        var verifier = CreateVerifier(testCode);
+
+        verifier.Verify();
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent ambiguous resolution of extension properties/methods when the extension receiver contains type parameters by checking whether the generic receiver can unify with the actual receiver type instead of accepting any generic candidate.

### Description
- Replace unconditional acceptance of extension candidates that `ContainsTypeParameters(...)` with an attempt to unify the generic receiver against the actual receiver using `TryUnifyExtensionReceiver(...)` in `Binder.cs` for property, static property and method extension candidate checks.
- Added a regression test `test/Raven.CodeAnalysis.Tests/Bugs/ResultExtensionPropertyResolutionTests.cs` which exercises `Result<int>.IsError` extension resolution to ensure the single-parameter `Result<T>` extension binds without ambiguity.
- Kept the unification logic local by constructing a `Dictionary<ITypeParameterSymbol,ITypeSymbol>` and passing it to `TryUnifyExtensionReceiver` when needed.

### Testing
- Ran the repository build via `scripts/codex-build.sh`, which completed successfully and produced `Raven.CodeAnalysis.dll` and related artifacts (success).
- Ran `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj /property:WarningLevel=0`; the run failed due to unrelated test infrastructure/syntax generation issues (missing generated `SyntaxKind` documentation trivia kinds), not because of the new changes (failure).
- Added and formatted the new test file and ensured `dotnet format` was run over the changed files (format step completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973dac87574832fae8949e3b224ffc1)