### PR TITLE
Rewrite propagate lowering for assignment statements

### DIFF
--- a/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Blocks.cs
+++ b/src/Raven.CodeAnalysis/BoundTree/Lowering/Lowerer.Blocks.cs
@@ -30,6 +30,13 @@ internal sealed partial class Lowerer
                 continue;
             }
 
+            if (statement is BoundAssignmentStatement assignmentStatement
+                && TryRewritePropagateAssignmentStatement(assignmentStatement, out var rewrittenAssignmentStatements))
+            {
+                statements.AddRange(rewrittenAssignmentStatements);
+                continue;
+            }
+
             statements.Add((BoundStatement)VisitStatement(statement));
         }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect lowering/emission for discard assignment forms like `_ = try? await ...` which produced runtime `InvalidProgramException` in async state machines by treating assignment statements as first-class propagate lowering targets.
- Improve lowering completeness by rebuilding assignment RHS with the lowered success expression so propagate semantics are preserved across assignment shapes.
- Add runtime coverage to prevent regressions and update the async-propagate plan to record findings and the corrective action taken.

### Description
- Add `TryRewritePropagateAssignmentStatement` that detects `BoundAssignmentStatement` whose RHS is a `BoundPropagateExpression` and routes it through the propagate lowering path. 
- Add `UpdateAssignmentRight(...)` to reconstruct all `BoundAssignmentExpression` shapes with the lowered success expression so assignments preserve their original form and types. 
- Wire assignment rewriting into block lowering by handling `BoundAssignmentStatement` in `VisitBlockStatement` and stop emitting a redundant success-expression for propagate expression statements whose value is unused. 
- Add `AsyncPropagate_DiscardAssignment_PropagatesError` unit test to cover `_ = try? await ...`, and update `docs/async-propagate-lowering-plan.md` to record the resolved discard-assignment behavior and follow-ups.

### Testing
- Ran `dotnet format` for the modified files with `--no-restore`, which completed successfully. 
- Built key projects with `dotnet build` for `src/Raven.CodeAnalysis` and `src/Raven.Compiler` with `--property WarningLevel=0`, both of which succeeded. 
- Ran the repository test suite via `timeout 180s dotnet test /property:WarningLevel=0`, which exhibited baseline unrelated failures (e.g., `DocumentationCommentTriviaTests`) so the full suite did not fully pass. 
- Executed targeted compiler runs using `dotnet run --project src/Raven.Compiler` on the `sample101` variants, and observed that `_ = try? await ...` now compiles and the error path propagates the enclosing `.Error(Exception)` instead of throwing `InvalidProgramException`. 
- Noted remaining issues from targeted runs: the standalone expression-statement variant still hangs under timeout and the `Task<Result<T,E>>` success-typing case still yields a bind error (`RAV1501`), which are recorded in the updated plan for follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974fd7b5a24832f9f4263de003c5070)