### PR TITLE
Preserve try-expression result type in async lowering

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/AsyncLowerer.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/AsyncLowerer.cs
@@ -1670,7 +1670,7 @@ internal static class AsyncLowerer
                     new BoundExpressionStatement(new BoundLocalAccess(resultLocal))
                 };
 
-                return new BoundBlockExpression(blockStatements, unitType);
+                return new BoundBlockExpression(blockStatements, resultType);
             }
 
             if (!ReferenceEquals(expression, node.Expression))


### PR DESCRIPTION
### Motivation
- Ensure `try` expressions that contain `await` continue to produce the enclosing `Result<T,E>` shape so downstream lowering/codegen (propagate lowering and async rewriting) can observe and preserve propagation semantics instead of being reduced to `Unit`.

### Description
- Change `AsyncLowerer` so the lowered `BoundBlockExpression` produced for `try`-with-`await` uses the computed `resultType` instead of `unitType`, implemented in `src/Raven.CodeAnalysis/BoundTree/Lowering/AsyncLowerer.cs`.

### Testing
- Ran `scripts/codex-build.sh` which completed successfully. 
- Built the compiler with `dotnet build src/Raven.Compiler/Raven.Compiler.csproj --property WarningLevel=0` which succeeded. 
- Ran the test suite with `dotnet test /property:WarningLevel=0` and observed unrelated failures in `Raven.CodeAnalysis.Testing` and `Raven.Editor.Tests`. 
- Ran `dotnet test test/Raven.CodeAnalysis.Tests/Raven.CodeAnalysis.Tests.csproj /property:WarningLevel=0` which failed due to existing `SyntaxKind` test errors. 
- Attempted to exercise the sample repro with `ravc` (no-emit) which timed out / hung in this environment and needs further investigation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f11a0670832f8a9261551be185b0)